### PR TITLE
docs: language-tax guide + README sections (v2.6.0)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -116,6 +116,36 @@ Full decision matrix → [Do I need CodeRouter?](./docs/start/when-do-i-need-cod
 | **`coderouter replay`** | Compare providers statistically (A/B analysis) / `--suggest-rules` for automated rule suggestions |
 | **Continuous Probe** | Background health monitoring even during idle |
 
+### Language Tax tracking — v2.6.0
+
+CJK text (Japanese / Chinese / Korean) costs more tokens on cloud tokenizers than the same meaning in English (**measured: ~1.6× on average with GPT-4o-era o200k, ~2.0× with GPT-4-era cl100k**). Local models bill nothing per token, so this "language tax" only bites on the cloud leg. CodeRouter v2.6.0 makes it **measurable, routable, and visible**.
+
+| Feature | What it does |
+|---|---|
+| **Language-tax measurement** | Set a provider's `tokenizer_path` (a local `tokenizer.json`) to compute the real token multiplier vs the char/4 heuristic and the extra USD. No network; inert when unset. |
+| **`cjk_ratio_min` routing** | Auto-route CJK-heavy turns to a local (tax-free) model; code/English falls through to the cloud chain. |
+| **Dashboard panel** | The `/dashboard` "Cost & Language Tax" panel shows total spend, cache savings, and language-tax spend live. |
+
+```yaml
+# providers.yaml — steer CJK-heavy turns to local
+auto_router:
+  rules:
+    - match: { cjk_ratio_min: 0.3 }   # >=30% CJK chars -> local
+      profile: local
+    - match: { has_tools: true }      # tool use -> cloud
+      profile: cloud
+  default_rule_profile: cloud
+
+providers:
+  - name: cloud-sonnet
+    kind: anthropic
+    base_url: https://api.anthropic.com
+    model: claude-sonnet-4-6
+    tokenizer_path: ~/.coderouter/tokenizers/sonnet.json   # accurate language-tax (optional)
+```
+
+Details → [Language Tax guide](./docs/guides/language-tax.en.md)
+
 ### Launcher — llama.cpp / vllm GUI
 
 Browser UI at `http://localhost:8088/launcher` for starting and managing local inference backends.
@@ -184,6 +214,7 @@ More detail → [Usage guide](./docs/guides/usage-guide.en.md) · [Architecture]
 | Use it well | [Usage guide](./docs/guides/usage-guide.en.md) |
 | Run for free | [Free-tier guide](./docs/guides/free-tier-guide.en.md) |
 | Launch llama.cpp / vllm via GUI | [Launcher guide](./docs/backends/launcher.md) |
+| Measure & avoid the language tax | [Language Tax guide](./docs/guides/language-tax.en.md) |
 | Stuck? | [Troubleshooting](./docs/guides/troubleshooting.en.md) |
 | Understand the design | [Architecture](./docs/concepts/architecture.md) |
 | Full release history | [CHANGELOG](./CHANGELOG.md) |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,36 @@ ANTHROPIC_BASE_URL=http://localhost:8088 ANTHROPIC_AUTH_TOKEN=dummy claude
 | **`coderouter replay`** | provider 切替の効果を統計比較 (A/B 分析) / `--suggest-rules` でルール最適化提案 |
 | **Continuous Probe** | idle 時も定期的に backend を監視 |
 
+### 言語税トラッキング — v2.6.0
+
+日本語などの CJK テキストは、クラウドのトークナイザだと「同じ意味の英語」より多くのトークンを消費します（**実測: GPT-4o 系 o200k で平均 1.6 倍、GPT-4 系 cl100k で平均 2.0 倍**）。ローカル LLM は課金されないので、この「言語税」はクラウド利用時だけ効いてきます。CodeRouter v2.6.0 はこれを **計測・ルーティング回避・可視化** します。
+
+| 機能 | 何をしてくれるか |
+|---|---|
+| **言語税の計測** | プロバイダに `tokenizer_path`（ローカルの `tokenizer.json`）を指定すると、char/4 ヒューリスティック比の実トークン倍率と割増 USD を算出（ネットワーク不要・未設定なら無効） |
+| **`cjk_ratio_min` ルーティング** | CJK 比率が高いリクエストを自動でローカル LLM（課金ゼロ）へ。コードや英語はクラウドへ |
+| **ダッシュボード可視化** | `/dashboard` の「Cost & Language Tax」パネルで総支出・キャッシュ節約・言語税をリアルタイム表示 |
+
+```yaml
+# providers.yaml — CJK 多めのターンはローカルへ自動回避
+auto_router:
+  rules:
+    - match: { cjk_ratio_min: 0.3 }   # 日本語が3割以上 → ローカル
+      profile: local
+    - match: { has_tools: true }      # ツール使用 → クラウド
+      profile: cloud
+  default_rule_profile: cloud
+
+providers:
+  - name: cloud-sonnet
+    kind: anthropic
+    base_url: https://api.anthropic.com
+    model: claude-sonnet-4-6
+    tokenizer_path: ~/.coderouter/tokenizers/sonnet.json   # 言語税の正確計測（任意）
+```
+
+詳細 → [言語税ガイド](./docs/guides/language-tax.md)
+
 ### Launcher — llama.cpp / vllm 起動 UI
 
 `http://localhost:8088/launcher` で開けるブラウザ UI。llama.cpp や vllm を GUI で起動・管理できます。
@@ -184,6 +214,7 @@ providers:
 | 使いこなす | [利用ガイド](./docs/guides/usage-guide.md) |
 | 無料で回す | [無料枠ガイド](./docs/guides/free-tier-guide.md) |
 | llama.cpp / vllm を GUI で起動 | [Launcher ガイド](./docs/backends/launcher.md) |
+| 言語税を計測・回避する | [言語税ガイド](./docs/guides/language-tax.md) |
 | 詰まった | [トラブルシューティング](./docs/guides/troubleshooting.md) |
 | 設計を知りたい | [アーキテクチャ詳細](./docs/concepts/architecture.md) |
 | 全リリース履歴 | [CHANGELOG](./CHANGELOG.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Index of CodeRouter's public documentation — find the right page by what you w
 | 自分に必要か知りたい / Is it for me? | [start/when-do-i-need-coderouter](start/when-do-i-need-coderouter.md) |
 | 無料で運用したい / Run for free | [guides/free-tier-guide](guides/free-tier-guide.md) |
 | 機能を一通り知りたい / Learn the features | [guides/usage-guide](guides/usage-guide.md) |
+| 言語税を計測・回避したい / Measure & avoid the language tax | [guides/language-tax](guides/language-tax.md) |
 | エラーで詰まった / Something broke | [guides/troubleshooting](guides/troubleshooting.md) |
 | ローカル LLM を起動したい / Launch a local LLM | [backends/launcher-quickstart](backends/launcher-quickstart.md) |
 | APIキー・機密の扱い / Secrets & security | [guides/security](guides/security.md) |
@@ -55,6 +56,7 @@ Many documents have a Japanese version (`.md`) and an English version (`.en.md`)
 日常的に使いこなすためのガイド。 / Day-to-day usage.
 
 - **usage-guide** — 機能を一通り使いこなす / Full feature guide · [日本語](guides/usage-guide.md) · [English](guides/usage-guide.en.md)
+- **language-tax** — 日本語の言語税を計測・ルーティング回避・可視化 / Measure, route around, and visualize the CJK language tax · [日本語](guides/language-tax.md) · [English](guides/language-tax.en.md)
 - **free-tier-guide** — NVIDIA NIM × OpenRouter Free でコストゼロ運用 / Zero-cost operation · [日本語](guides/free-tier-guide.md) · [English](guides/free-tier-guide.en.md)
 - **troubleshooting** — つまずいたときの解決集 / Fixing problems · [日本語](guides/troubleshooting.md) · [English](guides/troubleshooting.en.md)
 - **security** — シークレット管理とセキュリティ方針 / Secrets handling & security posture · [日本語](guides/security.md) · [English](guides/security.en.md)

--- a/docs/guides/language-tax.en.md
+++ b/docs/guides/language-tax.en.md
@@ -1,0 +1,138 @@
+# Language Tax guide
+
+Supplement to [`README.en.md`](../../README.en.md). Explains the **Language Tax tracking** added in CodeRouter v2.6.0 — how it works, how to configure it, and how to tune it.
+
+日本語版: [`language-tax.md`](./language-tax.md)
+
+Contents:
+
+1. [What the language tax is](#1-what-the-language-tax-is)
+2. [Measured data](#2-measured-data)
+3. [Enable measurement (`tokenizer_path`)](#3-enable-measurement-tokenizer_path)
+4. [Avoid it by routing (`cjk_ratio_min`)](#4-avoid-it-by-routing-cjk_ratio_min)
+5. [See it on the dashboard](#5-see-it-on-the-dashboard)
+6. [How it works & confidence](#6-how-it-works--confidence)
+7. [Tuning](#7-tuning)
+
+---
+
+## 1. What the language tax is
+
+Cloud LLM tokenizers split CJK text (Japanese / Chinese / Korean) into more pieces than English. So **the same meaning costs more tokens in Japanese**, inflating cloud API spend. That's the "language tax."
+
+Local models don't bill per token, so the tax only applies to the **cloud leg**. CodeRouter sits exactly at the local↔cloud boundary, so it can measure, avoid, and visualize it.
+
+Two distinct axes:
+
+- **Economic tax (same meaning, JA vs EN)** — how many more tokens the same task costs in Japanese vs English. This is the "expensiveness" operators feel.
+- **char/4-baseline multiplier (CodeRouter's metric)** — the router estimates tokens with a `char/4` heuristic (English-calibrated, ~4 chars/token). For CJK that heuristic badly under-counts, so the real-tokenizer multiplier is larger than the economic tax.
+
+---
+
+## 2. Measured data
+
+Measured with real production tokenizers (reproduce: `_OUTPUTS/CodeRouter-language-tax/measure/`).
+
+### Economic tax — same meaning, JA vs EN (avg of 5 translation pairs)
+
+| Tokenizer | Representative models | JA/EN token ratio |
+|---|---|---|
+| `cl100k_base` | GPT-4 / Claude-3 era | **2.04×** |
+| `o200k_base` | GPT-4o era | **1.60×** |
+
+Short instructions drop to **1.28–1.31×** on o200k. **Newer tokenizers are more JA-efficient** — the widely cited "1.2–1.5×" matches modern tokenizers on shorter text.
+
+### char/4-baseline multiplier (CodeRouter's `tax_multiplier`)
+
+Accurate tokenizer = a real **Qwen2.5** `tokenizer.json`.
+
+| Sample | CJK ratio | char/4 | real tokens | multiplier |
+|---|---|---|---|---|
+| English code | 0% | 18 | 22 | 1.22× |
+| English prose | 0% | 29 | 19 | 0.66× |
+| Mixed (JA comment + code) | 51% | 16 | 40 | **2.50×** |
+| Japanese instructions | 100% | 14 | 36 | **2.57×** |
+| Japanese technical prose | 98% | 29 | 87 | **3.00×** |
+
+> Note: English prose at 0.66× is because char/4 *over*-counts English prose (~6 chars/token in reality). char/4 is an approximation, so `tax_multiplier` is "tax relative to CodeRouter's own char/4 baseline" (confidence: MODERATE).
+
+---
+
+## 3. Enable measurement (`tokenizer_path`)
+
+Point a provider at the model's **local `tokenizer.json`**. **Unset = measurement disabled (multiplier 1.0)** and the hot path is untouched.
+
+```yaml
+providers:
+  - name: cloud-sonnet
+    kind: anthropic
+    base_url: https://api.anthropic.com
+    model: claude-sonnet-4-6
+    tokenizer_path: ~/.coderouter/tokenizers/sonnet.json
+```
+
+### Getting a tokenizer.json (once)
+
+CodeRouter itself never hits the network (local file only). Download the tokenizer once as the operator:
+
+```bash
+pip install "coderouter-cli[accuracy]"   # accurate-count backend (tokenizers)
+
+python - <<'PY'
+from huggingface_hub import hf_hub_download
+p = hf_hub_download(repo_id="Qwen/Qwen2.5-0.5B", filename="tokenizer.json")
+print(p)   # copy into ~/.coderouter/tokenizers/ and set tokenizer_path
+PY
+```
+
+> If you don't have a cloud model's exact tokenizer, a public tokenizer with similar billing behavior (e.g. an o200k-equivalent) works as a proxy; the multiplier is then approximate.
+
+---
+
+## 4. Avoid it by routing (`cjk_ratio_min`)
+
+When the latest user message's **CJK character ratio ≥ threshold**, auto-route to a tax-free local profile; code/English turns fall through to the cloud. Per-turn matcher, like `code_fence_ratio_min`.
+
+```yaml
+auto_router:
+  rules:
+    - match: { cjk_ratio_min: 0.3 }   # >=30% CJK chars -> local
+      profile: local
+    - match: { has_tools: true }      # tool use -> cloud
+      profile: cloud
+  default_rule_profile: cloud
+```
+
+Fires when `default_profile: auto`. `cjk_ratio_min` is the fraction of non-whitespace characters that are CJK (0.0–1.0).
+
+---
+
+## 5. See it on the dashboard
+
+The **"Cost & Language Tax"** panel at `http://localhost:8088/dashboard` shows total spend, cache savings, and **language-tax spend (aggregate + per-provider)**, polled every 2s. With no `tokenizer_path`, it shows "no tax measured."
+
+CLI users can read `counters.language_tax_usd_aggregate` / `counters.language_tax_usd` from `/metrics.json`; it's also exposed on the Prometheus `/metrics` endpoint.
+
+---
+
+## 6. How it works & confidence
+
+- **Measure**: `language_tax.estimate_language_tax(text, tokenizer_path=...)` counts with both char/4 (heuristic) and the real tokenizer (accurate), returning `tax_multiplier = accurate / char4` and `extra_tokens = accurate − char4`.
+- **Cost**: `compute_cost_for_attempt(..., language_tax=...)` computes the tax USD as `extra_tokens × provider input rate`; free/local providers contribute 0.
+- **Aggregate**: the `cache-observed` log carries `language_tax_usd` / `language_tax_multiplier`; `MetricsCollector` keeps per-provider + aggregate totals.
+
+Invariants:
+
+- **No new core dependency** (accurate counting is the existing optional `accuracy` extra, `tokenizers`).
+- **No network** (local `tokenizer.json` only; never contacts the HF Hub).
+- **Backward compatible** (everything defaulted; inert when `tokenizer_path` is unset).
+
+Confidence is **MODERATE**: char/4 is itself an English approximation, so the multiplier is "tax relative to CodeRouter's own English baseline." Still, it's a fully reproducible measurement with no network and no guessing.
+
+---
+
+## 7. Tuning
+
+- **Threshold**: start `cjk_ratio_min` around 0.3. Raise to 0.5 if you don't want code with a few JA comments going local; lower to 0.2 if your sessions are JA-dialogue heavy.
+- **Mixed turns**: ASCII-code-heavy requests with a little JA tend to land at 1.2–1.5× economic tax and low `cjk_ratio`. Keep tool turns on cloud by putting `has_tools: true` above the CJK rule.
+- **Measure first**: set `tokenizer_path`, watch real numbers on `/dashboard`, then A/B the routing avoidance with `coderouter replay`.

--- a/docs/guides/language-tax.md
+++ b/docs/guides/language-tax.md
@@ -1,0 +1,139 @@
+# 言語税 (Language Tax) ガイド
+
+[`README.md`](../../README.md) の補足。CodeRouter v2.6.0 で追加された **言語税トラッキング** の仕組み・設定・チューニングを説明します。
+
+English version: [`language-tax.en.md`](./language-tax.en.md)
+
+目次:
+
+1. [言語税とは](#1-言語税とは)
+2. [実測データ](#2-実測データ)
+3. [計測を有効化する (`tokenizer_path`)](#3-計測を有効化する-tokenizer_path)
+4. [ルーティングで回避する (`cjk_ratio_min`)](#4-ルーティングで回避する-cjk_ratio_min)
+5. [ダッシュボードで見る](#5-ダッシュボードで見る)
+6. [仕組みと確信度](#6-仕組みと確信度)
+7. [チューニング](#7-チューニング)
+
+---
+
+## 1. 言語税とは
+
+クラウド LLM のトークナイザは、日本語などの CJK テキストを英語より細かく分割します。その結果、**同じ意味でも日本語のほうがトークン数が多くなり、クラウド API の課金が増えます**。これが「言語税 (language tax)」です。
+
+ローカル LLM はトークン単位で課金されないので、言語税が効くのは**クラウドに投げるリクエストだけ**です。CodeRouter はローカル ↔ クラウドのルーターなので、この税を「計測・回避・可視化」する位置にいます。
+
+2つの異なる軸があることに注意してください。
+
+- **経済的な税（同義 JA vs EN）**: 同じタスクを日本語で書くと、英語で書くより何倍トークンを食うか。これがユーザーが体感する「割高さ」です。
+- **char/4 比の倍率（CodeRouter の指標）**: CodeRouter のルーターは `char/4` ヒューリスティック（英語基準で約4文字=1トークン）でトークンを概算します。CJK ではこの概算が大きく過小評価になるため、実トークナイザ比の倍率は経済的な税より大きく出ます。
+
+---
+
+## 2. 実測データ
+
+実在の本番トークナイザで計測した結果です（再現スクリプト: `_OUTPUTS/CodeRouter-language-tax/measure/`）。
+
+### 経済的な税 — 同じ意味で JA vs EN（対訳5ペアの平均）
+
+| トークナイザ | 代表モデル | JA/EN トークン比 |
+|---|---|---|
+| `cl100k_base` | GPT-4 / Claude-3 世代 | **2.04×** |
+| `o200k_base` | GPT-4o 世代 | **1.60×** |
+
+短い指示文では o200k で **1.28〜1.31×** まで下がるケースもあります。**新しいトークナイザほど日本語効率が良い**のが実測の重要な示唆です。一般に言われる「1.2〜1.5倍」は、最新トークナイザ・短文寄りの条件と整合します。
+
+### char/4 比の倍率（CodeRouter の `tax_multiplier`）
+
+実トークナイザ = ローカルの **Qwen2.5** `tokenizer.json` で計測。
+
+| サンプル | CJK 比率 | char/4 | 実トークン | 倍率 |
+|---|---|---|---|---|
+| 英語コード | 0% | 18 | 22 | 1.22× |
+| 英語の散文 | 0% | 29 | 19 | 0.66× |
+| 混在（日本語コメント+コード） | 51% | 16 | 40 | **2.50×** |
+| 日本語の指示文 | 100% | 14 | 36 | **2.57×** |
+| 日本語の技術文 | 98% | 29 | 87 | **3.00×** |
+
+> 補足: 英語の散文が 0.66× なのは、char/4 が英語の散文を**過大**評価する（実際は約6文字=1トークン）ためです。char/4 はあくまで近似で、`tax_multiplier` は「CodeRouter 自身の char/4 基準に対する倍率」である点に注意してください（確信度: MODERATE）。
+
+---
+
+## 3. 計測を有効化する (`tokenizer_path`)
+
+プロバイダに、そのモデルの **ローカル `tokenizer.json`** を指定するだけです。**未設定なら言語税計測は無効（倍率 1.0）** で、ホットパスに一切影響しません。
+
+```yaml
+providers:
+  - name: cloud-sonnet
+    kind: anthropic
+    base_url: https://api.anthropic.com
+    model: claude-sonnet-4-6
+    tokenizer_path: ~/.coderouter/tokenizers/sonnet.json
+```
+
+### tokenizer.json の入手（一度だけ）
+
+ネットワークアクセスは CodeRouter 本体では行いません（ローカルファイルのみ読み込み）。トークナイザは運用者が一度だけ手元に落としておきます。
+
+```bash
+pip install "coderouter-cli[accuracy]"   # 正確計測バックエンド (tokenizers)
+
+# 例: Hugging Face から該当モデルの tokenizer.json を取得して配置
+python - <<'PY'
+from huggingface_hub import hf_hub_download
+p = hf_hub_download(repo_id="Qwen/Qwen2.5-0.5B", filename="tokenizer.json")
+print(p)   # これを ~/.coderouter/tokenizers/ にコピーして tokenizer_path に指定
+PY
+```
+
+> クラウドモデル（Claude / GPT 等）の厳密なトークナイザが手元に無い場合は、課金挙動が近い公開トークナイザ（例: o200k 相当）を代理に使えます。倍率は近似値になります。
+
+---
+
+## 4. ルーティングで回避する (`cjk_ratio_min`)
+
+最新ユーザーメッセージの **CJK 文字比率がしきい値以上**なら、課金ゼロのローカルプロファイルへ自動ルーティングします。コードや英語のターンはクラウドへ通します。`code_fence_ratio_min` と同じ「ターン単位」の matcher です。
+
+```yaml
+auto_router:
+  rules:
+    - match: { cjk_ratio_min: 0.3 }   # 日本語が3割以上 → ローカル
+      profile: local
+    - match: { has_tools: true }      # ツール使用 → クラウド
+      profile: cloud
+  default_rule_profile: cloud
+```
+
+`default_profile: auto` のときに発火します。`cjk_ratio_min` は空白を除いた非空白文字に占める CJK 文字の割合（0.0〜1.0）です。
+
+---
+
+## 5. ダッシュボードで見る
+
+`http://localhost:8088/dashboard` の **「Cost & Language Tax」** パネルに、総支出・キャッシュ節約・**言語税（CJK 割増 USD、集計＋プロバイダ別）** が 2 秒ポーリングで表示されます。`tokenizer_path` 未設定なら「no tax measured」と表示されるだけです。
+
+CLI 派は `/metrics.json` の `counters.language_tax_usd_aggregate` / `counters.language_tax_usd`（プロバイダ別）を直接読めます。Prometheus の `/metrics` にも露出します。
+
+---
+
+## 6. 仕組みと確信度
+
+- **計測**: `language_tax.estimate_language_tax(text, tokenizer_path=...)` が char/4（ヒューリスティック）と実トークナイザ（正確）の2本立てでカウントし、`tax_multiplier = 実 / char4`、`extra_tokens = 実 − char4` を返します。
+- **コスト**: `compute_cost_for_attempt(..., language_tax=...)` が `extra_tokens × プロバイダの input 単価` で言語税 USD を算出。フリー / ローカルプロバイダは 0。
+- **集計**: `cache-observed` ログに `language_tax_usd` / `language_tax_multiplier` を載せ、`MetricsCollector` がプロバイダ別＋集計を保持。
+
+設計上の不変条件:
+
+- **新規コア依存なし**（正確計測は既存の任意 extra `accuracy` の `tokenizers`）。
+- **ネットワーク非依存**（`tokenizer.json` のローカル読み込みのみ。HF Hub へアクセスしない）。
+- **後方互換**（全フィールド/引数にデフォルト。`tokenizer_path` 未設定なら無効）。
+
+確信度は **MODERATE**: char/4 自体が英語の近似なので、倍率は「CodeRouter 自身の英語基準に対する税」です。とはいえネットワーク不要・推測なしで完全に再現可能な実測値です。
+
+---
+
+## 7. チューニング
+
+- **しきい値**: `cjk_ratio_min` は 0.3 前後が出発点。コード中心で日本語コメントが少し混じる程度ならローカルに送りたくない場合は 0.5 へ上げます。日本語の対話が主ならむしろ 0.2 へ下げます。
+- **混在ターンの扱い**: ASCII コードが主体で日本語指示が少量のリクエストは経済的税が 1.2〜1.5× に収まりやすく、`cjk_ratio_min` も低く出ます。ツール使用ターンは `has_tools: true` を上位ルールに置いて確実にクラウドへ。
+- **計測だけ先に**: まず `tokenizer_path` を設定して `/dashboard` で実額を見てから、ルーティング回避の効果を `coderouter replay` で A/B 比較するのがおすすめです。


### PR DESCRIPTION
Document the v2.6.0 language-tax feature with real measured numbers.

- docs/guides/language-tax.md / .en.md: new guide — what the tax is, measured data (economic JA/EN ~1.6-2.0x; char/4 multiplier ~2.5-3.0x on real Qwen2.5/tiktoken), tokenizer_path setup, cjk_ratio_min routing, dashboard panel, mechanism/confidence, tuning.
- README.md / README.en.md: "Language Tax tracking" feature subsection
  + config snippet + docs link.
- docs/README.md: index entries for the new guide.

Numbers are reproducible (no network, local tokenizer.json); see _OUTPUTS/CodeRouter-language-tax/measure/.