### PR TITLE
release: 2.6.0 — Language Tax tracking, routing & dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,77 @@ versioning follows [SemVer](https://semver.org/).
 
 ---
 
+## [v2.6.0] — 2026-06-20 (Language Tax: measure, route, visualize)
+
+Minor release: makes the CJK **"language tax"** — cloud tokenizers bill
+Japanese/Chinese/Korean text ~1.2–1.5× more tokens per character than
+English, while local models are unaffected — measurable, routable, and
+visible. Built entirely on existing infrastructure; **no new core
+dependency** (the accurate tokenizer is the existing optional `accuracy`
+extra), **no network** (local `tokenizer.json` only), and **fully
+backward compatible** — the feature is inert until a provider declares
+`tokenizer_path`.
+
+### Added
+
+- **Language-tax measurement (`coderouter/language_tax.py`).** A leaf
+  module exposing `cjk_char_ratio`, `estimate_language_tax`,
+  `LanguageTaxBreakdown`, and `language_tax_usd`. CJK detection is
+  stdlib-only (Unicode range checks); the accurate token count is
+  delegated to the optional `accuracy` (`tokenizers`) backend with a
+  char/4 fallback. The tax multiplier is `tokens_accurate /
+  tokens_heuristic` — ~1.0 for English/code, ~2.0–4.0 for pure CJK.
+
+- **End-to-end cost integration.** `CostBreakdown` gains
+  `language_tax_multiplier` / `language_tax_usd`;
+  `compute_cost_for_attempt` accepts an optional `language_tax=`. Both
+  `cache-observed` emit sites in `routing/fallback.py` (streaming +
+  non-streaming) build a `LanguageTaxBreakdown` **only when the provider
+  declares `tokenizer_path`**, so the hot path is untouched by default.
+  The `cache-observed` log line now carries `language_tax_usd` /
+  `language_tax_multiplier`, and `MetricsCollector` aggregates per-provider
+  + total language-tax spend (mirroring the cost-savings aggregation).
+
+- **`ProviderConfig.tokenizer_path`** — optional path to a local
+  `tokenizer.json` for accurate (language-tax) token counting. Local-file
+  only; never contacts the HuggingFace Hub. Inert when unset.
+
+- **`cjk_ratio_min` auto-route matcher.** A new `RuleMatcher` variant that
+  routes turns whose latest user message CJK ratio ≥ threshold to a
+  (typically local, tax-free) profile, while ASCII/code turns fall through
+  to the cloud chain. Per-turn property mirroring `code_fence_ratio_min`.
+
+  ```yaml
+  auto_router:
+    rules:
+      - match: { cjk_ratio_min: 0.3 }   # JA-heavy turns → local
+        profile: local
+      - match: { has_tools: true }
+        profile: cloud
+    default_rule_profile: cloud
+  ```
+
+- **Dashboard "Cost & Language Tax" panel** on `/dashboard`: total spend,
+  cache savings, and CJK language-tax spend (aggregate + per-provider).
+  Also surfaces the previously-hidden cost aggregates.
+
+- **`token_estimation.extract_text_from_anthropic_request()`** — pulls the
+  concatenated request text for the accurate tokenizer leg.
+
+### Security
+
+- **Bump starlette 1.0.1 → 1.3.1**, clearing four advisories
+  (CVE-2026-48817 / CVE-2026-48818 / CVE-2026-54282 / CVE-2026-54283) that
+  failed the `cve-audit` CI job (`pip-audit --strict`).
+
+### Notes
+
+- 38 new tests (`test_language_tax`, `test_language_tax_integration`,
+  `test_auto_router_cjk`, extended dashboard contract). Full suite:
+  **1250 passed, 8 skipped**. ruff clean. The 5-deps invariant is intact.
+
+---
+
 ## [v2.5.5] — 2026-06-06 (Claude Code >= 2.1.154 `system` role normalization)
 
 Patch release: ingress-side workaround for a Claude Code CLI regression.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 # in plan.md §11.B; once granted, this name will become an alias and
 # `coderouter` will become the canonical distribution name.
 name = "coderouter-cli"
-version = "2.5.5"
+version = "2.6.0"
 description = "Local-first, free-first, fallback-built-in LLM router. Claude Code / OpenAI compatible."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "coderouter-cli"
-version = "2.5.5"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
# feat: Language Tax tracking, routing & dashboard (v2.6)

## Summary

Cloud LLM tokenizers bill CJK text ~1.2–1.5x more tokens per character than English ("language tax"); local models are unaffected. This PR makes that cost **measurable, routable, and visible** — built entirely on existing CodeRouter infrastructure (`token_estimation_accurate`, `cost.py`, `MetricsCollector`, `auto_router` matchers).

Design held to the project's invariants throughout: **no new core dependency** (the accurate tokenizer is the existing optional `accuracy` extra), **no network** (local `tokenizer.json` only, never the HF Hub), and **fully backward compatible** (every new field/param is defaulted; the feature is inert until a provider declares `tokenizer_path`).

## What's included

### Phase 1 — measurement (`c0b542b`)
- New leaf module `coderouter/language_tax.py`: `cjk_char_ratio`, `estimate_language_tax`, `LanguageTaxBreakdown`, `language_tax_usd`. Stdlib-only CJK detection; accurate count delegated to the optional backend with char/4 fallback.
- `cost.py`: `CostBreakdown` gains `language_tax_multiplier` / `language_tax_usd`; `compute_cost_for_attempt` takes an optional `language_tax=`.
- `ProviderConfig.tokenizer_path` (optional, local-file-only).

### Phase 1b — engine wiring (`7fbc840`)
- `token_estimation.extract_text_from_anthropic_request()` + `language_tax.estimate_language_tax_for_request()`.
- `routing/fallback.py`: both `cache-observed` emit sites (streaming + non-streaming) build a `LanguageTaxBreakdown` **only when the provider declares `tokenizer_path`** — hot path untouched by default.
- `logging.py`: `cache-observed` payload carries `language_tax_usd` / `language_tax_multiplier`.
- `metrics/collector.py`: per-provider + aggregate `language_tax_usd`, mirroring the `cost_savings_usd` aggregation (snapshot / restore / reset).

### Phase 2 — language-tax routing (`64c85f8`)
- `RuleMatcher.cjk_ratio_min` (0..1), added to the one-of `_MATCHER_FIELDS` invariant.
- `auto_router._match_rule`: routes turns whose latest user message CJK ratio ≥ threshold to a (typically local, tax-free) profile, mirroring `code_fence_ratio_min`.

```yaml
auto_router:
  rules:
    - match: { cjk_ratio_min: 0.3 }   # JA-heavy turns → local
      profile: local
    - match: { has_tools: true }
      profile: cloud
  default_rule_profile: cloud
```

### Phase 3 — dashboard (`64c85f8`)
- New **"Cost & Language Tax"** panel on `/dashboard`: total spend, cache savings, and CJK language-tax spend (aggregate + per-provider). Also surfaces the previously-hidden cost aggregates.

### Security — unblock CI (`0b6f942`)
- `fix(deps)`: bump starlette 1.0.1 → 1.3.1, clearing four advisories (CVE-2026-48817/48818/54282/54283) that fail the `cve-audit` CI job (`pip-audit --strict`). Minimal lock diff (starlette block + revision + pending project-version line), verified with the exact CI steps.

## Testing

- **Full suite: 1250 passed, 8 skipped** (baseline was 1212; +38 new tests). No regressions.
- **ruff: clean** on all changed files.
- New tests: `test_language_tax.py` (15), `test_language_tax_integration.py` (12), `test_auto_router_cjk.py` (7), plus extended `test_dashboard_endpoint.py` contract.
- Measurement demo (simulated cloud tokenizer): pure English → ×1.00 (no tax), JA comment + code → ×1.93, pure Japanese → ×3.64.

## Compatibility / safety

- No new runtime dependency (5-deps invariant intact).
- No network I/O.
- Inert unless `tokenizer_path` is configured → zero behavior change for existing deployments.

## Files

13 source/test files (+953 lines) for the feature, plus a 10-line `uv.lock` security bump (4 commits total).
