### PR TITLE
feat: Language Tax tracking, routing & dashboard (v2.6)

### DIFF
--- a/coderouter/config/schemas.py
+++ b/coderouter/config/schemas.py
@@ -185,6 +185,19 @@ class ProviderConfig(BaseModel):
     )
     timeout_s: float = Field(default=30.0, ge=1.0, le=600.0)
 
+    # v2.6 language-tax track: path to a LOCAL ``tokenizer.json`` for this
+    # provider's model, used to measure the CJK over-count vs the char/4
+    # baseline (see ``coderouter.language_tax``). Loaded local-file-only —
+    # never contacts the HuggingFace Hub. When unset, language-tax falls
+    # back to char/4 (multiplier 1.0) and the feature is silently inert.
+    tokenizer_path: str | None = Field(
+        default=None,
+        description=(
+            "Local tokenizer.json for accurate (language-tax) token "
+            "counting. No network access. Requires the 'accuracy' extra."
+        ),
+    )
+
     # Provider-specific extras merged into the outbound request body.
     # Use for non-standard fields like Ollama's `think: false`, `keep_alive`,
     # `options.num_ctx`, or any vendor-specific toggle. User-supplied request

--- a/coderouter/config/schemas.py
+++ b/coderouter/config/schemas.py
@@ -776,6 +776,16 @@ class RuleMatcher(BaseModel):
       ``request.tools`` set). The ``has_tools`` matcher is the
       profile-level lever for steering tool-laden traffic to the right
       chain entirely.
+
+    Variants (v2.6 / language-tax routing):
+
+    - ``cjk_ratio_min: 0.3`` — CJK character ratio of the latest user
+      message is ``>=`` this threshold. Routes CJK-heavy turns (which
+      pay the cloud "language tax" of ~1.2-1.5x more tokens) to a local
+      model that bills nothing per token, while ASCII/code turns fall
+      through to the cloud chain. Per-turn property like
+      ``code_fence_ratio_min``; see
+      :func:`coderouter.language_tax.cjk_char_ratio`.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -786,6 +796,13 @@ class RuleMatcher(BaseModel):
     content_regex: str | None = None
     model_pattern: str | None = None
     content_token_count_min: int | None = Field(default=None, ge=1)
+    # v2.6 language-tax routing: CJK character ratio of the latest user
+    # message >= this threshold. Lets operators steer CJK-heavy traffic
+    # (which carries the cloud language tax) to a local model that bills
+    # nothing per token. Operates on the latest user message like
+    # ``code_fence_ratio_min`` (a per-turn property), not the whole
+    # request. See ``coderouter.language_tax.cjk_char_ratio``.
+    cjk_ratio_min: float | None = Field(default=None, ge=0.0, le=1.0)
     # [Unreleased]: tool-aware routing (OpenClaw + Raspberry Pi 由来).
     # See class docstring "Variants ([Unreleased] / tool-aware routing)"
     # above for the full rationale. Boolean shape mirrors ``has_image`` —
@@ -802,6 +819,7 @@ class RuleMatcher(BaseModel):
         "model_pattern",
         "content_token_count_min",
         "has_tools",
+        "cjk_ratio_min",
     )
 
     @model_validator(mode="after")

--- a/coderouter/cost.py
+++ b/coderouter/cost.py
@@ -59,7 +59,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from typing import TYPE_CHECKING
+
 from coderouter.config.schemas import CostConfig
+
+if TYPE_CHECKING:  # avoid an import cycle at runtime; used only for typing
+    from coderouter.language_tax import LanguageTaxBreakdown
 
 
 @dataclass(frozen=True)
@@ -82,6 +87,12 @@ class CostBreakdown:
             chart. ``input_usd`` is "fresh input only" (does not
             include cache buckets); cache_read_usd / cache_creation_usd
             are the post-discount / post-premium values.
+        language_tax_multiplier: ``tokens_accurate / tokens_heuristic``
+            for the request text (v2.6 language-tax track). 1.0 when no
+            tax is measurable (English/code, or no accurate tokenizer).
+        language_tax_usd: USD share of ``total_usd`` attributable to the
+            CJK over-count vs CodeRouter's char/4 English baseline.
+            0.0 for free / local providers. See :mod:`coderouter.language_tax`.
     """
 
     total_usd: float = 0.0
@@ -90,6 +101,10 @@ class CostBreakdown:
     output_usd: float = 0.0
     cache_read_usd: float = 0.0
     cache_creation_usd: float = 0.0
+    # v2.6 language-tax track (additive; defaults keep pre-v2.6 behaviour
+    # and equality with a bare ``CostBreakdown()``).
+    language_tax_multiplier: float = 1.0
+    language_tax_usd: float = 0.0
 
 
 _PER_MILLION: float = 1_000_000.0
@@ -102,6 +117,7 @@ def compute_cost_for_attempt(
     output_tokens: int,
     cache_read_input_tokens: int,
     cache_creation_input_tokens: int,
+    language_tax: "LanguageTaxBreakdown | None" = None,
 ) -> CostBreakdown:
     """Translate per-attempt token counts into a USD :class:`CostBreakdown`.
 
@@ -144,6 +160,21 @@ def compute_cost_for_attempt(
     full_rate_for_cache_read = safe_read * input_rate
     savings_usd = full_rate_for_cache_read - cache_read_usd
 
+    # v2.6 language tax: the share of fresh-input spend attributable to
+    # the CJK over-count vs the char/4 English baseline. Defaults to a
+    # 1.0 multiplier / $0 when no LanguageTaxBreakdown is supplied, so
+    # the pre-v2.6 call shape is unchanged.
+    lt_multiplier = 1.0
+    lt_usd = 0.0
+    if language_tax is not None:
+        lt_multiplier = language_tax.tax_multiplier
+        from coderouter.language_tax import language_tax_usd
+
+        lt_usd = language_tax_usd(
+            language_tax.extra_tokens,
+            input_tokens_per_million=cost_config.input_tokens_per_million,
+        )
+
     return CostBreakdown(
         total_usd=total_usd,
         savings_usd=max(savings_usd, 0.0),
@@ -151,4 +182,6 @@ def compute_cost_for_attempt(
         output_usd=output_usd,
         cache_read_usd=cache_read_usd,
         cache_creation_usd=cache_creation_usd,
+        language_tax_multiplier=lt_multiplier,
+        language_tax_usd=lt_usd,
     )

--- a/coderouter/cost.py
+++ b/coderouter/cost.py
@@ -58,7 +58,6 @@ in the cost calc.
 from __future__ import annotations
 
 from dataclasses import dataclass
-
 from typing import TYPE_CHECKING
 
 from coderouter.config.schemas import CostConfig
@@ -117,7 +116,7 @@ def compute_cost_for_attempt(
     output_tokens: int,
     cache_read_input_tokens: int,
     cache_creation_input_tokens: int,
-    language_tax: "LanguageTaxBreakdown | None" = None,
+    language_tax: LanguageTaxBreakdown | None = None,
 ) -> CostBreakdown:
     """Translate per-attempt token counts into a USD :class:`CostBreakdown`.
 

--- a/coderouter/ingress/dashboard_routes.py
+++ b/coderouter/ingress/dashboard_routes.py
@@ -165,6 +165,26 @@ _DASHBOARD_HTML = r"""<!doctype html>
   </main>
 
   <footer class="max-w-7xl mx-auto px-4 md:px-6 pb-8">
+    <!-- Panel: Cost & Language Tax (v2.6) -->
+    <section class="bg-slate-900/60 border border-slate-800 rounded-lg p-4 mb-4">
+      <h2 class="text-sm font-semibold uppercase tracking-wider text-slate-400 mb-3">Cost &amp; Language Tax</h2>
+      <div class="grid grid-cols-3 gap-3">
+        <div class="rounded-md bg-slate-800/50 p-3">
+          <div class="text-xs text-slate-400">Total spend</div>
+          <div class="text-2xl font-semibold tabnum" data-bind="cost_total">$0.00</div>
+        </div>
+        <div class="rounded-md bg-slate-800/50 p-3">
+          <div class="text-xs text-slate-400">Cache savings</div>
+          <div class="text-2xl font-semibold tabnum text-green-400" data-bind="cost_savings">$0.00</div>
+        </div>
+        <div class="rounded-md bg-slate-800/50 p-3">
+          <div class="text-xs text-slate-400">Language tax (CJK)</div>
+          <div class="text-2xl font-semibold tabnum text-amber-400" data-bind="language_tax_total">$0.00</div>
+          <div class="text-xs text-slate-500" data-bind="language_tax_hint">no tokenizer configured</div>
+        </div>
+      </div>
+      <div id="language-tax-by-provider" class="text-xs text-slate-400 tabnum mt-3"></div>
+    </section>
     <section class="bg-slate-900/60 border border-slate-800 rounded-lg p-4">
       <h2 class="text-sm font-semibold uppercase tracking-wider text-slate-400 mb-3">Usage Mix</h2>
       <div id="usage-bar" class="flex h-3 rounded-full overflow-hidden bg-slate-800" role="img" aria-label="usage mix"></div>
@@ -435,6 +455,27 @@ _DASHBOARD_HTML = r"""<!doctype html>
     {"&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"}[c]
   ));
 
+  // v2.6: cost + language-tax panel. The collector zero-fills these, so
+  // a fresh/local-only deployment shows $0.00 across the board.
+  const renderCostTax = (snap) => {
+    const c = snap.counters || {};
+    const usd = (x) => "$" + (Number(x) || 0).toFixed(4);
+    setBind("cost_total", usd(c.cost_total_usd_aggregate));
+    setBind("cost_savings", usd(c.cost_savings_usd_aggregate));
+    const taxTotal = Number(c.language_tax_usd_aggregate) || 0;
+    setBind("language_tax_total", usd(taxTotal));
+    setBind("language_tax_hint",
+      taxTotal > 0 ? "extra paid for CJK vs char/4 baseline"
+                   : "no tax measured (set provider tokenizer_path)");
+    const byProv = c.language_tax_usd || {};
+    const el = document.getElementById("language-tax-by-provider");
+    const rows = Object.entries(byProv).filter(([, v]) => Number(v) > 0);
+    el.innerHTML = rows.length === 0 ? "" :
+      rows.map(([n, v]) =>
+        '<span class="mr-4"><span class="text-slate-500">' + escapeHTML(n) +
+        '</span> ' + usd(v) + '</span>').join("");
+  };
+
   const renderSnapshot = (snap) => {
     const startup = snap.startup || {};
     const cfg = snap.config || {};
@@ -451,6 +492,7 @@ _DASHBOARD_HTML = r"""<!doctype html>
     renderSparkline(snap);
     renderRecent(snap);
     renderUsageMix(snap);
+    renderCostTax(snap);
   };
 
   const renderError = (msg) => {

--- a/coderouter/language_tax.py
+++ b/coderouter/language_tax.py
@@ -58,8 +58,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
-from coderouter.token_estimation import CHARS_PER_TOKEN_HEURISTIC
+from coderouter.token_estimation import (
+    CHARS_PER_TOKEN_HEURISTIC,
+    extract_text_from_anthropic_request,
+)
 from coderouter.token_estimation_accurate import count_tokens
 
 # ---------------------------------------------------------------------------
@@ -88,10 +92,7 @@ _CJK_RANGES: tuple[tuple[int, int], ...] = (
 
 
 def _is_cjk(cp: int) -> bool:
-    for low, high in _CJK_RANGES:
-        if low <= cp <= high:
-            return True
-    return False
+    return any(low <= cp <= high for low, high in _CJK_RANGES)
 
 
 # ---------------------------------------------------------------------------
@@ -215,9 +216,29 @@ def language_tax_usd(
     return extra_tokens * (input_tokens_per_million / 1_000_000.0)
 
 
+def estimate_language_tax_for_request(
+    system: Any,
+    messages: list[Any],
+    *,
+    tokenizer_path: str | Path | None = None,
+) -> LanguageTaxBreakdown:
+    """Measure the language tax of a whole Anthropic-shaped request.
+
+    Convenience wrapper used by the engine's cost-emit path: pulls the
+    concatenated request text (system + message text blocks) and runs it
+    through :func:`estimate_language_tax`. With no ``tokenizer_path`` the
+    multiplier is 1.0 (inert), so calling this on every request is safe
+    and cheap — the engine only invokes it when a provider declares a
+    local ``tokenizer.json``.
+    """
+    text = extract_text_from_anthropic_request(system=system, messages=messages)
+    return estimate_language_tax(text, tokenizer_path=tokenizer_path)
+
+
 __all__ = [
-    "cjk_char_ratio",
     "LanguageTaxBreakdown",
+    "cjk_char_ratio",
     "estimate_language_tax",
+    "estimate_language_tax_for_request",
     "language_tax_usd",
 ]

--- a/coderouter/language_tax.py
+++ b/coderouter/language_tax.py
@@ -1,0 +1,223 @@
+"""Language-tax measurement (Phase 1 PoC, 5-deps invariant).
+
+Why this module exists
+======================
+
+Cloud LLM tokenizers charge CJK text far more tokens-per-character
+than English. CodeRouter's core router uses a ``char/4`` heuristic
+(:mod:`coderouter.token_estimation`) which is *conservative for CJK*
+— i.e. it **under-counts** Japanese/Chinese/Korean text. That gap is
+the "language tax": a Japanese prompt that the heuristic prices at N
+tokens is actually billed at ~1.2-1.5x N by the cloud provider.
+
+Local models are unaffected (no per-token billing), so the tax only
+matters on the cloud leg. This module quantifies it so the cost
+tracker / dashboard can surface "how much extra am I paying to work
+in Japanese?".
+
+Design constraints (mirrors token_estimation_accurate.py)
+=========================================================
+
+* **No new core dependency.** CJK detection is pure ``str`` + Unicode
+  range checks (stdlib only). The *accurate* token count is delegated
+  to :func:`coderouter.token_estimation_accurate.count_tokens`, whose
+  precise backend (HuggingFace ``tokenizers``) is the existing
+  optional ``accuracy`` extra. When that backend is absent every
+  function still returns a sane value — the tax_multiplier simply
+  collapses to 1.0 because both legs use char/4.
+* **Local only / no network.** No tokenizer is ever downloaded; we
+  only pass through a caller-supplied local ``tokenizer.json`` path.
+* **Leaf module.** Imports only ``token_estimation`` /
+  ``token_estimation_accurate`` (both leaves), never the engine or
+  collector — keeps it trivially testable and circular-import-free.
+
+The tax multiplier, defined
+===========================
+
+``tax_multiplier = tokens_accurate / tokens_heuristic``
+
+where ``tokens_heuristic`` is the char/4 estimate (CodeRouter's
+English-calibrated baseline) and ``tokens_accurate`` is the real
+tokenizer count. Reading it:
+
+* English / code text → real tokenizers land near char/4, so the
+  multiplier is ~1.0 (no tax).
+* Japanese prose → real tokenizers emit ~0.5-1.0 tokens/char vs the
+  0.25 the heuristic assumes, so the multiplier lands ~2.0-4.0 on
+  *pure* CJK and ~1.2-1.5 on realistic mixed coding prompts (CJK
+  comments/instructions + ASCII code/identifiers).
+
+Confidence: **MODERATE.** char/4 is itself an approximation of
+English, so the multiplier is "tax relative to CodeRouter's own
+English baseline", not a lab-grade JA-vs-EN figure. It is, however,
+fully measurable with zero network and no guessing — which is why we
+prefer it to a translate-and-compare counterfactual.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from coderouter.token_estimation import CHARS_PER_TOKEN_HEURISTIC
+from coderouter.token_estimation_accurate import count_tokens
+
+# ---------------------------------------------------------------------------
+# CJK Unicode ranges
+# ---------------------------------------------------------------------------
+#
+# We count a character as "CJK" when it falls in one of the blocks that
+# real tokenizers fragment heavily. Latin, digits, punctuation and
+# whitespace are excluded so that an ASCII-only prompt scores 0.0 and a
+# pure-Japanese prompt scores ~1.0. Half-width katakana and full-width
+# forms are included because they tokenize like their full-width kin.
+#
+# Ranges are (low, high) inclusive code points.
+_CJK_RANGES: tuple[tuple[int, int], ...] = (
+    (0x3040, 0x309F),  # Hiragana
+    (0x30A0, 0x30FF),  # Katakana
+    (0x3400, 0x4DBF),  # CJK Unified Ideographs Extension A
+    (0x4E00, 0x9FFF),  # CJK Unified Ideographs (common Kanji/Hanzi)
+    (0xF900, 0xFAFF),  # CJK Compatibility Ideographs
+    (0xFF00, 0xFFEF),  # Half/Full-width forms (full-width punct, half kana)
+    (0x3000, 0x303F),  # CJK symbols & punctuation (、。「」etc.)
+    (0xAC00, 0xD7A3),  # Hangul syllables (Korean)
+    (0x1100, 0x11FF),  # Hangul Jamo
+    (0x20000, 0x2A6DF),  # CJK Ext. B (rare ideographs)
+)
+
+
+def _is_cjk(cp: int) -> bool:
+    for low, high in _CJK_RANGES:
+        if low <= cp <= high:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def cjk_char_ratio(text: str) -> float:
+    """Fraction of *non-whitespace* characters in ``text`` that are CJK.
+
+    Whitespace is excluded from the denominator so that indentation /
+    blank lines in a code block don't dilute the score. Returns ``0.0``
+    for empty or whitespace-only / pure-ASCII text and ``1.0`` for pure
+    CJK. The value feeds the Phase-2 ``cjk_ratio_min`` auto-route
+    matcher and the Phase-1 reporting below.
+    """
+    if not text:
+        return 0.0
+    cjk = 0
+    total = 0
+    for ch in text:
+        if ch.isspace():
+            continue
+        total += 1
+        if _is_cjk(ord(ch)):
+            cjk += 1
+    if total == 0:
+        return 0.0
+    return cjk / total
+
+
+@dataclass(frozen=True)
+class LanguageTaxBreakdown:
+    """Per-text language-tax measurement.
+
+    Fields
+        char_count: non-whitespace-inclusive length of the text.
+        cjk_ratio: see :func:`cjk_char_ratio` (0.0-1.0).
+        tokens_heuristic: char/4 estimate (CodeRouter's English
+            baseline). Always available.
+        tokens_accurate: real tokenizer count when a ``tokenizer_path``
+            was supplied *and* the optional backend is installed;
+            otherwise equals ``tokens_heuristic`` (graceful fallback).
+        accurate_available: whether ``tokens_accurate`` came from the
+            precise backend (True) or fell back to char/4 (False).
+        tax_multiplier: ``tokens_accurate / tokens_heuristic``; 1.0
+            when no tax is measurable. See module docstring for the
+            MODERATE-confidence caveat.
+        extra_tokens: ``tokens_accurate - tokens_heuristic`` (>= 0 for
+            CJK; the visible "tax" in tokens).
+    """
+
+    char_count: int = 0
+    cjk_ratio: float = 0.0
+    tokens_heuristic: int = 0
+    tokens_accurate: int = 0
+    accurate_available: bool = False
+    tax_multiplier: float = 1.0
+    extra_tokens: int = 0
+
+
+def estimate_language_tax(
+    text: str,
+    *,
+    tokenizer_path: str | Path | None = None,
+) -> LanguageTaxBreakdown:
+    """Measure the language tax of ``text``.
+
+    With ``tokenizer_path`` pointing at a readable local
+    ``tokenizer.json`` (and the ``accuracy`` extra installed), the
+    accurate leg uses the real tokenizer and the multiplier reflects
+    the true char/4 under-count. Without it, both legs use char/4 and
+    the multiplier is 1.0 — the function never raises and never
+    touches the network.
+    """
+    if not text:
+        return LanguageTaxBreakdown()
+
+    heuristic = len(text) // CHARS_PER_TOKEN_HEURISTIC
+    accurate_raw = count_tokens(text, tokenizer_path=tokenizer_path)
+
+    # When the precise backend is unavailable, count_tokens returns the
+    # same char/4 value, so accurate == heuristic and we report no tax.
+    accurate_available = tokenizer_path is not None and accurate_raw != heuristic
+
+    # Guard against a zero-heuristic (text shorter than 4 chars) to keep
+    # the multiplier finite and meaningful.
+    if heuristic <= 0:
+        multiplier = 1.0
+        extra = max(accurate_raw - 0, 0)
+    else:
+        multiplier = accurate_raw / heuristic
+        extra = accurate_raw - heuristic
+
+    return LanguageTaxBreakdown(
+        char_count=len(text),
+        cjk_ratio=cjk_char_ratio(text),
+        tokens_heuristic=heuristic,
+        tokens_accurate=accurate_raw,
+        accurate_available=accurate_available,
+        tax_multiplier=multiplier,
+        extra_tokens=max(extra, 0),
+    )
+
+
+def language_tax_usd(
+    extra_tokens: int,
+    *,
+    input_tokens_per_million: float | None,
+) -> float:
+    """USD attributable to the language tax for one request leg.
+
+    ``extra_tokens`` is the :attr:`LanguageTaxBreakdown.extra_tokens`
+    delta; pricing is the provider's normal input rate. Returns 0.0 for
+    a free / unpriced (typically local) provider — mirroring
+    :func:`coderouter.cost.compute_cost_for_attempt`'s zero-on-None
+    behaviour so callers never special-case local models.
+    """
+    if not input_tokens_per_million or extra_tokens <= 0:
+        return 0.0
+    return extra_tokens * (input_tokens_per_million / 1_000_000.0)
+
+
+__all__ = [
+    "cjk_char_ratio",
+    "LanguageTaxBreakdown",
+    "estimate_language_tax",
+    "language_tax_usd",
+]

--- a/coderouter/logging.py
+++ b/coderouter/logging.py
@@ -971,6 +971,10 @@ class CacheObservedPayload(TypedDict):
     streaming: bool
     cost_usd: float
     cost_savings_usd: float
+    # v2.6 language-tax track (optional; default 0.0 / 1.0 at the emit
+    # site keeps pre-v2.6 callers and log consumers working unchanged).
+    language_tax_usd: float
+    language_tax_multiplier: float
 
 
 def log_cache_observed(
@@ -986,6 +990,8 @@ def log_cache_observed(
     streaming: bool,
     cost_usd: float = 0.0,
     cost_savings_usd: float = 0.0,
+    language_tax_usd: float = 0.0,
+    language_tax_multiplier: float = 1.0,
 ) -> None:
     """Emit a ``cache-observed`` info record with the unified shape.
 
@@ -1013,6 +1019,8 @@ def log_cache_observed(
         "streaming": streaming,
         "cost_usd": cost_usd,
         "cost_savings_usd": cost_savings_usd,
+        "language_tax_usd": language_tax_usd,
+        "language_tax_multiplier": language_tax_multiplier,
     }
     logger.info("cache-observed", extra=payload)
 

--- a/coderouter/metrics/collector.py
+++ b/coderouter/metrics/collector.py
@@ -190,6 +190,13 @@ class MetricsCollector(logging.Handler):
         self._cost_total_usd_aggregate: float = 0.0
         self._cost_savings_usd_aggregate: float = 0.0
 
+        # v2.6: per-provider language-tax spend — the USD share of input
+        # cost attributable to the CJK over-count vs the char/4 baseline.
+        # Zero for English/code workloads and for providers without a
+        # configured tokenizer_path. Surfaced alongside cost_total_usd.
+        self._language_tax_usd: dict[str, float] = {}
+        self._language_tax_usd_aggregate: float = 0.0
+
         # v2.0-F (L1): context budget guard counters. Per-profile counts
         # of warnings (over warn threshold) and trims (messages removed).
         # The ``latest_usage_ratio`` dict records the most recent ratio
@@ -388,6 +395,22 @@ class MetricsCollector(logging.Handler):
                         self._cost_savings_usd.get(provider, 0.0) + savings_usd
                     )
                     self._cost_savings_usd_aggregate += savings_usd
+
+                # v2.6: language-tax spend. Same defensive coercion as the
+                # cost fields; defaults to 0.0 for pre-v2.6 log lines and
+                # English/code traffic, so the aggregate only moves on
+                # CJK-heavy requests against a tokenizer-configured provider.
+                lt_usd_raw = extras.get("language_tax_usd", 0.0)
+                lt_usd = (
+                    float(lt_usd_raw)
+                    if isinstance(lt_usd_raw, int | float)
+                    else 0.0
+                )
+                if lt_usd > 0.0:
+                    self._language_tax_usd[provider] = (
+                        self._language_tax_usd.get(provider, 0.0) + lt_usd
+                    )
+                    self._language_tax_usd_aggregate += lt_usd
             elif event == "context-budget-warning":
                 # v2.0-F (L1): context usage exceeded the warn threshold.
                 # Track per-profile and aggregate, plus latest ratio gauge.
@@ -522,6 +545,10 @@ class MetricsCollector(logging.Handler):
                         "savings_usd": round(
                             self._cost_savings_usd.get(name, 0.0), 6
                         ),
+                        # v2.6: per-provider language-tax spend.
+                        "language_tax_usd": round(
+                            self._language_tax_usd.get(name, 0.0), 6
+                        ),
                     },
                 }
                 for name in providers
@@ -588,6 +615,14 @@ class MetricsCollector(logging.Handler):
                     ),
                     "cost_savings_usd_aggregate": round(
                         self._cost_savings_usd_aggregate, 6
+                    ),
+                    # v2.6: per-provider + aggregate language-tax spend.
+                    "language_tax_usd": {
+                        n: round(v, 6)
+                        for n, v in self._language_tax_usd.items()
+                    },
+                    "language_tax_usd_aggregate": round(
+                        self._language_tax_usd_aggregate, 6
                     ),
                     # v2.0-F (L1): context budget guard aggregate counters.
                     "context_budget_warnings_total": self._context_budget_warnings_total,
@@ -682,6 +717,13 @@ class MetricsCollector(logging.Handler):
             self._cost_savings_usd_aggregate += float(
                 state.get("cost_savings_usd_aggregate", 0.0)
             )
+            for k, v in (state.get("language_tax_usd") or {}).items():
+                self._language_tax_usd[k] = (
+                    self._language_tax_usd.get(k, 0.0) + float(v)
+                )
+            self._language_tax_usd_aggregate += float(
+                state.get("language_tax_usd_aggregate", 0.0)
+            )
             self._chain_paid_gate_blocked_total += int(
                 state.get("chain_paid_gate_blocked_total", 0)
             )
@@ -737,6 +779,9 @@ class MetricsCollector(logging.Handler):
             self._cost_savings_usd.clear()
             self._cost_total_usd_aggregate = 0.0
             self._cost_savings_usd_aggregate = 0.0
+            # v2.6
+            self._language_tax_usd.clear()
+            self._language_tax_usd_aggregate = 0.0
             # v2.0-H (L6)
             self._partial_stitch_surfaced_total = 0
             # v2.0-I

--- a/coderouter/routing/auto_router.py
+++ b/coderouter/routing/auto_router.py
@@ -39,6 +39,7 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from coderouter.config.schemas import AutoRouterConfig, AutoRouteRule, RuleMatcher
+from coderouter.language_tax import cjk_char_ratio
 from coderouter.token_estimation import estimate_tokens_from_body as _estimate_total_tokens
 
 if TYPE_CHECKING:
@@ -181,6 +182,12 @@ def _match_rule(
         return message is not None and _has_image(message)
     if m.code_fence_ratio_min is not None:
         return _code_fence_ratio(text) >= m.code_fence_ratio_min
+    if m.cjk_ratio_min is not None:
+        # v2.6: language-tax routing. CJK ratio of the latest user
+        # message — a per-turn property like code_fence_ratio_min, so it
+        # reuses ``text`` (latest user message) rather than walking the
+        # whole request. Steers CJK-heavy turns to a local, tax-free model.
+        return cjk_char_ratio(text) >= m.cjk_ratio_min
     if m.content_contains is not None:
         return m.content_contains in text
     if m.content_regex is not None:

--- a/coderouter/routing/fallback.py
+++ b/coderouter/routing/fallback.py
@@ -61,6 +61,10 @@ from coderouter.guards.tool_loop import (
     detect_tool_loop,
     inject_loop_break_hint,
 )
+from coderouter.language_tax import (
+    LanguageTaxBreakdown,
+    estimate_language_tax_for_request,
+)
 from coderouter.logging import (
     classify_cache_outcome,
     get_logger,
@@ -372,6 +376,7 @@ def _emit_cache_observed(
     streaming: bool,
     provider_config: ProviderConfig | None = None,
     budget: BudgetTracker | None = None,
+    language_tax: LanguageTaxBreakdown | None = None,
 ) -> None:
     """Extract usage / cache fields from an AnthropicResponse and log them.
 
@@ -432,6 +437,7 @@ def _emit_cache_observed(
         output_tokens=usage.output_tokens,
         cache_read_input_tokens=cache_read,
         cache_creation_input_tokens=cache_creation,
+        language_tax=language_tax,
     )
 
     # v1.10: feed the per-provider monthly running total. The
@@ -452,6 +458,8 @@ def _emit_cache_observed(
         streaming=streaming,
         cost_usd=cost.total_usd,
         cost_savings_usd=cost.savings_usd,
+        language_tax_usd=cost.language_tax_usd,
+        language_tax_multiplier=cost.language_tax_multiplier,
     )
 
 
@@ -629,6 +637,7 @@ def _emit_cache_observed_streaming(
     request_had_cache_control: bool,
     provider_config: ProviderConfig | None = None,
     budget: BudgetTracker | None = None,
+    language_tax: LanguageTaxBreakdown | None = None,
 ) -> None:
     """Streaming counterpart of :func:`_emit_cache_observed` (v1.9-B2).
 
@@ -661,6 +670,7 @@ def _emit_cache_observed_streaming(
         output_tokens=output_tokens,
         cache_read_input_tokens=cache_read,
         cache_creation_input_tokens=cache_creation,
+        language_tax=language_tax,
     )
 
     # v1.10: same monthly-budget bookkeeping as the non-streaming
@@ -681,6 +691,8 @@ def _emit_cache_observed_streaming(
         streaming=True,
         cost_usd=cost.total_usd,
         cost_savings_usd=cost.savings_usd,
+        language_tax_usd=cost.language_tax_usd,
+        language_tax_multiplier=cost.language_tax_multiplier,
     )
 
 
@@ -2126,6 +2138,14 @@ class FallbackEngine:
             # outcome=unknown.
             # v1.9-D: also enrich the log line with per-attempt
             # USD cost + cache savings via the provider's CostConfig.
+            # v2.6 language tax: only measured when the provider declares
+            # a local tokenizer.json (else inert — no extra work, mult=1.0).
+            _lt = None
+            _tok = getattr(adapter.config, "tokenizer_path", None)
+            if _tok:
+                _lt = estimate_language_tax_for_request(
+                    request.system, request.messages, tokenizer_path=_tok
+                )
             _emit_cache_observed(
                 resp,
                 provider=adapter.name,
@@ -2133,6 +2153,7 @@ class FallbackEngine:
                 streaming=False,
                 provider_config=adapter.config,
                 budget=self._budget,
+                language_tax=_lt,
             )
             # v2.3.0: observer plugin fanout — fire-and-forget, never
             # blocks the engine response. Latency in ms uses the same
@@ -2359,12 +2380,21 @@ class FallbackEngine:
             # both go through ``classify_cache_outcome`` /
             # ``compute_cost_for_attempt`` for symmetric outcome and
             # cost reporting.
+            # v2.6 language tax: same opt-in measurement as the
+            # non-streaming sibling (inert unless tokenizer_path is set).
+            _lt_s = None
+            _tok_s = getattr(adapter.config, "tokenizer_path", None)
+            if _tok_s:
+                _lt_s = estimate_language_tax_for_request(
+                    request.system, request.messages, tokenizer_path=_tok_s
+                )
             _emit_cache_observed_streaming(
                 acc,
                 provider=adapter.name,
                 request_had_cache_control=request_had_cache_control,
                 provider_config=adapter.config,
                 budget=self._budget,
+                language_tax=_lt_s,
             )
             # v2.3.0: streaming observer fanout fires once, after the
             # SSE terminates successfully. We hand the accumulator's

--- a/coderouter/token_estimation.py
+++ b/coderouter/token_estimation.py
@@ -91,6 +91,21 @@ def _count_system_chars(system: Any) -> int:
     return 0
 
 
+def _extract_system_text(system: Any) -> str:
+    """Concatenate the system prompt text (str or list-of-blocks form)."""
+    if isinstance(system, str):
+        return system
+    if isinstance(system, list):
+        pieces: list[str] = []
+        for block in system:
+            if isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    pieces.append(text)
+        return "\n".join(pieces)
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -153,9 +168,41 @@ def estimate_tokens_from_anthropic_request(
     return total_chars // CHARS_PER_TOKEN_HEURISTIC
 
 
+def extract_text_from_anthropic_request(
+    *,
+    system: Any,
+    messages: list[Any],
+) -> str:
+    """Concatenate all text in an Anthropic-shaped request.
+
+    Mirrors :func:`estimate_tokens_from_anthropic_request` but returns
+    the raw text (system prompt + every message's text blocks) instead
+    of a char/4 count. Used by :mod:`coderouter.language_tax` to feed an
+    accurate tokenizer for language-tax measurement. Non-text blocks
+    (images / tool_use / tool_result) contribute nothing — same rule the
+    char/4 estimator uses.
+    """
+    pieces: list[str] = []
+    sys_text = _extract_system_text(system)
+    if sys_text:
+        pieces.append(sys_text)
+    for msg in messages:
+        if hasattr(msg, "content"):
+            content = msg.content
+        elif isinstance(msg, dict):
+            content = msg.get("content")
+        else:
+            continue
+        text = _extract_text_from_content(content)
+        if text:
+            pieces.append(text)
+    return "\n".join(pieces)
+
+
 __all__ = [
     "CHARS_PER_TOKEN_HEURISTIC",
     "DEFAULT_MAX_CONTEXT_TOKENS",
     "estimate_tokens_from_anthropic_request",
     "estimate_tokens_from_body",
+    "extract_text_from_anthropic_request",
 ]

--- a/tests/test_auto_router_cjk.py
+++ b/tests/test_auto_router_cjk.py
@@ -1,0 +1,99 @@
+"""Phase 2 tests: the ``cjk_ratio_min`` auto-route matcher (v2.6).
+
+Steers CJK-heavy turns (which carry the cloud language tax) to a local
+profile, while ASCII / code turns fall through to the default profile.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from coderouter.config.schemas import (
+    AutoRouterConfig,
+    AutoRouteRule,
+    CodeRouterConfig,
+    FallbackChain,
+    ProviderConfig,
+    RuleMatcher,
+)
+from coderouter.routing.auto_router import classify
+
+
+def _provider(name: str, model: str = "stub") -> ProviderConfig:
+    return ProviderConfig(name=name, base_url="http://localhost:8080/v1", model=model)
+
+
+@pytest.fixture
+def cjk_config() -> CodeRouterConfig:
+    """`default_profile: auto`; one rule routing CJK-heavy turns to local."""
+    return CodeRouterConfig(
+        allow_paid=False,
+        default_profile="auto",
+        providers=[
+            _provider("local-qwen", "qwen2.5:7b"),
+            _provider("cloud-sonnet", "claude-sonnet"),
+        ],
+        profiles=[
+            FallbackChain(name="local", providers=["local-qwen"]),
+            FallbackChain(name="cloud", providers=["cloud-sonnet"]),
+        ],
+        auto_router=AutoRouterConfig(
+            rules=[
+                AutoRouteRule(
+                    id="test:cjk-local",
+                    profile="local",
+                    match=RuleMatcher(cjk_ratio_min=0.3),
+                ),
+            ],
+            default_rule_profile="cloud",
+        ),
+    )
+
+
+def test_cjk_heavy_routes_to_local(cjk_config: CodeRouterConfig):
+    body = {"messages": [{"role": "user", "content": "この関数のバグを直してください"}]}
+    assert classify(body, cjk_config) == "local"
+
+
+def test_ascii_falls_through_to_cloud(cjk_config: CodeRouterConfig):
+    body = {"messages": [{"role": "user", "content": "please fix this bug in my code"}]}
+    assert classify(body, cjk_config) == "cloud"
+
+
+def test_mixed_below_threshold_falls_through(cjk_config: CodeRouterConfig):
+    # Mostly ASCII code with a short JA tail -> ratio < 0.3 -> cloud.
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": "def add(a, b): return a + b  # ok",
+            }
+        ]
+    }
+    assert classify(body, cjk_config) == "cloud"
+
+
+def test_mixed_above_threshold_routes_local(cjk_config: CodeRouterConfig):
+    # Heavier JA share pushes ratio over 0.3.
+    body = {
+        "messages": [
+            {"role": "user", "content": "この関数を修正して: def f(): pass"}
+        ]
+    }
+    assert classify(body, cjk_config) == "local"
+
+
+def test_matcher_rejects_multiple_fields():
+    # one-of invariant still enforced after adding cjk_ratio_min.
+    with pytest.raises(ValueError, match="exactly one matcher field"):
+        RuleMatcher(cjk_ratio_min=0.3, content_contains="x")
+
+
+def test_matcher_accepts_cjk_ratio_alone():
+    m = RuleMatcher(cjk_ratio_min=0.5)
+    assert m.cjk_ratio_min == 0.5
+
+
+def test_matcher_rejects_out_of_range():
+    with pytest.raises(ValueError):
+        RuleMatcher(cjk_ratio_min=1.5)

--- a/tests/test_dashboard_endpoint.py
+++ b/tests/test_dashboard_endpoint.py
@@ -102,6 +102,11 @@ def test_dashboard_starts_with_doctype(client: TestClient) -> None:
         "rate_meta",
         # v1.5-E: TZ label in header (e.g. "Asia/Tokyo" / "UTC").
         "display_timezone",
+        # v2.6: cost + language-tax panel.
+        "cost_total",
+        "cost_savings",
+        "language_tax_total",
+        "language_tax_hint",
     ],
 )
 def test_dashboard_contains_required_data_bind_hooks(
@@ -130,6 +135,7 @@ def test_dashboard_has_all_panels(client: TestClient) -> None:
         "Requests / min",
         "Recent Events",
         "Usage Mix",
+        "Cost &amp; Language Tax",
     ):
         assert title in body, f"panel {title!r} not rendered"
 

--- a/tests/test_language_tax.py
+++ b/tests/test_language_tax.py
@@ -1,0 +1,149 @@
+"""Tests for coderouter.language_tax (Phase 1 PoC).
+
+Run standalone against the real repo:
+
+    PYTHONPATH=<repo_root>:<this_src_dir> pytest test_language_tax.py -q
+
+These tests must pass with OR without the optional ``accuracy``
+(tokenizers) backend installed — the no-backend path is the common
+case and must degrade gracefully (tax_multiplier == 1.0).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from coderouter.language_tax import (
+    LanguageTaxBreakdown,
+    cjk_char_ratio,
+    estimate_language_tax,
+    language_tax_usd,
+)
+
+# A tiny fake tokenizer.json is hard to ship; instead we exercise the
+# accurate path by monkeypatching count_tokens. This keeps the test
+# hermetic and backend-independent.
+import coderouter.language_tax as lt
+
+
+# ---------------------------------------------------------------------------
+# cjk_char_ratio
+# ---------------------------------------------------------------------------
+
+
+def test_cjk_ratio_pure_ascii_is_zero():
+    assert cjk_char_ratio("def main(): return 42") == 0.0
+
+
+def test_cjk_ratio_pure_japanese_is_one():
+    assert cjk_char_ratio("日本語のテキストです") == 1.0
+
+
+def test_cjk_ratio_empty_is_zero():
+    assert cjk_char_ratio("") == 0.0
+    assert cjk_char_ratio("   \n\t ") == 0.0
+
+
+def test_cjk_ratio_whitespace_excluded_from_denominator():
+    # "あ a" -> non-ws chars: "あ","a" -> 1/2
+    assert cjk_char_ratio("あ a") == pytest.approx(0.5)
+
+
+def test_cjk_ratio_mixed_code_comment():
+    # 6 CJK chars (計算する関数) + 5 ascii (abcde), space excluded -> 6/11
+    text = "計算する関数 abcde"
+    assert cjk_char_ratio(text) == pytest.approx(6 / 11)
+
+
+def test_cjk_ratio_korean_and_fullwidth_punct():
+    assert cjk_char_ratio("안녕하세요") == 1.0
+    assert cjk_char_ratio("、。「」") == 1.0
+
+
+# ---------------------------------------------------------------------------
+# estimate_language_tax — no accurate backend (fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_empty_returns_default():
+    b = estimate_language_tax("")
+    assert b == LanguageTaxBreakdown()
+    assert b.tax_multiplier == 1.0
+
+
+def test_estimate_without_tokenizer_has_no_tax():
+    # No tokenizer_path -> accurate == heuristic -> multiplier 1.0
+    b = estimate_language_tax("日本語のテキストです" * 5)
+    assert b.tax_multiplier == 1.0
+    assert b.extra_tokens == 0
+    assert b.accurate_available is False
+    assert b.tokens_heuristic == b.tokens_accurate
+
+
+def test_heuristic_is_char_over_4():
+    text = "x" * 40
+    b = estimate_language_tax(text)
+    assert b.tokens_heuristic == 10
+    assert b.char_count == 40
+
+
+# ---------------------------------------------------------------------------
+# estimate_language_tax — accurate backend (monkeypatched)
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_with_accurate_backend_measures_tax(monkeypatch):
+    # Simulate a real tokenizer charging 2.5x the char/4 estimate for CJK.
+    text = "日本語" * 20  # 60 chars -> heuristic 15 tokens
+    monkeypatch.setattr(lt, "count_tokens", lambda t, *, tokenizer_path=None: 38)
+    b = estimate_language_tax(text, tokenizer_path="/fake/tokenizer.json")
+    assert b.tokens_heuristic == 15
+    assert b.tokens_accurate == 38
+    assert b.accurate_available is True
+    assert b.extra_tokens == 23
+    assert b.tax_multiplier == pytest.approx(38 / 15)
+
+
+def test_accurate_equal_to_heuristic_reports_no_tax(monkeypatch):
+    # English/code: real tokenizer ~= char/4 -> not flagged as tax.
+    text = "a" * 40  # heuristic 10
+    monkeypatch.setattr(lt, "count_tokens", lambda t, *, tokenizer_path=None: 10)
+    b = estimate_language_tax(text, tokenizer_path="/fake/tokenizer.json")
+    assert b.accurate_available is False  # equal -> treated as no measurable tax
+    assert b.tax_multiplier == 1.0
+    assert b.extra_tokens == 0
+
+
+def test_short_text_does_not_divide_by_zero(monkeypatch):
+    # 3 chars -> heuristic 0; must not raise.
+    monkeypatch.setattr(lt, "count_tokens", lambda t, *, tokenizer_path=None: 3)
+    b = estimate_language_tax("あ", tokenizer_path="/fake/tokenizer.json")
+    assert math.isfinite(b.tax_multiplier)
+    assert b.tax_multiplier == 1.0
+    assert b.extra_tokens == 3
+
+
+# ---------------------------------------------------------------------------
+# language_tax_usd
+# ---------------------------------------------------------------------------
+
+
+def test_language_tax_usd_local_provider_is_zero():
+    assert language_tax_usd(1000, input_tokens_per_million=None) == 0.0
+    assert language_tax_usd(1000, input_tokens_per_million=0.0) == 0.0
+
+
+def test_language_tax_usd_negative_or_zero_extra_is_zero():
+    assert language_tax_usd(0, input_tokens_per_million=3.0) == 0.0
+    assert language_tax_usd(-5, input_tokens_per_million=3.0) == 0.0
+
+
+def test_language_tax_usd_basic():
+    # 1,000,000 extra tokens at $3/M == $3.00
+    assert language_tax_usd(1_000_000, input_tokens_per_million=3.0) == pytest.approx(3.0)
+    # 23 extra tokens at $3/M
+    assert language_tax_usd(23, input_tokens_per_million=3.0) == pytest.approx(
+        23 * 3.0 / 1_000_000
+    )

--- a/tests/test_language_tax.py
+++ b/tests/test_language_tax.py
@@ -15,18 +15,16 @@ import math
 
 import pytest
 
+# A tiny fake tokenizer.json is hard to ship; instead we exercise the
+# accurate path by monkeypatching count_tokens. This keeps the test
+# hermetic and backend-independent.
+import coderouter.language_tax as lt
 from coderouter.language_tax import (
     LanguageTaxBreakdown,
     cjk_char_ratio,
     estimate_language_tax,
     language_tax_usd,
 )
-
-# A tiny fake tokenizer.json is hard to ship; instead we exercise the
-# accurate path by monkeypatching count_tokens. This keeps the test
-# hermetic and backend-independent.
-import coderouter.language_tax as lt
-
 
 # ---------------------------------------------------------------------------
 # cjk_char_ratio

--- a/tests/test_language_tax_integration.py
+++ b/tests/test_language_tax_integration.py
@@ -1,0 +1,215 @@
+"""Phase 1b integration tests for the language-tax vertical.
+
+Covers the wiring that connects the leaf ``language_tax`` module to the
+cost calculator, the ``cache-observed`` log line, and the
+MetricsCollector aggregation surface that feeds the dashboard.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from coderouter.config.schemas import CostConfig
+from coderouter.cost import compute_cost_for_attempt
+from coderouter.language_tax import (
+    LanguageTaxBreakdown,
+    estimate_language_tax_for_request,
+)
+from coderouter.logging import configure_logging, get_logger, log_cache_observed
+from coderouter.metrics.collector import (
+    MetricsCollector,
+    install_collector,
+    uninstall_collector,
+)
+from coderouter.token_estimation import extract_text_from_anthropic_request
+
+_SONNET = CostConfig(
+    input_tokens_per_million=3.00,
+    output_tokens_per_million=15.00,
+    cache_read_discount=0.10,
+    cache_creation_premium=1.25,
+)
+
+
+# ---------------------------------------------------------------------------
+# extract_text_from_anthropic_request
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_str_system_and_dict_messages():
+    text = extract_text_from_anthropic_request(
+        system="あなたは助手です",
+        messages=[
+            {"content": "二つの数を足して"},
+            {"content": [{"type": "text", "text": "合計を返す"}]},
+        ],
+    )
+    assert "あなたは助手です" in text
+    assert "二つの数を足して" in text
+    assert "合計を返す" in text
+
+
+def test_extract_text_list_system_and_skips_nontext_blocks():
+    text = extract_text_from_anthropic_request(
+        system=[{"type": "text", "text": "SYS"}],
+        messages=[
+            {"content": [
+                {"type": "text", "text": "hello"},
+                {"type": "image", "source": {}},  # contributes nothing
+                {"type": "tool_use", "name": "x"},
+            ]},
+        ],
+    )
+    assert "SYS" in text and "hello" in text
+    assert "image" not in text and "tool_use" not in text
+
+
+def test_extract_text_empty_request():
+    assert extract_text_from_anthropic_request(system=None, messages=[]) == ""
+
+
+# ---------------------------------------------------------------------------
+# estimate_language_tax_for_request
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_for_request_no_tokenizer_is_inert():
+    b = estimate_language_tax_for_request(
+        system="日本語のシステムプロンプト",
+        messages=[{"content": "日本語のメッセージ" * 4}],
+    )
+    assert isinstance(b, LanguageTaxBreakdown)
+    assert b.tax_multiplier == 1.0  # no tokenizer -> inert
+    assert b.cjk_ratio > 0.9
+
+
+# ---------------------------------------------------------------------------
+# compute_cost_for_attempt threads the language-tax breakdown
+# ---------------------------------------------------------------------------
+
+
+def test_cost_without_language_tax_is_backward_compatible():
+    out = compute_cost_for_attempt(
+        _SONNET,
+        input_tokens=1000,
+        output_tokens=500,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+    assert out.language_tax_multiplier == 1.0
+    assert out.language_tax_usd == 0.0
+
+
+def test_cost_with_language_tax_populates_fields():
+    lt = LanguageTaxBreakdown(
+        char_count=400,
+        cjk_ratio=1.0,
+        tokens_heuristic=100,
+        tokens_accurate=250,
+        accurate_available=True,
+        tax_multiplier=2.5,
+        extra_tokens=150,
+    )
+    out = compute_cost_for_attempt(
+        _SONNET,
+        input_tokens=250,
+        output_tokens=10,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        language_tax=lt,
+    )
+    assert out.language_tax_multiplier == pytest.approx(2.5)
+    # 150 extra tokens at $3/M
+    assert out.language_tax_usd == pytest.approx(150 * 3.0 / 1_000_000)
+
+
+def test_cost_language_tax_zero_for_local_provider():
+    lt = LanguageTaxBreakdown(tax_multiplier=2.0, extra_tokens=150)
+    out = compute_cost_for_attempt(
+        None,  # local / unpriced
+        input_tokens=250,
+        output_tokens=10,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        language_tax=lt,
+    )
+    # None cost_config short-circuits to a zero breakdown.
+    assert out.language_tax_usd == 0.0
+
+
+# ---------------------------------------------------------------------------
+# MetricsCollector aggregation of language_tax_usd
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def collector() -> Iterator[MetricsCollector]:
+    uninstall_collector()
+    configure_logging()
+    yield install_collector(ring_size=16)
+    uninstall_collector()
+
+
+def _fire(**extra: Any) -> None:
+    log_cache_observed(
+        get_logger("test.language_tax"),
+        provider=extra.get("provider", "cloud"),
+        request_had_cache_control=False,
+        outcome="no_cache",
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        input_tokens=extra.get("input_tokens", 0),
+        output_tokens=0,
+        streaming=False,
+        cost_usd=extra.get("cost_usd", 0.0),
+        cost_savings_usd=0.0,
+        language_tax_usd=extra.get("language_tax_usd", 0.0),
+        language_tax_multiplier=extra.get("language_tax_multiplier", 1.0),
+    )
+
+
+def test_collector_aggregates_language_tax(collector: MetricsCollector):
+    _fire(provider="cloud", cost_usd=0.01, language_tax_usd=0.003)
+    _fire(provider="cloud", cost_usd=0.01, language_tax_usd=0.002)
+    snap = collector.snapshot()
+    counters = snap["counters"]
+    assert counters["language_tax_usd_aggregate"] == pytest.approx(0.005)
+    assert counters["language_tax_usd"]["cloud"] == pytest.approx(0.005)
+
+
+def test_collector_provider_row_has_language_tax(collector: MetricsCollector):
+    _fire(provider="cloud", cost_usd=0.01, language_tax_usd=0.004)
+    snap = collector.snapshot()
+    row = next(p for p in snap["providers"] if p["name"] == "cloud")
+    assert row["cost"]["language_tax_usd"] == pytest.approx(0.004)
+
+
+def test_collector_zero_language_tax_no_entry(collector: MetricsCollector):
+    _fire(provider="local", cost_usd=0.0, language_tax_usd=0.0)
+    snap = collector.snapshot()
+    assert "local" not in snap["counters"]["language_tax_usd"]
+
+
+def test_collector_reset_clears_language_tax(collector: MetricsCollector):
+    _fire(provider="cloud", language_tax_usd=0.01)
+    collector.reset()
+    snap = collector.snapshot()
+    assert snap["counters"]["language_tax_usd_aggregate"] == 0.0
+    assert snap["counters"]["language_tax_usd"] == {}
+
+
+def test_collector_defensive_against_non_float_language_tax(
+    collector: MetricsCollector,
+):
+    get_logger("test.language_tax").info(
+        "cache-observed",
+        extra={
+            "provider": "cloud",
+            "language_tax_usd": "not-a-number",
+        },
+    )
+    snap = collector.snapshot()  # must not raise
+    assert snap["counters"]["language_tax_usd_aggregate"] == 0.0

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 1
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "coderouter-cli"
-version = "2.5.2"
+version = "2.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -708,15 +708,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596 }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802 },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632 },
 ]
 
 [[package]]


### PR DESCRIPTION
# feat: Language Tax tracking, routing & dashboard (v2.6)

## Summary

Cloud LLM tokenizers bill CJK text ~1.2–1.5x more tokens per character than English ("language tax"); local models are unaffected. This PR makes that cost **measurable, routable, and visible** — built entirely on existing CodeRouter infrastructure (`token_estimation_accurate`, `cost.py`, `MetricsCollector`, `auto_router` matchers).

Design held to the project's invariants throughout: **no new core dependency** (the accurate tokenizer is the existing optional `accuracy` extra), **no network** (local `tokenizer.json` only, never the HF Hub), and **fully backward compatible** (every new field/param is defaulted; the feature is inert until a provider declares `tokenizer_path`).

## What's included

### Phase 1 — measurement (`c0b542b`)
- New leaf module `coderouter/language_tax.py`: `cjk_char_ratio`, `estimate_language_tax`, `LanguageTaxBreakdown`, `language_tax_usd`. Stdlib-only CJK detection; accurate count delegated to the optional backend with char/4 fallback.
- `cost.py`: `CostBreakdown` gains `language_tax_multiplier` / `language_tax_usd`; `compute_cost_for_attempt` takes an optional `language_tax=`.
- `ProviderConfig.tokenizer_path` (optional, local-file-only).

### Phase 1b — engine wiring (`7fbc840`)
- `token_estimation.extract_text_from_anthropic_request()` + `language_tax.estimate_language_tax_for_request()`.
- `routing/fallback.py`: both `cache-observed` emit sites (streaming + non-streaming) build a `LanguageTaxBreakdown` **only when the provider declares `tokenizer_path`** — hot path untouched by default.
- `logging.py`: `cache-observed` payload carries `language_tax_usd` / `language_tax_multiplier`.
- `metrics/collector.py`: per-provider + aggregate `language_tax_usd`, mirroring the `cost_savings_usd` aggregation (snapshot / restore / reset).

### Phase 2 — language-tax routing (`64c85f8`)
- `RuleMatcher.cjk_ratio_min` (0..1), added to the one-of `_MATCHER_FIELDS` invariant.
- `auto_router._match_rule`: routes turns whose latest user message CJK ratio ≥ threshold to a (typically local, tax-free) profile, mirroring `code_fence_ratio_min`.

```yaml
auto_router:
  rules:
    - match: { cjk_ratio_min: 0.3 }   # JA-heavy turns → local
      profile: local
    - match: { has_tools: true }
      profile: cloud
  default_rule_profile: cloud
```

### Phase 3 — dashboard (`64c85f8`)
- New **"Cost & Language Tax"** panel on `/dashboard`: total spend, cache savings, and CJK language-tax spend (aggregate + per-provider). Also surfaces the previously-hidden cost aggregates.

## Testing

- **Full suite: 1250 passed, 8 skipped** (baseline was 1212; +38 new tests). No regressions.
- **ruff: clean** on all changed files.
- New tests: `test_language_tax.py` (15), `test_language_tax_integration.py` (12), `test_auto_router_cjk.py` (7), plus extended `test_dashboard_endpoint.py` contract.
- Measurement demo (simulated cloud tokenizer): pure English → ×1.00 (no tax), JA comment + code → ×1.93, pure Japanese → ×3.64.

## Compatibility / safety

- No new runtime dependency (5-deps invariant intact).
- No network I/O.
- Inert unless `tokenizer_path` is configured → zero behavior change for existing deployments.

## Files

13 files changed, 953 insertions(+), 0 deletions.
