### PR TITLE
fix: normalize non-spec roles in Anthropic messages array (Claude Cod…

### DIFF
--- a/coderouter/translation/anthropic.py
+++ b/coderouter/translation/anthropic.py
@@ -10,9 +10,12 @@ through unchanged if a client sends them.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+logger = logging.getLogger(__name__)
 
 # ============================================================
 # Content blocks
@@ -106,6 +109,113 @@ class AnthropicTool(BaseModel):
 
 
 # ============================================================
+# Role normalization (Claude Code CLI >= 2.1.154 workaround)
+# ============================================================
+
+_SPEC_MESSAGE_ROLES = frozenset({"user", "assistant"})
+
+
+def _content_as_text(content: Any) -> str:
+    """Best-effort plain-text extraction from a message ``content`` field.
+
+    Strings pass through; block lists contribute their ``text`` blocks
+    joined with newlines; anything else yields "".
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text", "")))
+        return "\n".join(p for p in parts if p)
+    return ""
+
+
+def normalize_message_roles(payload: dict[str, Any]) -> dict[str, Any]:
+    """Normalize non-spec roles inside ``messages`` before validation.
+
+    Claude Code CLI >= 2.1.154 has a regression where it emits messages
+    with ``role: "system"`` (and reportedly ``ctx`` / ``msg``) inside the
+    ``messages`` array. The Anthropic Messages API spec allows only
+    ``user`` / ``assistant`` there, so without this hop those requests
+    die in validation with "Input should be 'user' or 'assistant'"
+    (see anthropics/claude-code#63469, vllm-project/vllm#44000).
+
+    Policy:
+        - ``role: "system"`` → text content merged into the top-level
+          ``system`` field (appended after any existing system prompt;
+          same join rule as ``convert.to_anthropic_request``).
+        - any other non-spec role (``ctx``, ``msg``, ...) → coerced to
+          ``user`` so conversation position is preserved. Anthropic
+          merges consecutive same-role turns, so this is safe.
+        - messages whose salvaged content is empty are dropped entirely
+          (Anthropic rejects empty turns).
+
+    Returns a shallow-copied payload; the caller's dict is not mutated.
+    Non-dict message entries (already-validated models) pass through.
+    """
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        return payload
+
+    system_texts: list[str] = []
+    messages_out: list[Any] = []
+    coerced_roles: list[str] = []
+
+    for msg in messages:
+        if not isinstance(msg, dict):
+            # Already a validated AnthropicMessage (internal construction
+            # path, e.g. convert.to_anthropic_request) — spec roles only.
+            messages_out.append(msg)
+            continue
+        role = msg.get("role")
+        if role in _SPEC_MESSAGE_ROLES:
+            messages_out.append(msg)
+            continue
+        if role == "system":
+            text = _content_as_text(msg.get("content"))
+            if text:
+                system_texts.append(text)
+            coerced_roles.append("system")
+            continue
+        # Unknown role (ctx / msg / future surprises): keep its position
+        # in the conversation as a user turn; drop if nothing salvageable.
+        text = _content_as_text(msg.get("content"))
+        coerced_roles.append(str(role))
+        if text:
+            messages_out.append({"role": "user", "content": text})
+
+    if not coerced_roles:
+        return payload
+
+    out = dict(payload)
+    out["messages"] = messages_out
+
+    if system_texts:
+        joined = "\n".join(system_texts)
+        existing = out.get("system")
+        if existing is None:
+            out["system"] = joined
+        elif isinstance(existing, str):
+            out["system"] = f"{existing}\n{joined}" if existing else joined
+        elif isinstance(existing, list):
+            out["system"] = [*existing, {"type": "text", "text": joined}]
+        else:  # unexpected shape — don't lose the client's value
+            out["system"] = existing
+
+    logger.warning(
+        "normalized-nonspec-message-roles",
+        extra={
+            "roles": coerced_roles,
+            "system_merged": bool(system_texts),
+            "hint": "client is likely Claude Code CLI >= 2.1.154 (known regression)",
+        },
+    )
+    return out
+
+
+# ============================================================
 # Request
 # ============================================================
 
@@ -146,6 +256,19 @@ class AnthropicRequest(BaseModel):
     # beta-gated body fields like `context_management`, `cache_control`,
     # `thinking` beyond what the default minor version accepts.
     anthropic_beta: str | None = Field(default=None, exclude=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_roles(cls, data: Any) -> Any:
+        """Claude Code >= 2.1.154 sends system/ctx/msg roles in messages.
+
+        Normalize them before field validation so the request doesn't
+        422 at ingress (and doesn't 400 upstream at api.anthropic.com
+        via the native adapter). See ``normalize_message_roles``.
+        """
+        if isinstance(data, dict):
+            return normalize_message_roles(data)
+        return data
 
 
 # ============================================================

--- a/tests/test_role_normalization.py
+++ b/tests/test_role_normalization.py
@@ -1,0 +1,201 @@
+"""Tests for Claude Code CLI >= 2.1.154 role normalization.
+
+Claude Code 2.1.154+ has a regression where it emits ``role: "system"``
+(and reportedly ``ctx`` / ``msg``) inside the Anthropic ``messages``
+array, which the spec restricts to ``user`` / ``assistant``.
+See anthropics/claude-code#63469, vllm-project/vllm#44000.
+
+These tests cover ``normalize_message_roles`` and its wiring as a
+``model_validator(mode="before")`` on ``AnthropicRequest``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+# Same import convention as test_translation_anthropic.py: adapters.base
+# must load before coderouter.translation, otherwise a pre-existing circular
+# import (translation → convert → adapters → anthropic_native → convert)
+# blows up at collection time.
+import coderouter.adapters.base  # noqa: F401  (import-order anchor)
+from coderouter.translation import AnthropicMessage, AnthropicRequest
+from coderouter.translation.anthropic import normalize_message_roles
+
+
+def _req(messages, **kwargs):
+    payload = {"model": "m", "max_tokens": 100, "messages": messages, **kwargs}
+    return AnthropicRequest.model_validate(payload)
+
+
+# ------------------------------------------------------------
+# The exact Claude Code >= 2.1.154 regression shape
+# ------------------------------------------------------------
+
+
+def test_claude_code_system_role_in_messages_is_accepted():
+    req = _req(
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "system", "content": "injected system reminder"},
+            {"role": "assistant", "content": "hi"},
+        ]
+    )
+    assert [m.role for m in req.messages] == ["user", "assistant"]
+    assert req.system == "injected system reminder"
+
+
+def test_system_role_with_block_list_content():
+    req = _req(
+        [
+            {"role": "user", "content": "q"},
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "part one"},
+                    {"type": "text", "text": "part two"},
+                ],
+            },
+        ]
+    )
+    assert req.system == "part one\npart two"
+
+
+def test_system_role_appends_to_existing_string_system():
+    req = _req(
+        [
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": "extra"},
+        ],
+        system="original",
+    )
+    assert req.system == "original\nextra"
+
+
+def test_system_role_appends_to_existing_block_list_system():
+    req = _req(
+        [
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": "extra"},
+        ],
+        system=[{"type": "text", "text": "original"}],
+    )
+    assert req.system == [
+        {"type": "text", "text": "original"},
+        {"type": "text", "text": "extra"},
+    ]
+
+
+def test_multiple_system_messages_joined_in_order():
+    req = _req(
+        [
+            {"role": "system", "content": "first"},
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": "second"},
+        ]
+    )
+    assert req.system == "first\nsecond"
+    assert [m.role for m in req.messages] == ["user"]
+
+
+# ------------------------------------------------------------
+# ctx / msg / unknown roles
+# ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("role", ["ctx", "msg", "tool", "something_new"])
+def test_unknown_role_coerced_to_user_preserving_position(role):
+    req = _req(
+        [
+            {"role": "user", "content": "q"},
+            {"role": role, "content": "context blob"},
+            {"role": "assistant", "content": "a"},
+        ]
+    )
+    assert [m.role for m in req.messages] == ["user", "user", "assistant"]
+    assert req.messages[1].content == "context blob"
+    assert req.system is None
+
+
+def test_unknown_role_with_empty_content_dropped():
+    req = _req(
+        [
+            {"role": "user", "content": "q"},
+            {"role": "ctx", "content": ""},
+            {"role": "msg", "content": []},
+        ]
+    )
+    assert [m.role for m in req.messages] == ["user"]
+
+
+def test_empty_system_role_message_dropped_without_touching_system():
+    req = _req(
+        [
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": ""},
+        ]
+    )
+    assert req.system is None
+    assert [m.role for m in req.messages] == ["user"]
+
+
+# ------------------------------------------------------------
+# Spec-conformant requests are untouched
+# ------------------------------------------------------------
+
+
+def test_valid_request_passes_through_unchanged():
+    payload = {
+        "model": "m",
+        "max_tokens": 100,
+        "system": "sys",
+        "messages": [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": [{"type": "text", "text": "a"}]},
+        ],
+    }
+    req = AnthropicRequest.model_validate(payload)
+    assert req.system == "sys"
+    assert [m.role for m in req.messages] == ["user", "assistant"]
+    # normalize_message_roles returns the same object when nothing to do
+    assert normalize_message_roles(payload) is payload
+
+
+def test_caller_payload_not_mutated():
+    payload = {
+        "model": "m",
+        "max_tokens": 100,
+        "messages": [
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": "s"},
+        ],
+    }
+    AnthropicRequest.model_validate(payload)
+    assert len(payload["messages"]) == 2  # original untouched
+    assert "system" not in payload
+
+
+def test_internal_construction_with_model_instances_still_works():
+    # convert.to_anthropic_request constructs with AnthropicMessage objects;
+    # the before-validator must pass them through.
+    req = AnthropicRequest(
+        model="m",
+        max_tokens=100,
+        messages=[AnthropicMessage(role="user", content="q")],
+        system="sys",
+    )
+    assert req.messages[0].role == "user"
+    assert req.system == "sys"
+
+
+def test_message_model_itself_still_rejects_system_role():
+    # The strict wire model is unchanged — normalization happens at the
+    # request boundary, not by widening the role enum.
+    with pytest.raises(ValidationError):
+        AnthropicMessage.model_validate({"role": "system", "content": "x"})
+
+
+def test_all_messages_invalid_roles_yields_empty_messages_but_valid_request():
+    req = _req([{"role": "system", "content": "only system"}])
+    assert req.messages == []
+    assert req.system == "only system"


### PR DESCRIPTION
…e >= 2.1.154)

Claude Code CLI 2.1.154+ has a regression where it emits messages with role "system" (and reportedly "ctx"/"msg") inside the messages array, which the Anthropic Messages API restricts to user/assistant. Requests died at ingress validation with 422 "Input should be 'user' or 'assistant'".

Add a before-validator on AnthropicRequest that:
- merges role=system message text into the top-level system field
- coerces other unknown roles to user, preserving position
- drops messages with no salvageable content
- logs a warning when normalization fires

The strict AnthropicMessage role enum is unchanged, so the wire model still matches the spec and the native adapter forwards a valid payload to api.anthropic.com.

Refs: anthropics/claude-code#63469, vllm-project/vllm#44000

Tests: 1191 passed, 7 skipped (16 new in tests/test_role_normalization.py)