### PR TITLE
docs(examples): reorganize provider samples with category index

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,68 @@
+# examples — 設定サンプル早わかり
+
+CodeRouter の `providers.yaml` サンプル集です。**「どれを使えばいいか分からない」を解消するための索引**です。
+まず下の決定表で 1 つ選び、`~/.coderouter/providers.yaml` にコピーして使ってください。
+
+```bash
+mkdir -p ~/.coderouter
+cp examples/<選んだファイル> ~/.coderouter/providers.yaml
+coderouter serve --port 8088
+```
+
+> どのファイルも、先頭に `# 【カテゴリ】 …` 行を入れてあります。開いた瞬間に用途が分かります。
+
+---
+
+## まずこれ — あなたの状況 → 使うファイル
+
+| あなたの状況 | 使うファイル | カテゴリ |
+|---|---|---|
+| **とりあえず動かしたい / 迷っている** | `providers.yaml` | 汎用・全部入り |
+| Ollama で、**何も考えず**用途別に振り分けたい | `providers.ollama-auto.yaml` | Ollama 通常 |
+| Ollama で、**振り分けルールを自分で**書きたい | `providers.ollama-auto-custom.yaml` | Ollama 通常（上級） |
+| Ollama で、**ローカル→無料クラウド**だけで完結させたい | `providers.ollama-free-chain.yaml` | Ollama 通常 |
+| **Ollama を使わず**、手元の GGUF を llama.cpp / vLLM で | `providers.llamacpp-vllm.yaml` | llama.cpp / vLLM |
+| 無料の高品質クラウド（**NVIDIA NIM**）を足したい | `providers.nvidia-nim.yaml` | クラウド無料枠 |
+| **Raspberry Pi** など小型 SBC で動かしたい | `providers.raspberrypi.yaml` | 特殊ハード |
+| （開発者向け）Context Budget の検証をしたい | `providers.context-budget-test.yaml` | 内部検証用 |
+
+どれを選んでも、別途 `.env`（`OPENROUTER_API_KEY` など）が要る場合は `cp examples/.env.example .env` してキーを入れます。無料クラウドを使わないなら不要です。
+
+---
+
+## カテゴリ別の中身
+
+### 🟢 汎用 — 迷ったらこれ
+
+- **`providers.yaml`** … 全部入りのフルリファレンス。Ollama / llama.cpp / LM Studio / OpenRouter / Anthropic まで多数の provider と 13 プロファイル（`multi` / `coding` / `general` / `reasoning` / `claude-code` ほか）を定義済み。Claude Code 用に最適化された既定スターターでもあります。**「まず動かす」「他の設定の書き方の見本帳」**として使う。`README` の `curl` ワンライナーが取得するのもこのファイルです。
+
+### 🟦 Ollama 通常 — いちばん手軽な構成
+
+前提: `ollama pull` でモデルを落としてある（各ファイル冒頭にコマンドあり）。
+
+- **`providers.ollama-auto.yaml`** … v1.6 `auto_router` の**ゼロ設定**版。リクエスト本文を見て、画像→`multi` / コード濃→`coding` / その他→`writing` に自動で振り分け。`auto_router:` ブロックを書かなくても内蔵ルールが効く。`multi` / `coding` / `writing` の 3 プロファイルだけ用意すればよい。**最短で「賢い振り分け」を体験したい人向け。**
+- **`providers.ollama-auto-custom.yaml`** … 上の**振り分けルールを自分で書く**版。`auto_router:` ブロックを足すと内蔵ルールは丸ごと置き換わる（マージされない）。「翻訳依頼は文章モデル」等の独自ルールを入れたくなったらここから。
+- **`providers.ollama-free-chain.yaml`** … Qwen3.5 / Gemma4 を主役に、**ローカル → 無料クラウド**だけで完結する鎖。有料 API は `ALLOW_PAID=true` を明示しない限り呼ばれない。Note 記事連動のシンプル構成。
+
+### 🟨 llama.cpp / vLLM — Ollama を使わない
+
+- **`providers.llamacpp-vllm.yaml`** … 手元の `.gguf` を **llama.cpp** で、または **vLLM** で動かす最小構成。Launcher（`/launcher`）で起動したサーバーを provider として登録する形。**Ollama を入れたくない / DL 済み GGUF をそのまま使いたい人向け**（詳細は連作 note 第 22 話、`docs/backends/launcher.md`）。
+
+### 🟧 特殊 — 環境・用途が限定的
+
+- **`providers.nvidia-nim.yaml`** … `ローカル → NVIDIA NIM 無料枠 → OpenRouter 無料 →（有料）`。NIM は OpenRouter より緩いレート（~40 req/min）の高品質エスケープハッチ。
+- **`providers.raspberrypi.yaml`** … Raspberry Pi 4/5 8GB 等の CPU 推論前提。**ローカルは tool 無し**、tool が必要なリクエストだけ無料クラウドへ逃がす割り切り構成（`has_tools` matcher）。
+
+### ⚙️ 内部検証用 — 通常は使わない
+
+- **`providers.context-budget-test.yaml`** … Context Budget（L1）の動作検証用に閾値を低くした構成。**本番には使わない**。検証後は通常の `providers.yaml` に戻すこと。
+
+---
+
+## 動作確認済み
+
+このフォルダの全 `providers*.yaml` は、CodeRouter 本体の設定ローダ（`load_config`、スキーマ＋起動時バリデーション）と、`coderouter serve` の実起動で確認済みです（設定ロード → サーバ起動 → `/dashboard` 応答まで到達）。実際のルーティングには対応バックエンド（Ollama / llama.cpp など）の起動が別途必要です。
+
+---
+
+最終更新: 2026-06-24

--- a/examples/providers.context-budget-test.yaml
+++ b/examples/providers.context-budget-test.yaml
@@ -1,5 +1,6 @@
 # ============================================================
 # CodeRouter providers.yaml — v2.0-F Context Budget 検証用
+# 【カテゴリ】 内部検証用 / Context Budget（本番には使わない）
 #
 # 目的:
 #   Context Budget Management (L1) の実機検証を最小構成で行う。
@@ -7,7 +8,7 @@
 #   トリガーできるようにしている。
 #
 # 使い方:
-#   1. cp examples/providers.v2-context-budget.yaml ~/.coderouter/providers.yaml
+#   1. cp examples/providers.context-budget-test.yaml ~/.coderouter/providers.yaml
 #   2. Ollama (qwen3:32b) or LM Studio (qwen3.5) を起動
 #   3. coderouter serve --port 8088
 #   4. docs/inside/verification-v2.0-F.md の手順を実施

--- a/examples/providers.llamacpp-vllm.yaml
+++ b/examples/providers.llamacpp-vllm.yaml
@@ -1,5 +1,6 @@
 # ============================================================
 # CodeRouter providers.yaml — llama.cpp / vllm ローカル推論サンプル
+# 【カテゴリ】 llama.cpp / vLLM ＋ Launcher（Ollama 不要）
 #
 # このファイルは以下を想定した最小構成です:
 #   - llama.cpp (llama-server) でモデルを起動
@@ -7,7 +8,7 @@
 #   - Launcher UI (/launcher) で起動・管理
 #
 # 使い方:
-#   1. cp examples/providers.llama-cpp-vllm.yaml ~/.coderouter/providers.yaml
+#   1. cp examples/providers.llamacpp-vllm.yaml ~/.coderouter/providers.yaml
 #   2. 必要に応じてパス・ポートを編集
 #   3. coderouter serve
 #   4. http://localhost:8088/launcher でモデルを起動
@@ -77,33 +78,42 @@ launcher:
 
   option_profiles:
 
+    # ⚠ context size の既定について
+    #   Claude Code は毎ターン 15〜35K tokens の system prompt + 会話を送ります。
+    #   ctx-size / max-model-len が小さいと llama.cpp / vLLM が
+    #   "exceed_context_size_error (400)" を返し、CodeRouter からは provider-failed
+    #   → 502 になります。そのため Claude Code 用途では既定を 32768 以上にしています。
+    #   （4096 では Claude Code の system prompt がそもそも入りません）
+    #   モデルの素の対応長を超える場合は YaRN 等の rope 拡張が必要です。
+    #   VRAM/メモリが厳しいときだけ「VRAM 節約」プロファイルを選んでください。
+
     # ── llama.cpp オプションプロファイル ──────────────────────────────────────
     llama.cpp:
 
       - name: "GPU フル活用 (CUDA/Metal)"
         args:
           "-ngl": 99
-          "--ctx-size": 4096
+          "--ctx-size": 65536     # Claude Code(~35K)も余裕。VRAM に応じて 32768〜131072
           "--threads": 4
           "--batch-size": 512
 
       - name: "GPU 控えめ (VRAM 節約)"
         args:
           "-ngl": 20
-          "--ctx-size": 2048
+          "--ctx-size": 16384     # 小さめ。Claude Code の長い会話には不足する場合あり
           "--threads": 8
 
       - name: "CPU のみ"
         args:
           "-ngl": 0
-          "--ctx-size": 4096
+          "--ctx-size": 32768     # Claude Code 最低ライン。CPU 推論は遅いので注意
           "--threads": 12
           "--mlock": true
 
       - name: "Apple Silicon M-series"
         args:
           "-ngl": 99          # Metal: 全レイヤー GPU
-          "--ctx-size": 4096
+          "--ctx-size": 65536     # 統合メモリは余裕がある前提。足りなければ 32768 に
           "--threads": 6
 
       - name: "長コンテキスト (128K)"
@@ -119,13 +129,13 @@ launcher:
       - name: "標準 (auto dtype)"
         args:
           "--dtype": "auto"
-          "--max-model-len": 4096
+          "--max-model-len": 32768   # Claude Code 用。モデルの対応長以内で増減可
           "--gpu-memory-utilization": 0.85
 
       - name: "高速推論 (float16)"
         args:
           "--dtype": "float16"
-          "--max-model-len": 4096
+          "--max-model-len": 32768   # 同上。長い会話は 65536 以上を検討
           "--gpu-memory-utilization": 0.90
           "--max-num-batched-tokens": 8192
 
@@ -134,7 +144,7 @@ launcher:
           "--dtype": "float16"
           "--quantization": "bitsandbytes"
           "--load-format": "bitsandbytes"
-          "--max-model-len": 2048
+          "--max-model-len": 16384   # 省メモリ用に小さめ。Claude Code には不足する場合あり
           "--gpu-memory-utilization": 0.70
 
       - name: "長コンテキスト (32K)"
@@ -147,5 +157,5 @@ launcher:
         args:
           "--dtype": "auto"
           "--tensor-parallel-size": 2
-          "--max-model-len": 8192
+          "--max-model-len": 65536   # 2 GPU なら余裕。Claude Code(~35K)も収まる
           "--gpu-memory-utilization": 0.85

--- a/examples/providers.nvidia-nim.yaml
+++ b/examples/providers.nvidia-nim.yaml
@@ -1,5 +1,6 @@
 # ============================================================
 # CodeRouter providers.yaml — NVIDIA NIM free-tier starter
+# 【カテゴリ】 クラウド無料枠 / NVIDIA NIM（ローカル→NIM→OpenRouter）
 #
 # Shape:
 #   local (Ollama)  →  NVIDIA NIM free  →  OpenRouter free  →  (paid)

--- a/examples/providers.ollama-auto-custom.yaml
+++ b/examples/providers.ollama-auto-custom.yaml
@@ -1,19 +1,20 @@
 # ============================================================
 # CodeRouter providers.yaml — v1.6 auto_router customizer
+# 【カテゴリ】 Ollama 通常 / auto_router 上級（ルールを自分で書く）
 #
 # This is the "copy & edit" starter for users who've outgrown the
-# zero-config example (providers.auto.yaml) and want to override the
+# zero-config example (providers.ollama-auto.yaml) and want to override the
 # bundled ruleset with their own. Everything below the `auto_router:`
-# block is identical to providers.auto.yaml, so diffing the two files
+# block is identical to providers.ollama-auto.yaml, so diffing the two files
 # shows exactly what customization adds.
 #
-# Key behavior differences vs providers.auto.yaml:
+# Key behavior differences vs providers.ollama-auto.yaml:
 #
-#   - providers.auto.yaml          → no auto_router: block → the bundled
+#   - providers.ollama-auto.yaml          → no auto_router: block → the bundled
 #                                    rules apply (image → multi /
 #                                    code-fence≥0.3 → coding / else
 #                                    → writing).
-#   - providers.auto-custom.yaml   → auto_router: block REPLACES the
+#   - providers.ollama-auto-custom.yaml   → auto_router: block REPLACES the
 #                                    bundled rules (no merge). You own
 #                                    the whole list.
 #

--- a/examples/providers.ollama-auto.yaml
+++ b/examples/providers.ollama-auto.yaml
@@ -1,5 +1,6 @@
 # ============================================================
 # CodeRouter providers.yaml — v1.6 auto_router starter (zero-config)
+# 【カテゴリ】 Ollama 通常 / auto_router ゼロ設定スターター
 #
 # This is the beginner-first starter for v1.6's auto_router. Drop it in
 # as your ~/.coderouter/providers.yaml and every request is classified
@@ -24,7 +25,7 @@
 #
 # Advanced users:
 #   - Add `auto_router:` to override the bundled rules — see
-#     providers.auto-custom.yaml for a copy-edit starting point.
+#     providers.ollama-auto-custom.yaml for a copy-edit starting point.
 #   - Per-request overrides still work (body.profile /
 #     X-CodeRouter-Profile / X-CodeRouter-Mode) — auto only fires when
 #     none of those are set.

--- a/examples/providers.ollama-free-chain.yaml
+++ b/examples/providers.ollama-free-chain.yaml
@@ -1,5 +1,6 @@
 # ============================================================
 # CodeRouter providers.yaml — Note 記事用サンプル (2026-04 版)
+# 【カテゴリ】 Ollama 通常 / ローカル→無料クラウドの鎖（記事連動）
 #
 # Qwen3.5 / Gemma4 を主役にした、Claude Code + Codex CLI 向けの
 # 「ローカル → 無料クラウド」のみで完結するチェーン。
@@ -8,10 +9,10 @@
 # 使い方:
 #   1. このファイルを ~/.coderouter/providers.yaml に置く
 #        mkdir -p ~/.coderouter
-#        cp examples/providers.note-2026.yaml ~/.coderouter/providers.yaml
+#        cp examples/providers.ollama-free-chain.yaml ~/.coderouter/providers.yaml
 #      または GitHub から直接:
 #        curl -fsSL -o ~/.coderouter/providers.yaml \
-#          https://raw.githubusercontent.com/zephel01/CodeRouter/main/examples/providers.note-2026.yaml
+#          https://raw.githubusercontent.com/zephel01/CodeRouter/main/examples/providers.ollama-free-chain.yaml
 #   2. ステップ 1 で `ollama pull` したモデル名と一致しているか確認
 #   3. （任意）OpenRouter の無料クラウドを使う場合のみ
 #        export OPENROUTER_API_KEY="sk-or-v1-..."

--- a/examples/providers.raspberrypi.yaml
+++ b/examples/providers.raspberrypi.yaml
@@ -1,5 +1,6 @@
 # ============================================================
 # CodeRouter providers.yaml — Raspberry Pi 8GB starter
+# 【カテゴリ】 特殊ハード / Raspberry Pi 8GB（CPU推論・tool は無料クラウドへ）
 #
 # Use case (OpenClaw + Pi 由来):
 #   小型 SBC (Raspberry Pi 4/5 8GB、Jetson Nano 等) で OpenClaw 等の

--- a/examples/providers.yaml
+++ b/examples/providers.yaml
@@ -1,5 +1,6 @@
 # ============================================================
 # CodeRouter providers.yaml — sample
+# 【カテゴリ】 汎用 / フルリファレンス（迷ったらこれ。Claude Code 既定スターター）
 #
 # Default behavior:
 #   - allow_paid: false  (paid providers are skipped unless ALLOW_PAID=true)


### PR DESCRIPTION
examples の整理: サンプルyamlをカテゴリ準拠の名前にリネーム、各ファイルに【カテゴリ】行を追加、決定表つき examples/README.md を新規追加。