### PR TITLE
feat(shim): fill native /v1/messages endpoint gaps (count_tokens, too…

### DIFF
--- a/coderouter/config/capability_registry.py
+++ b/coderouter/config/capability_registry.py
@@ -115,6 +115,20 @@ class RegistryCapabilities(BaseModel):
             "startup check)."
         ),
     )
+    tool_choice: bool | None = Field(
+        default=None,
+        description=(
+            "S2 (shim): does the upstream honor a forced Anthropic "
+            "``tool_choice`` (``{type: any}`` / ``{type: tool}``) on the "
+            "wire? When True, the fallback engine's ``tool_choice_action`` "
+            "leaves the request untouched. ``None`` (default) = no opinion "
+            "→ the gate falls back to ``provider.kind == 'anthropic'``. "
+            "``False`` hard-disables even on an anthropic-kind provider "
+            "(useful when a specific model regresses). Independent from "
+            "``providers.yaml capabilities.tool_choice`` (explicit "
+            "per-provider opt-in, highest precedence)."
+        ),
+    )
     cache_control: bool | None = Field(
         default=None,
         description=(
@@ -201,6 +215,7 @@ class ResolvedCapabilities:
     max_context_tokens: int | None = None
     claude_code_suitability: Literal["ok", "degraded"] | None = None
     cache_control: bool | None = None
+    tool_choice: bool | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +268,7 @@ class CapabilityRegistry:
         resolved_max_ctx: int | None = None
         resolved_suitability: Literal["ok", "degraded"] | None = None
         resolved_cache_control: bool | None = None
+        resolved_tool_choice: bool | None = None
 
         thinking_locked = False
         reasoning_locked = False
@@ -260,6 +276,7 @@ class CapabilityRegistry:
         max_ctx_locked = False
         suitability_locked = False
         cache_control_locked = False
+        tool_choice_locked = False
 
         for rule in self._rules:
             if not rule.kind_matches(kind):
@@ -285,6 +302,9 @@ class CapabilityRegistry:
             if not cache_control_locked and caps.cache_control is not None:
                 resolved_cache_control = caps.cache_control
                 cache_control_locked = True
+            if not tool_choice_locked and caps.tool_choice is not None:
+                resolved_tool_choice = caps.tool_choice
+                tool_choice_locked = True
             if (
                 thinking_locked
                 and reasoning_locked
@@ -292,6 +312,7 @@ class CapabilityRegistry:
                 and max_ctx_locked
                 and suitability_locked
                 and cache_control_locked
+                and tool_choice_locked
             ):
                 break
 
@@ -302,6 +323,7 @@ class CapabilityRegistry:
             max_context_tokens=resolved_max_ctx,
             claude_code_suitability=resolved_suitability,
             cache_control=resolved_cache_control,
+            tool_choice=resolved_tool_choice,
         )
 
     # ------------------------------------------------------------------

--- a/coderouter/config/schemas.py
+++ b/coderouter/config/schemas.py
@@ -43,6 +43,18 @@ class Capabilities(BaseModel):
     # you explicitly want the raw reasoning text to flow to the client
     # (e.g. CodeRouter is fronting a reasoning-aware downstream).
     reasoning_passthrough: bool = False
+    # S2 (shim): Anthropic's ``tool_choice`` forcing modes (``{type: any}``
+    # / ``{type: tool, name: ...}``). Only a subset of backends honor a
+    # forced tool_choice on the wire; openai_compat translation drops it.
+    # This narrow per-model flag mirrors ``thinking`` / ``prompt_cache``:
+    # when unset (None), the capability gate falls back to the registry and
+    # then to a ``kind == "anthropic"`` heuristic (see
+    # ``coderouter/routing/capability.py``). Motivation: let the fallback
+    # engine's ``tool_choice_action`` emulate forced tool calls via a
+    # system-prompt directive on backends that would otherwise silently
+    # ignore the field. Backward compatible — None leaves v2.x behavior
+    # untouched (no gate, no emulation).
+    tool_choice: bool | None = None
     # v1.0+ fields, declared early so providers.yaml can future-proof
     reasoning_control: Literal["none", "openai", "anthropic", "provider_specific"] = "none"
     mcp: Literal["none", "anthropic", "provider_specific"] = "none"
@@ -703,6 +715,72 @@ class FallbackChain(BaseModel):
             "``off`` discards partial content (legacy error event). "
             "``surface`` returns accumulated text as a graceful stream "
             "termination with a ``coderouter_partial`` metadata event."
+        ),
+    )
+
+    # --- S2 (shim): tool_choice capability gate + emulation -----------------
+    #
+    # Anthropic clients (Claude Code, SDKs) can pin the model to a specific
+    # tool with ``tool_choice: {type: "tool", name: "X"}`` or force *some*
+    # tool with ``{type: "any"}``. Native Anthropic honors this; most
+    # openai_compat backends silently ignore it after translation, so the
+    # model may answer with plain text where the client expected a tool
+    # call. This knob decides what the fallback engine does when a forced
+    # tool_choice request is routed to a provider that does not support it
+    # (per ``provider_supports_tool_choice``):
+    #
+    #   * ``off``     — no detection / no mutation / no log. Backward-compat
+    #                   default (identical to pre-shim behavior).
+    #   * ``warn``    — emit a ``capability-degraded`` log line only; the
+    #                   request is sent unchanged.
+    #   * ``emulate`` — strip the ``tool_choice`` field and inject an English
+    #                   directive into the system prompt instructing the
+    #                   model to call the requested tool. Best-effort
+    #                   forcing for backends without native support. The
+    #                   original request object is left untouched so a later
+    #                   capable provider in the chain still receives the real
+    #                   ``tool_choice``.
+    tool_choice_action: Literal["off", "warn", "emulate"] = Field(
+        default="off",
+        description=(
+            "S2 (shim): action when a request carries a forced "
+            "``tool_choice`` (``{type: any}`` or ``{type: tool}``) and the "
+            "target provider does not support it. ``off`` (default) leaves "
+            "the request unchanged. ``warn`` emits a ``capability-degraded`` "
+            "log only. ``emulate`` strips ``tool_choice`` and injects a "
+            "system-prompt directive to coax the model into calling the "
+            "tool. Per-provider — capable providers are never mutated."
+        ),
+    )
+
+    # --- S3 (shim): cache_control strip -------------------------------------
+    #
+    # By default cache_control markers are simply lost during Anthropic →
+    # OpenAI translation and the ``capability-degraded`` gate logs it
+    # (v0.5-B, observability only). Some strict openai_compat backends,
+    # however, 400 when an unexpected ``cache_control`` key rides along on a
+    # content block (rather than silently ignoring it). ``strip`` proactively
+    # removes those keys from a deep copy of the request before dispatch to
+    # a non-supporting provider, so the marker never reaches the wire.
+    #
+    #   * ``off``   — legacy behavior: leave the request as-is and rely on
+    #                 the existing ``capability-degraded`` observability log.
+    #   * ``strip`` — deep-copy the request and remove every ``cache_control``
+    #                 key from system / tools / message blocks before sending
+    #                 to a non-supporting provider; emit a
+    #                 ``cache-control-stripped`` log with the marker count.
+    #                 Does NOT emit a tokens-saved event (this is not token
+    #                 savings, just a wire-compatibility strip).
+    cache_control_action: Literal["off", "strip"] = Field(
+        default="off",
+        description=(
+            "S3 (shim): action when a request carries ``cache_control`` "
+            "markers and the target provider does not support them. ``off`` "
+            "(default) keeps legacy behavior (marker dropped in translation, "
+            "``capability-degraded`` log only). ``strip`` removes the "
+            "``cache_control`` keys from a deep copy before dispatch and "
+            "emits a ``cache-control-stripped`` log. Per-provider — capable "
+            "providers are never mutated."
         ),
     )
 

--- a/coderouter/ingress/anthropic_routes.py
+++ b/coderouter/ingress/anthropic_routes.py
@@ -38,6 +38,8 @@ from coderouter.routing import (
     NoProvidersAvailableError,
 )
 from coderouter.routing.auto_router import RESERVED_PROFILE_NAME, classify
+from coderouter.token_estimation import extract_text_from_anthropic_request
+from coderouter.token_estimation_accurate import count_tokens, is_accuracy_available
 from coderouter.translation import (
     AnthropicRequest,
     AnthropicStreamEvent,
@@ -314,6 +316,112 @@ async def messages(
             headers=resp_headers,
         )
     return anth_resp.model_dump(exclude_none=True)
+
+
+def _resolve_count_tokens_tokenizer_path(
+    config: Any, profile: str | None
+) -> str | None:
+    """S1 (shim): best-effort resolve a local tokenizer.json for counting.
+
+    Routing for ``count_tokens`` is not a full chain resolution — we only
+    need *a* representative tokenizer for the profile the request would use.
+    We take the first provider of the resolved profile (or the default
+    profile) and return its ``tokenizer_path`` when declared. Any resolution
+    hiccup (unknown profile, empty chain, stub config in tests) returns
+    ``None``, which makes :func:`count_tokens` fall back to the char/4
+    heuristic — a graceful degrade rather than an error.
+    """
+    try:
+        chosen = profile or config.default_profile
+        chain_cfg = config.profile_by_name(chosen)
+        for pname in getattr(chain_cfg, "providers", []) or []:
+            pconf = next((p for p in config.providers if p.name == pname), None)
+            if pconf is not None:
+                tok = getattr(pconf, "tokenizer_path", None)
+                if tok:
+                    return tok
+                # First provider resolved but declares no tokenizer — stop
+                # here (don't scan the whole chain for an unrelated one).
+                return None
+    except (AttributeError, KeyError, ValueError, TypeError):
+        return None
+    return None
+
+
+@router.post("/messages/count_tokens", response_model=None)
+async def count_tokens_route(
+    payload: dict[str, Any],
+    request: Request,
+    x_coderouter_profile: str | None = Header(default=None, alias=_PROFILE_HEADER),
+    x_coderouter_mode: str | None = Header(default=None, alias=_MODE_HEADER),
+) -> dict[str, Any]:
+    """Anthropic ``POST /v1/messages/count_tokens`` — local token estimate.
+
+    Mirrors Anthropic's count_tokens endpoint: the request body has the
+    same shape as ``/v1/messages`` (minus the ``max_tokens`` requirement)
+    and the response is ``{"input_tokens": N}``. CodeRouter answers this
+    entirely locally — there is no upstream round-trip — using the same
+    text-extraction the language-tax / context-budget guards use, feeding
+    an accurate local tokenizer when the routed provider declares one and
+    the ``accuracy`` extra is installed, otherwise the char/4 heuristic.
+
+    Validation is deliberately looser than :class:`AnthropicRequest` (no
+    ``max_tokens`` needed): ``model`` and a non-empty ``messages`` list are
+    required, everything else optional. Profile selection follows the same
+    body > profile-header > mode-header precedence as ``/messages`` so the
+    tokenizer resolves against the provider the real request would hit.
+    """
+    config = request.app.state.config
+
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="request body must be a JSON object")
+
+    messages = payload.get("messages")
+    if not isinstance(messages, list) or not messages:
+        raise HTTPException(
+            status_code=400,
+            detail="'messages' is required and must be a non-empty list",
+        )
+    if "model" not in payload:
+        raise HTTPException(status_code=400, detail="'model' is required")
+
+    # Profile selection — body field wins over header, mode header last
+    # (same policy as /messages). Kept minimal: we only need the profile to
+    # pick a representative tokenizer, so an unknown mode/profile degrades
+    # to the default rather than 400'ing the count.
+    profile = payload.get("profile") or x_coderouter_profile
+    if profile is None and x_coderouter_mode:
+        try:
+            profile = config.resolve_mode(x_coderouter_mode)
+        except (KeyError, AttributeError):
+            profile = None
+
+    # Combine system + messages (+ tool JSON length) into one text blob and
+    # count. tools contribute their JSON length as a coarse proxy for the
+    # schema tokens Anthropic would bill.
+    text = extract_text_from_anthropic_request(
+        system=payload.get("system"),
+        messages=messages,
+    )
+    tools = payload.get("tools")
+    if isinstance(tools, list) and tools:
+        with contextlib.suppress(TypeError, ValueError):
+            text = f"{text}\n{json.dumps(tools, ensure_ascii=False)}"
+
+    tokenizer_path = _resolve_count_tokens_tokenizer_path(config, profile)
+    input_tokens = count_tokens(text, tokenizer_path=tokenizer_path)
+    # Report the method count_tokens *actually* used: the accurate backend
+    # only engages when a path is declared AND the optional ``tokenizers``
+    # dependency is importable (see token_estimation_accurate). Otherwise
+    # count_tokens transparently falls back to char/4 — so we must too, or
+    # the log would misreport a heuristic count as tokenizer-accurate.
+    method = "tokenizer" if (tokenizer_path and is_accuracy_available()) else "heuristic"
+
+    logger.info(
+        "count-tokens-served",
+        extra={"method": method, "input_tokens": input_tokens},
+    )
+    return {"input_tokens": input_tokens}
 
 
 async def _anthropic_sse_iterator(

--- a/coderouter/logging.py
+++ b/coderouter/logging.py
@@ -129,6 +129,7 @@ CapabilityDegradedReason = Literal[
     "provider-does-not-support",
     "translation-lossy",
     "non-standard-field",
+    "unsupported-backend",
 ]
 """Why a capability was degraded.
 
@@ -142,6 +143,10 @@ CapabilityDegradedReason = Literal[
 - ``non-standard-field``: upstream emits a field that is not in the spec
   the ingress speaks, so we strip it on the response-side boundary.
   v0.5-C reasoning field.
+- ``unsupported-backend``: the request asks for a semantic the target
+  backend does not honor (S2 forced ``tool_choice``); with action
+  ``warn`` the request is sent unchanged, with ``emulate`` a separate
+  ``tool-choice-emulated`` line records the substituted directive.
 """
 
 

--- a/coderouter/routing/capability.py
+++ b/coderouter/routing/capability.py
@@ -38,6 +38,7 @@ Design decisions
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from coderouter.config.capability_registry import (
     CapabilityRegistry,
@@ -63,13 +64,17 @@ __all__ = [
     "CapabilityRegistry",
     "ResolvedCapabilities",
     "anthropic_request_has_cache_control",
+    "anthropic_request_has_forced_tool_choice",
     "anthropic_request_requires_thinking",
     "check_claude_code_chain_suitability",
+    "emulate_tool_choice",
     "get_default_registry",
     "log_capability_degraded",
     "provider_supports_cache_control",
     "provider_supports_thinking",
+    "provider_supports_tool_choice",
     "reset_default_registry",
+    "strip_cache_control",
     "strip_thinking",
 ]
 
@@ -306,6 +311,218 @@ def anthropic_request_has_cache_control(request: AnthropicRequest) -> bool:
                     return True
 
     return False
+
+
+# ---------------------------------------------------------------------------
+# S2 (shim): tool_choice capability gate + emulation
+#
+# Anthropic's ``tool_choice`` forces the model to call a tool: ``{type:
+# "any"}`` (call *some* provided tool) or ``{type: "tool", name: "X"}``
+# (call the named tool). Native Anthropic honors this on the wire; most
+# openai_compat backends silently ignore it after Anthropic → OpenAI
+# translation, so the model can answer with plain text where the client
+# expected a tool call. The gate here answers "does this provider honor a
+# forced tool_choice?" with the same 3-tier resolution as the other v0.5
+# gates. The fallback engine's ``tool_choice_action`` uses the answer to
+# either warn or emulate the forcing via a system-prompt directive.
+#
+# ``auto`` / ``none`` / absent tool_choice never trips the gate — only the
+# forcing modes matter (a non-forced choice loses nothing meaningful in
+# translation).
+# ---------------------------------------------------------------------------
+
+
+def provider_supports_tool_choice(
+    provider: ProviderConfig,
+    *,
+    registry: CapabilityRegistry | None = None,
+) -> bool:
+    """Does this provider honor a forced Anthropic ``tool_choice``?
+
+    Resolution order (mirrors :func:`provider_supports_cache_control`):
+        1. If ``provider.capabilities.tool_choice`` is True → True
+           (explicit per-provider opt-in from providers.yaml — highest
+           precedence).
+        2. Consult the capability registry for an explicit
+           ``tool_choice: true|false`` declaration on this
+           ``(kind, model)``. A registry value of ``False`` hard-disables
+           the capability even on a provider whose ``kind`` would normally
+           pass.
+        3. Fall back to the heuristic ``kind == "anthropic"`` — native
+           ``/v1/messages`` passthrough forwards ``tool_choice`` verbatim,
+           whereas openai_compat translation drops the forcing semantics.
+
+    This routine does not inspect the request — it's a per-provider
+    capability. Combine with :func:`anthropic_request_has_forced_tool_choice`
+    in the engine to decide whether to warn / emulate. The ``registry``
+    kwarg is for tests; production callers pass nothing.
+    """
+    if provider.capabilities.tool_choice:
+        return True
+    resolved = _resolve(provider, registry)
+    if resolved.tool_choice is True:
+        return True
+    if resolved.tool_choice is False:
+        return False
+    return provider.kind == "anthropic"
+
+
+def anthropic_request_has_forced_tool_choice(request: AnthropicRequest) -> bool:
+    """True iff the request forces a tool call via ``tool_choice``.
+
+    Anthropic's ``tool_choice.type`` is one of ``auto`` / ``none`` /
+    ``any`` / ``tool``. Only ``any`` (force *some* tool) and ``tool``
+    (force the named tool) are "forcing" modes that a non-supporting
+    backend would silently ignore. ``auto`` / ``none`` / a missing field
+    return False — there is nothing to emulate.
+    """
+    choice = request.tool_choice
+    if not isinstance(choice, dict):
+        return False
+    return choice.get("type") in ("any", "tool")
+
+
+# English directive templates injected into the system prompt when
+# emulating a forced tool_choice on a non-supporting backend. Kept as
+# module constants so tests can assert the exact text and operators can
+# grep for it.
+_EMULATE_TOOL_DIRECTIVE = (
+    '\n\nIMPORTANT: You MUST respond by calling the tool named "{name}". '
+    "Do not respond with plain text."
+)
+_EMULATE_ANY_DIRECTIVE = (
+    "\n\nIMPORTANT: You MUST respond by calling one of the provided tools. "
+    "Do not respond with plain text."
+)
+
+
+def _inject_system_directive(system: Any, directive: str) -> str | list[dict[str, Any]]:
+    """Append ``directive`` to an Anthropic ``system`` field.
+
+    Handles both wire shapes:
+        - ``str`` (short form) → returns ``system + directive`` (a new
+          ``str``; ``None`` is treated as empty).
+        - ``list[dict]`` (block form) → returns a new list with the
+          directive appended as a trailing ``text`` block, so existing
+          blocks (including any ``cache_control`` markers) are untouched.
+    """
+    if system is None:
+        return directive
+    if isinstance(system, str):
+        return system + directive
+    if isinstance(system, list):
+        return [*system, {"type": "text", "text": directive}]
+    # Unexpected shape — fall back to a fresh string so we never lose the
+    # forcing directive (the original object is left untouched upstream).
+    return directive
+
+
+def emulate_tool_choice(request: AnthropicRequest) -> AnthropicRequest:
+    """Return a copy of ``request`` with tool_choice emulated in the prompt.
+
+    Used by the fallback engine's ``tool_choice_action: "emulate"`` path.
+    The returned request has (1) its ``tool_choice`` field removed and (2)
+    an English directive appended to ``system`` instructing the model to
+    call the requested tool. The directive text differs for ``type ==
+    "tool"`` (names the tool) vs ``type == "any"`` (any provided tool).
+
+    The original request is NOT mutated — the engine iterates a fallback
+    chain and a later capable provider must still receive the real
+    ``tool_choice``. Like :func:`strip_thinking`, the CodeRouter-internal
+    ``profile`` / ``anthropic_beta`` fields are preserved.
+
+    No-op-safe: when the request carries no forced tool_choice this still
+    returns a deep copy (callers gate on
+    :func:`anthropic_request_has_forced_tool_choice` first, so this is
+    just defensive).
+    """
+    choice = request.tool_choice if isinstance(request.tool_choice, dict) else {}
+    ctype = choice.get("type")
+    if ctype == "tool":
+        name = choice.get("name", "")
+        directive = _EMULATE_TOOL_DIRECTIVE.format(name=name)
+    else:  # "any" (or defensive fallback)
+        directive = _EMULATE_ANY_DIRECTIVE
+
+    dumped = request.model_dump()
+    dumped.pop("tool_choice", None)
+    dumped["system"] = _inject_system_directive(request.system, directive)
+    emulated = AnthropicRequest.model_validate(dumped)
+    emulated.profile = request.profile
+    emulated.anthropic_beta = request.anthropic_beta
+    return emulated
+
+
+# ---------------------------------------------------------------------------
+# S3 (shim): cache_control strip
+#
+# The v0.5-B gate (above) is observability-only — it logs that cache_control
+# will be lost in translation but never mutates the request, because most
+# openai_compat backends simply ignore the unknown key. Some strict backends
+# 400 instead. ``strip_cache_control`` proactively removes every
+# ``cache_control`` key from a deep copy of the request so the marker never
+# reaches such a backend. Returns ``(request, markers_removed)`` so the
+# engine can log the count. The original request is not mutated (a later
+# capable provider must still receive the markers).
+# ---------------------------------------------------------------------------
+
+
+def _strip_cache_control_from_blocks(blocks: Any) -> int:
+    """Remove ``cache_control`` from each dict block in ``blocks`` in place.
+
+    Returns the number of keys removed. Non-list / non-dict entries are
+    ignored. Mutates the dicts in the given list (the caller passes a deep
+    copy's containers).
+    """
+    removed = 0
+    if not isinstance(blocks, list):
+        return 0
+    for block in blocks:
+        if isinstance(block, dict) and "cache_control" in block:
+            del block["cache_control"]
+            removed += 1
+    return removed
+
+
+def strip_cache_control(request: AnthropicRequest) -> tuple[AnthropicRequest, int]:
+    """Return ``(copy, markers_removed)`` with all cache_control keys gone.
+
+    Walks the same three locations as
+    :func:`anthropic_request_has_cache_control` — ``system`` blocks,
+    ``tools[*]`` (where the marker rides via ``extra="allow"``), and each
+    list-form ``messages[*].content`` — and removes every ``cache_control``
+    key from a deep copy. The original request is untouched so the fallback
+    chain can hand the real markers to a later capable provider.
+
+    ``markers_removed`` is the total count across all three locations,
+    surfaced by the engine in the ``cache-control-stripped`` log. When the
+    request carried no markers this returns ``(copy, 0)``.
+    """
+    dumped = request.model_dump()
+    removed = 0
+
+    # system blocks (list form only — the str short form can't carry it).
+    removed += _strip_cache_control_from_blocks(dumped.get("system"))
+
+    # tool definitions — cache_control arrives via extra="allow".
+    tools = dumped.get("tools")
+    if isinstance(tools, list):
+        for tool in tools:
+            if isinstance(tool, dict) and "cache_control" in tool:
+                del tool["cache_control"]
+                removed += 1
+
+    # message content blocks (list form only).
+    messages = dumped.get("messages")
+    if isinstance(messages, list):
+        for msg in messages:
+            if isinstance(msg, dict):
+                removed += _strip_cache_control_from_blocks(msg.get("content"))
+
+    stripped = AnthropicRequest.model_validate(dumped)
+    stripped.profile = request.profile
+    stripped.anthropic_beta = request.anthropic_beta
+    return stripped, removed
 
 
 # ---------------------------------------------------------------------------

--- a/coderouter/routing/fallback.py
+++ b/coderouter/routing/fallback.py
@@ -86,10 +86,14 @@ from coderouter.routing.adaptive import AdaptiveAdjuster
 from coderouter.routing.budget import BudgetTracker
 from coderouter.routing.capability import (
     anthropic_request_has_cache_control,
+    anthropic_request_has_forced_tool_choice,
     anthropic_request_requires_thinking,
+    emulate_tool_choice,
     log_capability_degraded,
     provider_supports_cache_control,
     provider_supports_thinking,
+    provider_supports_tool_choice,
+    strip_cache_control,
     strip_thinking,
 )
 from coderouter.translation import (
@@ -433,6 +437,104 @@ def _apply_context_budget_guard(
 
     # Trim couldn't remove anything (e.g. only preserve_last_n messages)
     return request, "warning"
+
+
+# ---------------------------------------------------------------------------
+# S2 / S3 (shim): per-provider tool_choice + cache_control shims
+#
+# Applied at the adapter-call site (same position as strip_thinking) so the
+# mutation is per-provider: a request that falls through to a *capable*
+# provider later in the chain still receives its original tool_choice /
+# cache_control markers. All three actions are opt-in (default ``off``) and
+# read from the resolved profile.
+#
+# The shim is a pure function returning the (possibly-copied) request to
+# send to *this* provider. It never mutates the original request object.
+# ---------------------------------------------------------------------------
+
+
+def _apply_tool_choice_shim(
+    request: AnthropicRequest,
+    *,
+    adapter: BaseAdapter,
+    action: str,
+) -> AnthropicRequest:
+    """S2: warn / emulate a forced tool_choice on a non-supporting provider.
+
+    Returns the request to hand to this provider. Only acts when the
+    request carries a forced ``tool_choice`` (``any`` / ``tool``) AND the
+    provider does not support it:
+
+      * ``warn``    → emit a ``capability-degraded`` log; request unchanged.
+      * ``emulate`` → return :func:`emulate_tool_choice` (tool_choice
+                      stripped, system directive injected) + emit a
+                      ``tool-choice-emulated`` log.
+
+    Any other case (action ``off``, non-forced choice, or a capable
+    provider) returns ``request`` unchanged.
+    """
+    if action == "off":
+        return request
+    if not anthropic_request_has_forced_tool_choice(request):
+        return request
+    if provider_supports_tool_choice(adapter.config):
+        return request
+
+    if action == "warn":
+        log_capability_degraded(
+            logger,
+            provider=adapter.name,
+            dropped=["tool_choice"],
+            reason="unsupported-backend",
+        )
+        return request
+
+    if action == "emulate":
+        choice = request.tool_choice if isinstance(request.tool_choice, dict) else {}
+        mode = choice.get("type")
+        tool_name = choice.get("name") if mode == "tool" else None
+        emulated = emulate_tool_choice(request)
+        logger.info(
+            "tool-choice-emulated",
+            extra={"provider": adapter.name, "tool_name": tool_name, "mode": mode},
+        )
+        return emulated
+
+    return request
+
+
+def _apply_cache_control_shim(
+    request: AnthropicRequest,
+    *,
+    adapter: BaseAdapter,
+    action: str,
+    request_had_cache_control: bool,
+) -> AnthropicRequest:
+    """S3: strip cache_control markers before a non-supporting provider.
+
+    Returns the request to hand to this provider. Only acts when the
+    profile's ``cache_control_action`` is ``strip``, the request carries
+    cache_control markers, and the provider does not support them. Emits a
+    ``cache-control-stripped`` log with the marker count. Never emits a
+    tokens-saved event (this is a wire-compatibility strip, not a savings).
+
+    When the strip does not apply, returns ``request`` unchanged — the
+    existing v0.5-B ``capability-degraded`` observability log (emitted at
+    the call site) is preserved as the ``off`` default behavior.
+    """
+    if action != "strip":
+        return request
+    if not request_had_cache_control:
+        return request
+    if provider_supports_cache_control(adapter.config):
+        return request
+
+    stripped, markers_removed = strip_cache_control(request)
+    logger.info(
+        "cache-control-stripped",
+        extra={"provider": adapter.name, "markers_removed": markers_removed},
+    )
+    return stripped
 
 
 def _emit_cache_observed(
@@ -1596,6 +1698,25 @@ class FallbackEngine:
             append_system_prompt=profile.append_system_prompt,
         )
 
+    def _resolve_shim_actions(self, profile_name: str | None) -> tuple[str, str]:
+        """S2 / S3 (shim): resolve ``(tool_choice_action, cache_control_action)``.
+
+        Both default to ``off``, so a missing / stub profile (e.g. a
+        ``__new__``-constructed test engine) yields the backward-compatible
+        no-op pair. Resolved once at the top of each Anthropic entry point
+        (profiles are immutable per request) and passed to every adapter
+        call so the per-provider shim helpers stay pure.
+        """
+        chosen = profile_name or self.config.default_profile
+        try:
+            profile = self.config.profile_by_name(chosen)
+        except (KeyError, ValueError):
+            return "off", "off"
+        return (
+            getattr(profile, "tool_choice_action", "off"),
+            getattr(profile, "cache_control_action", "off"),
+        )
+
     def _resolve_chain(self, profile_name: str | None) -> list[BaseAdapter]:
         """Return the list of adapters to try, in order, for this profile.
 
@@ -2306,6 +2427,10 @@ class FallbackEngine:
         # ever asked for caching. Compute once; the v0.5-B gate uses the
         # same value below for the capability-degraded log.
         request_had_cache_control = anthropic_request_has_cache_control(request)
+        # S2 / S3 (shim): resolve the opt-in per-provider actions once.
+        tool_choice_action, cache_control_action = self._resolve_shim_actions(
+            request.profile
+        )
 
         for adapter, will_degrade in chain:
             is_native = isinstance(adapter, AnthropicAdapter)
@@ -2337,6 +2462,19 @@ class FallbackEngine:
                     dropped=["cache_control"],
                     reason="translation-lossy",
                 )
+            # S2 (shim): forced tool_choice warn / emulate on non-supporting
+            # providers. S3 (shim): cache_control strip. Both mutate a
+            # per-provider copy; a later capable provider still gets the
+            # original request.
+            effective_request = _apply_tool_choice_shim(
+                effective_request, adapter=adapter, action=tool_choice_action
+            )
+            effective_request = _apply_cache_control_shim(
+                effective_request,
+                adapter=adapter,
+                action=cache_control_action,
+                request_had_cache_control=request_had_cache_control,
+            )
             logger.info(
                 "try-provider",
                 extra={
@@ -2534,6 +2672,10 @@ class FallbackEngine:
         # v1.9-A: compute once for the v0.5-B capability-degraded gate
         # AND for the cache-observed emission below.
         request_had_cache_control = anthropic_request_has_cache_control(request)
+        # S2 / S3 (shim): resolve the opt-in per-provider actions once.
+        tool_choice_action, cache_control_action = self._resolve_shim_actions(
+            request.profile
+        )
 
         for adapter, will_degrade in chain:
             is_native = isinstance(adapter, AnthropicAdapter)
@@ -2557,6 +2699,16 @@ class FallbackEngine:
                     dropped=["cache_control"],
                     reason="translation-lossy",
                 )
+            # S2 / S3 (shim): mirror of the non-streaming path.
+            effective_request = _apply_tool_choice_shim(
+                effective_request, adapter=adapter, action=tool_choice_action
+            )
+            effective_request = _apply_cache_control_shim(
+                effective_request,
+                adapter=adapter,
+                action=cache_control_action,
+                request_had_cache_control=request_had_cache_control,
+            )
             logger.info(
                 "try-provider",
                 extra={

--- a/tests/test_capability_degraded_payload.py
+++ b/tests/test_capability_degraded_payload.py
@@ -35,17 +35,19 @@ from coderouter.routing.capability import (
 # ---------------------------------------------------------------------------
 
 
-def test_literal_enumerates_the_three_v0_5_reasons() -> None:
-    """``CapabilityDegradedReason`` must list exactly the 3 v0.5 reasons.
+def test_literal_enumerates_the_known_reasons() -> None:
+    """``CapabilityDegradedReason`` must list exactly the known reasons.
 
     Adding a new reason is deliberate — this test is the deliberate
-    forcing function. When v0.6+ extends the literal, update this test
-    at the same time so the retro / CHANGELOG / TypedDict stay in sync.
+    forcing function. When the literal extends, update this test at the
+    same time so the retro / CHANGELOG / TypedDict stay in sync. The S2
+    shim added ``unsupported-backend`` for the forced-tool_choice gate.
     """
     assert set(get_args(CapabilityDegradedReason)) == {
         "provider-does-not-support",
         "translation-lossy",
         "non-standard-field",
+        "unsupported-backend",
     }
 
 

--- a/tests/test_capability_tool_choice.py
+++ b/tests/test_capability_tool_choice.py
@@ -1,0 +1,251 @@
+"""Unit tests for the S2 tool_choice capability gate + request helpers.
+
+Covers:
+    * ``provider_supports_tool_choice`` 3-tier resolution
+      (explicit capabilities → registry → kind fallback),
+    * ``anthropic_request_has_forced_tool_choice`` forcing-mode detection,
+    * ``emulate_tool_choice`` request rewriting (both system shapes),
+    * ``strip_cache_control`` marker removal.
+
+Pure-function tests — no engine, no HTTP.
+"""
+
+from __future__ import annotations
+
+from coderouter.config.capability_registry import (
+    CapabilityRegistry,
+    CapabilityRule,
+    RegistryCapabilities,
+)
+from coderouter.config.schemas import Capabilities, ProviderConfig
+from coderouter.routing.capability import (
+    anthropic_request_has_forced_tool_choice,
+    emulate_tool_choice,
+    provider_supports_tool_choice,
+    strip_cache_control,
+)
+from coderouter.translation.anthropic import AnthropicRequest
+
+
+def _anthropic(name: str = "anth", **caps: bool) -> ProviderConfig:
+    return ProviderConfig(
+        name=name,
+        kind="anthropic",
+        base_url="https://api.anthropic.com",
+        model="claude-sonnet-4-6",
+        api_key_env="ANTHROPIC_API_KEY",
+        capabilities=Capabilities(**caps),
+    )
+
+
+def _openai(name: str = "oai", **caps: bool) -> ProviderConfig:
+    return ProviderConfig(
+        name=name,
+        kind="openai_compat",
+        base_url="http://localhost:11434/v1",
+        model="qwen-coder",
+        capabilities=Capabilities(**caps),
+    )
+
+
+def _registry(*, kind: str, match: str, tool_choice: bool) -> CapabilityRegistry:
+    return CapabilityRegistry.from_rule_lists(
+        user=[
+            CapabilityRule(
+                match=match,
+                kind=kind,  # type: ignore[arg-type]
+                capabilities=RegistryCapabilities(tool_choice=tool_choice),
+            )
+        ]
+    )
+
+
+# ----------------------------------------------------------------------
+# provider_supports_tool_choice — 3-tier resolution
+# ----------------------------------------------------------------------
+
+
+def test_gate_explicit_capability_wins() -> None:
+    """capabilities.tool_choice: true opts an openai_compat provider in,
+    overriding the kind heuristic that would otherwise say False."""
+    prov = _openai(tool_choice=True)
+    # Empty registry so tier 2 never fires; explicit flag is tier 1.
+    reg = CapabilityRegistry.from_rule_lists()
+    assert provider_supports_tool_choice(prov, registry=reg) is True
+
+
+def test_gate_registry_true_promotes_openai() -> None:
+    """A registry rule declaring tool_choice=true promotes an
+    openai_compat model the kind heuristic would reject."""
+    prov = _openai()
+    reg = _registry(kind="openai_compat", match="qwen-coder", tool_choice=True)
+    assert provider_supports_tool_choice(prov, registry=reg) is True
+
+
+def test_gate_registry_false_hard_disables_anthropic() -> None:
+    """A registry rule declaring tool_choice=false hard-disables even an
+    anthropic-kind provider that the fallback would otherwise pass."""
+    prov = _anthropic()
+    reg = _registry(kind="anthropic", match="claude-sonnet-4-6", tool_choice=False)
+    assert provider_supports_tool_choice(prov, registry=reg) is False
+
+
+def test_gate_kind_fallback_anthropic_true_openai_false() -> None:
+    """With no explicit flag and no registry opinion, the kind heuristic
+    decides: anthropic → True, openai_compat → False."""
+    empty = CapabilityRegistry.from_rule_lists()
+    assert provider_supports_tool_choice(_anthropic(), registry=empty) is True
+    assert provider_supports_tool_choice(_openai(), registry=empty) is False
+
+
+# ----------------------------------------------------------------------
+# anthropic_request_has_forced_tool_choice — forcing-mode detection
+# ----------------------------------------------------------------------
+
+
+def _req(tool_choice: dict | None) -> AnthropicRequest:
+    body: dict = {
+        "model": "m",
+        "max_tokens": 16,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    if tool_choice is not None:
+        body["tool_choice"] = tool_choice
+    return AnthropicRequest.model_validate(body)
+
+
+def test_forced_true_for_any_and_tool() -> None:
+    assert anthropic_request_has_forced_tool_choice(_req({"type": "any"})) is True
+    assert (
+        anthropic_request_has_forced_tool_choice(
+            _req({"type": "tool", "name": "get_weather"})
+        )
+        is True
+    )
+
+
+def test_forced_false_for_auto_none_and_absent() -> None:
+    assert anthropic_request_has_forced_tool_choice(_req({"type": "auto"})) is False
+    assert anthropic_request_has_forced_tool_choice(_req({"type": "none"})) is False
+    assert anthropic_request_has_forced_tool_choice(_req(None)) is False
+
+
+# ----------------------------------------------------------------------
+# emulate_tool_choice — request rewriting
+# ----------------------------------------------------------------------
+
+
+def test_emulate_tool_strips_choice_and_names_tool_str_system() -> None:
+    req = AnthropicRequest.model_validate(
+        {
+            "model": "m",
+            "max_tokens": 16,
+            "system": "base prompt",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": {"type": "tool", "name": "get_weather"},
+        }
+    )
+    out = emulate_tool_choice(req)
+    assert out.tool_choice is None
+    assert isinstance(out.system, str)
+    assert out.system.startswith("base prompt")
+    assert 'the tool named "get_weather"' in out.system
+    assert "Do not respond with plain text." in out.system
+    # Original untouched.
+    assert req.tool_choice == {"type": "tool", "name": "get_weather"}
+    assert req.system == "base prompt"
+
+
+def test_emulate_any_appends_block_to_list_system() -> None:
+    req = AnthropicRequest.model_validate(
+        {
+            "model": "m",
+            "max_tokens": 16,
+            "system": [
+                {"type": "text", "text": "base", "cache_control": {"type": "ephemeral"}}
+            ],
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": {"type": "any"},
+        }
+    )
+    out = emulate_tool_choice(req)
+    assert out.tool_choice is None
+    assert isinstance(out.system, list)
+    # Original block preserved verbatim (incl. cache_control), directive
+    # appended as a new trailing text block.
+    assert out.system[0] == {
+        "type": "text",
+        "text": "base",
+        "cache_control": {"type": "ephemeral"},
+    }
+    assert "one of the provided tools" in out.system[-1]["text"]
+
+
+def test_emulate_preserves_profile_and_beta() -> None:
+    req = _req({"type": "any"})
+    req.profile = "coding"
+    req.anthropic_beta = "beta-x"
+    out = emulate_tool_choice(req)
+    assert out.profile == "coding"
+    assert out.anthropic_beta == "beta-x"
+
+
+# ----------------------------------------------------------------------
+# strip_cache_control — marker removal + count
+# ----------------------------------------------------------------------
+
+
+def test_strip_cache_control_removes_all_markers() -> None:
+    req = AnthropicRequest.model_validate(
+        {
+            "model": "m",
+            "max_tokens": 16,
+            "system": [
+                {"type": "text", "text": "sys", "cache_control": {"type": "ephemeral"}}
+            ],
+            "tools": [
+                {
+                    "name": "t",
+                    "input_schema": {},
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "hi",
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                }
+            ],
+            "tool_choice": {"type": "auto"},
+        }
+    )
+    out, removed = strip_cache_control(req)
+    assert removed == 3
+    assert "cache_control" not in out.system[0]
+    assert "cache_control" not in (out.tools[0].model_extra or {})
+    assert "cache_control" not in out.messages[0].content[0]
+    # Other fields preserved.
+    assert out.tool_choice == {"type": "auto"}
+    assert out.system[0]["text"] == "sys"
+    # Original untouched.
+    assert req.system[0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_strip_cache_control_no_markers_returns_zero() -> None:
+    req = AnthropicRequest.model_validate(
+        {
+            "model": "m",
+            "max_tokens": 16,
+            "system": "plain",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+    )
+    out, removed = strip_cache_control(req)
+    assert removed == 0
+    assert out.system == "plain"

--- a/tests/test_config_shim_actions.py
+++ b/tests/test_config_shim_actions.py
@@ -1,0 +1,49 @@
+"""Config fail-fast tests for the S2/S3 shim action fields.
+
+The new ``FallbackChain.tool_choice_action`` and ``cache_control_action``
+are constrained ``Literal`` enums; an out-of-set value must raise a
+Pydantic ``ValidationError`` at config-load rather than silently no-op'ing
+at request time (same fast-fail philosophy as the other ``*_action``
+fields). Also asserts the backward-compatible defaults.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from coderouter.config.schemas import Capabilities, FallbackChain
+
+
+def test_defaults_are_off() -> None:
+    chain = FallbackChain(name="default", providers=["a"])
+    assert chain.tool_choice_action == "off"
+    assert chain.cache_control_action == "off"
+
+
+def test_valid_tool_choice_actions() -> None:
+    for action in ("off", "warn", "emulate"):
+        chain = FallbackChain(name="d", providers=["a"], tool_choice_action=action)
+        assert chain.tool_choice_action == action
+
+
+def test_valid_cache_control_actions() -> None:
+    for action in ("off", "strip"):
+        chain = FallbackChain(name="d", providers=["a"], cache_control_action=action)
+        assert chain.cache_control_action == action
+
+
+def test_invalid_tool_choice_action_raises() -> None:
+    with pytest.raises(ValidationError):
+        FallbackChain(name="d", providers=["a"], tool_choice_action="bogus")
+
+
+def test_invalid_cache_control_action_raises() -> None:
+    with pytest.raises(ValidationError):
+        FallbackChain(name="d", providers=["a"], cache_control_action="drop")
+
+
+def test_capabilities_tool_choice_default_none_and_bool() -> None:
+    assert Capabilities().tool_choice is None
+    assert Capabilities(tool_choice=True).tool_choice is True
+    assert Capabilities(tool_choice=False).tool_choice is False

--- a/tests/test_fallback_cache_strip.py
+++ b/tests/test_fallback_cache_strip.py
@@ -1,0 +1,254 @@
+"""Engine-level tests for the S3 cache_control strip shim.
+
+Focus: FallbackEngine.generate_anthropic / stream_anthropic with a
+cache_control request routed through a provider that does not support it,
+under ``cache_control_action``.
+
+  * ``strip`` → the adapter receives a request with the cache_control keys
+    removed; a ``cache-control-stripped`` log fires with the marker count;
+    the original request is untouched; a supporting provider is not stripped.
+  * ``off``   → legacy behavior — the request is passed through unchanged
+    and only the existing v0.5-B ``capability-degraded`` log fires (no
+    ``cache-control-stripped`` line).
+
+Reuses the FakeAdapter scaffolding from tests/test_fallback_anthropic.py.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from coderouter.adapters.base import BaseAdapter
+from coderouter.config.schemas import (
+    Capabilities,
+    CodeRouterConfig,
+    FallbackChain,
+    ProviderConfig,
+)
+from coderouter.routing import FallbackEngine
+from coderouter.translation.anthropic import AnthropicRequest
+from tests.test_fallback_anthropic import FakeAnthropicAdapter, FakeOpenAIAdapter
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _anthropic_provider(name: str) -> ProviderConfig:
+    return ProviderConfig(
+        name=name,
+        kind="anthropic",
+        base_url="https://api.anthropic.com",
+        model="claude-sonnet-4-6",
+        api_key_env="ANTHROPIC_API_KEY",
+    )
+
+
+def _openai_provider(name: str, *, prompt_cache: bool = False) -> ProviderConfig:
+    return ProviderConfig(
+        name=name,
+        kind="openai_compat",
+        base_url="http://localhost:11434/v1",
+        model="qwen-coder",
+        capabilities=Capabilities(prompt_cache=prompt_cache),
+    )
+
+
+def _config(
+    providers: list[ProviderConfig],
+    chain: list[str],
+    *,
+    action: str = "off",
+) -> CodeRouterConfig:
+    return CodeRouterConfig(
+        allow_paid=False,
+        default_profile="default",
+        providers=providers,
+        profiles=[
+            FallbackChain(name="default", providers=chain, cache_control_action=action)
+        ],
+    )
+
+
+def _engine(config: CodeRouterConfig, adapters: dict[str, BaseAdapter]) -> FallbackEngine:
+    engine = FallbackEngine.__new__(FallbackEngine)
+    engine.config = config
+    engine._adapters = adapters  # type: ignore[attr-defined]
+    return engine
+
+
+def _cache_request() -> AnthropicRequest:
+    return AnthropicRequest.model_validate(
+        {
+            "model": "m",
+            "max_tokens": 64,
+            "system": [
+                {
+                    "type": "text",
+                    "text": "long reusable system prompt",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "hi",
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
+def _stripped_logs(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.msg == "cache-control-stripped"]
+
+
+def _tokens_saved_logs(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.msg == "tokens-saved"]
+
+
+# ----------------------------------------------------------------------
+# strip — non-streaming
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_strip_removes_cache_control_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    compat_cfg = _openai_provider("ollama")
+    config = _config([compat_cfg], chain=["ollama"], action="strip")
+    compat = FakeOpenAIAdapter(compat_cfg, text="ok")
+    engine = _engine(config, {"ollama": compat})
+
+    original = _cache_request()
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        await engine.generate_anthropic(original)
+
+    logs = _stripped_logs(caplog)
+    assert len(logs) == 1
+    assert logs[0].provider == "ollama"
+    assert logs[0].markers_removed == 2
+
+    # No tokens-saved event — this is a wire-compat strip, not savings.
+    assert _tokens_saved_logs(caplog) == []
+
+    # Original request untouched (markers preserved for a later provider).
+    assert original.system[0]["cache_control"] == {"type": "ephemeral"}
+    assert original.messages[0].content[0]["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.asyncio
+async def test_strip_preserves_other_fields(caplog: pytest.LogCaptureFixture) -> None:
+    """The strip removes only cache_control; the system text and messages
+    survive so the request is otherwise byte-for-byte equivalent."""
+    compat_cfg = _openai_provider("ollama")
+    config = _config([compat_cfg], chain=["ollama"], action="strip")
+    compat = FakeOpenAIAdapter(compat_cfg, text="ok")
+    engine = _engine(config, {"ollama": compat})
+
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        await engine.generate_anthropic(_cache_request())
+
+    # The translated ChatRequest carries the system text intact.
+    chat_req = compat.generate_calls[0]
+    system_text = " ".join(
+        m.content or "" for m in chat_req.messages if m.role == "system"
+    )
+    assert "long reusable system prompt" in system_text
+
+
+@pytest.mark.asyncio
+async def test_off_passes_through_no_strip_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """action=off → the request passes through untouched; only the existing
+    v0.5-B capability-degraded log fires (no cache-control-stripped)."""
+    compat_cfg = _openai_provider("ollama")
+    config = _config([compat_cfg], chain=["ollama"], action="off")
+    compat = FakeOpenAIAdapter(compat_cfg, text="ok")
+    engine = _engine(config, {"ollama": compat})
+
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        await engine.generate_anthropic(_cache_request())
+
+    assert _stripped_logs(caplog) == []
+    # The legacy translation-lossy observability log still fires.
+    degraded = [
+        r
+        for r in caplog.records
+        if r.msg == "capability-degraded"
+        and getattr(r, "reason", None) == "translation-lossy"
+    ]
+    assert len(degraded) == 1
+
+
+@pytest.mark.asyncio
+async def test_supporting_provider_not_stripped(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An anthropic-kind provider preserves cache_control end-to-end →
+    even with action=strip the markers are left in place, no strip log."""
+    anth_cfg = _anthropic_provider("sonnet")
+    config = _config([anth_cfg], chain=["sonnet"], action="strip")
+    anth = FakeAnthropicAdapter(anth_cfg, text="ok")
+    engine = _engine(config, {"sonnet": anth})
+
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        await engine.generate_anthropic(_cache_request())
+
+    assert _stripped_logs(caplog) == []
+    # The native adapter received the request WITH cache_control intact.
+    received = anth.generate_calls[0]
+    assert received.system[0]["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.asyncio
+async def test_explicit_prompt_cache_flag_suppresses_strip(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """capabilities.prompt_cache: true declares the openai_compat upstream
+    preserves the marker → treated as capable, no strip."""
+    compat_cfg = _openai_provider("future-compat", prompt_cache=True)
+    config = _config([compat_cfg], chain=["future-compat"], action="strip")
+    compat = FakeOpenAIAdapter(compat_cfg, text="ok")
+    engine = _engine(config, {"future-compat": compat})
+
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        await engine.generate_anthropic(_cache_request())
+
+    assert _stripped_logs(caplog) == []
+
+
+# ----------------------------------------------------------------------
+# strip — streaming
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_strip_removes_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    compat_cfg = _openai_provider("ollama")
+    config = _config([compat_cfg], chain=["ollama"], action="strip")
+    compat = FakeOpenAIAdapter(compat_cfg, text="streamed")
+    engine = _engine(config, {"ollama": compat})
+
+    original = _cache_request()
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        events = [ev async for ev in engine.stream_anthropic(original)]
+
+    assert events
+    logs = _stripped_logs(caplog)
+    assert len(logs) == 1
+    assert logs[0].markers_removed == 2
+    # Original untouched.
+    assert original.system[0]["cache_control"] == {"type": "ephemeral"}

--- a/tests/test_fallback_tool_choice_emulate.py
+++ b/tests/test_fallback_tool_choice_emulate.py
@@ -1,0 +1,267 @@
+"""Engine-level tests for the S2 tool_choice shim (warn / emulate).
+
+Focus: FallbackEngine.generate_anthropic / stream_anthropic with a forced
+``tool_choice`` request routed through a provider that does not support it.
+
+  * ``emulate`` → the adapter receives a request with NO tool_choice and a
+    system-prompt directive injected; the ORIGINAL request is unchanged;
+    a ``tool-choice-emulated`` log fires.
+  * ``warn``    → the adapter receives the request UNCHANGED; only a
+    ``capability-degraded`` (reason=unsupported-backend) log fires.
+  * ``off``     → no mutation, no shim log.
+  * A supporting (anthropic-kind) provider is never mutated.
+
+Reuses the FakeAdapter scaffolding from tests/test_fallback_anthropic.py.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from coderouter.adapters.base import BaseAdapter
+from coderouter.config.schemas import (
+    Capabilities,
+    CodeRouterConfig,
+    FallbackChain,
+    ProviderConfig,
+)
+from coderouter.routing import FallbackEngine
+from coderouter.translation.anthropic import AnthropicRequest
+from tests.test_fallback_anthropic import FakeAnthropicAdapter, FakeOpenAIAdapter
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _anthropic_provider(name: str, *, tool_choice: bool = False) -> ProviderConfig:
+    return ProviderConfig(
+        name=name,
+        kind="anthropic",
+        base_url="https://api.anthropic.com",
+        model="claude-sonnet-4-6",
+        api_key_env="ANTHROPIC_API_KEY",
+        capabilities=Capabilities(tool_choice=tool_choice),
+    )
+
+
+def _openai_provider(name: str) -> ProviderConfig:
+    return ProviderConfig(
+        name=name,
+        kind="openai_compat",
+        base_url="http://localhost:11434/v1",
+        model="qwen-coder",
+    )
+
+
+def _config(
+    providers: list[ProviderConfig],
+    chain: list[str],
+    *,
+    action: str = "off",
+) -> CodeRouterConfig:
+    return CodeRouterConfig(
+        allow_paid=False,
+        default_profile="default",
+        providers=providers,
+        profiles=[
+            FallbackChain(name="default", providers=chain, tool_choice_action=action)
+        ],
+    )
+
+
+def _engine(config: CodeRouterConfig, adapters: dict[str, BaseAdapter]) -> FallbackEngine:
+    engine = FallbackEngine.__new__(FallbackEngine)
+    engine.config = config
+    engine._adapters = adapters  # type: ignore[attr-defined]
+    return engine
+
+
+def _forced_request(mode: str = "tool", name: str = "get_weather") -> AnthropicRequest:
+    tc: dict = {"type": mode}
+    if mode == "tool":
+        tc["name"] = name
+    return AnthropicRequest.model_validate(
+        {
+            "model": "m",
+            "max_tokens": 64,
+            "system": "base system",
+            "messages": [{"role": "user", "content": "what's the weather?"}],
+            "tools": [{"name": name, "input_schema": {}}],
+            "tool_choice": tc,
+        }
+    )
+
+
+def _emulated_logs(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.msg == "tool-choice-emulated"]
+
+
+def _degraded_logs(
+    caplog: pytest.LogCaptureFixture, *, reason: str | None = None
+) -> list[logging.LogRecord]:
+    records = [r for r in caplog.records if r.msg == "capability-degraded"]
+    if reason is not None:
+        records = [r for r in records if getattr(r, "reason", None) == reason]
+    return records
+
+
+# ----------------------------------------------------------------------
+# emulate — non-streaming
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emulate_strips_tool_choice_and_injects_system(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    compat_cfg = _openai_provider("ollama")
+    config = _config([compat_cfg], chain=["ollama"], action="emulate")
+    compat = FakeOpenAIAdapter(compat_cfg, text="ok")
+    engine = _engine(config, {"ollama": compat})
+
+    original = _forced_request()
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        await engine.generate_anthropic(original)
+
+    # The openai_compat adapter records the ChatRequest it received; the
+    # translated system prompt must carry the injected directive and the
+    # request must not force a tool anymore. We assert via the translated
+    # ChatRequest messages (system role).
+    assert compat.generate_calls, "adapter was called"
+    chat_req = compat.generate_calls[0]
+    system_text = " ".join(
+        m.content or "" for m in chat_req.messages if m.role == "system"
+    )
+    assert 'the tool named "get_weather"' in system_text
+    # tool_choice forcing must not survive into the ChatRequest.
+    assert getattr(chat_req, "tool_choice", None) in (None, "auto", "none")
+
+    # Original request object is untouched (fallback to a capable provider
+    # later in the chain must still see the real tool_choice).
+    assert original.tool_choice == {"type": "tool", "name": "get_weather"}
+    assert original.system == "base system"
+
+    # Structured log fired with the tool name + mode.
+    logs = _emulated_logs(caplog)
+    assert len(logs) == 1
+    assert logs[0].tool_name == "get_weather"
+    assert logs[0].mode == "tool"
+    assert logs[0].provider == "ollama"
+
+
+@pytest.mark.asyncio
+async def test_warn_leaves_request_unchanged_logs_only(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    compat_cfg = _openai_provider("ollama")
+    config = _config([compat_cfg], chain=["ollama"], action="warn")
+    compat = FakeOpenAIAdapter(compat_cfg, text="ok")
+    engine = _engine(config, {"ollama": compat})
+
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        await engine.generate_anthropic(_forced_request())
+
+    # No emulation log; a capability-degraded/unsupported-backend log fires.
+    assert _emulated_logs(caplog) == []
+    degraded = _degraded_logs(caplog, reason="unsupported-backend")
+    assert len(degraded) == 1
+    assert degraded[0].dropped == ["tool_choice"]
+    assert degraded[0].provider == "ollama"
+
+    # The system prompt was NOT rewritten (no directive injected).
+    chat_req = compat.generate_calls[0]
+    system_text = " ".join(
+        m.content or "" for m in chat_req.messages if m.role == "system"
+    )
+    assert "Do not respond with plain text." not in system_text
+
+
+@pytest.mark.asyncio
+async def test_off_does_not_mutate_or_log(caplog: pytest.LogCaptureFixture) -> None:
+    compat_cfg = _openai_provider("ollama")
+    config = _config([compat_cfg], chain=["ollama"], action="off")
+    compat = FakeOpenAIAdapter(compat_cfg, text="ok")
+    engine = _engine(config, {"ollama": compat})
+
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        await engine.generate_anthropic(_forced_request())
+
+    assert _emulated_logs(caplog) == []
+    assert _degraded_logs(caplog, reason="unsupported-backend") == []
+
+
+@pytest.mark.asyncio
+async def test_supporting_provider_not_emulated(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An anthropic-kind provider honors tool_choice natively → even with
+    action=emulate the request is passed through untouched, no shim log."""
+    anth_cfg = _anthropic_provider("sonnet")
+    config = _config([anth_cfg], chain=["sonnet"], action="emulate")
+    anth = FakeAnthropicAdapter(anth_cfg, text="ok")
+    engine = _engine(config, {"sonnet": anth})
+
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        await engine.generate_anthropic(_forced_request())
+
+    assert _emulated_logs(caplog) == []
+    # Native adapter received the real, unmutated request.
+    assert anth.generate_calls
+    received = anth.generate_calls[0]
+    assert received.tool_choice == {"type": "tool", "name": "get_weather"}
+
+
+@pytest.mark.asyncio
+async def test_auto_tool_choice_not_emulated(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-forced ``tool_choice: auto`` request is never emulated even on
+    a non-supporting provider — only forcing modes matter."""
+    compat_cfg = _openai_provider("ollama")
+    config = _config([compat_cfg], chain=["ollama"], action="emulate")
+    compat = FakeOpenAIAdapter(compat_cfg, text="ok")
+    engine = _engine(config, {"ollama": compat})
+
+    req = AnthropicRequest.model_validate(
+        {
+            "model": "m",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": {"type": "auto"},
+        }
+    )
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        await engine.generate_anthropic(req)
+
+    assert _emulated_logs(caplog) == []
+
+
+# ----------------------------------------------------------------------
+# emulate — streaming
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_emulate_injects_system(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    compat_cfg = _openai_provider("ollama")
+    config = _config([compat_cfg], chain=["ollama"], action="emulate")
+    compat = FakeOpenAIAdapter(compat_cfg, text="streamed")
+    engine = _engine(config, {"ollama": compat})
+
+    original = _forced_request(mode="any")
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        events = [ev async for ev in engine.stream_anthropic(original)]
+
+    assert events
+    logs = _emulated_logs(caplog)
+    assert len(logs) == 1
+    assert logs[0].mode == "any"
+    # any-mode → tool_name is None.
+    assert logs[0].tool_name is None
+    # Original unchanged.
+    assert original.tool_choice == {"type": "any"}

--- a/tests/test_ingress_count_tokens.py
+++ b/tests/test_ingress_count_tokens.py
@@ -1,0 +1,150 @@
+"""Ingress tests for POST /v1/messages/count_tokens (S1 shim).
+
+Exercises the HTTP boundary of the local token-count endpoint: response
+shape (``{"input_tokens": N}``), the char/4 heuristic value (integrates
+with ``len(text) // 4``), tool JSON inclusion, and the loose validation
+(``model`` + non-empty ``messages`` required, ``max_tokens`` not needed).
+
+The endpoint is fully local — no engine round-trip — so we reuse the
+``_RecordingEngine`` scaffolding from tests/test_ingress_anthropic.py
+only to satisfy ``app.state.engine`` (the route never calls it).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from coderouter.config.schemas import CodeRouterConfig
+from coderouter.ingress.app import create_app
+from tests.test_ingress_anthropic import _RecordingEngine, two_profile_config  # noqa: F401
+
+
+@pytest.fixture
+def client(
+    two_profile_config: CodeRouterConfig, monkeypatch: pytest.MonkeyPatch  # noqa: F811
+) -> TestClient:
+    monkeypatch.setattr(
+        "coderouter.ingress.app.load_config",
+        lambda path=None: two_profile_config,
+    )
+    app = create_app()
+    app.state.engine = _RecordingEngine()
+    app.state.config = two_profile_config
+    return TestClient(app)
+
+
+def test_count_tokens_returns_input_tokens_schema(client: TestClient) -> None:
+    """200 with an ``{"input_tokens": int}`` body per the Anthropic spec."""
+    resp = client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "hello world"}],
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert list(body.keys()) == ["input_tokens"]
+    assert isinstance(body["input_tokens"], int)
+    assert body["input_tokens"] >= 0
+
+
+def test_count_tokens_heuristic_matches_char_over_4(client: TestClient) -> None:
+    """With no provider tokenizer declared, the count is len(text) // 4.
+
+    The two_profile_config providers declare no ``tokenizer_path``, so the
+    endpoint uses the char/4 heuristic. ``system`` + message text are
+    joined with a newline (see extract_text_from_anthropic_request).
+    """
+    system = "S" * 20
+    user = "U" * 40
+    # Joined text is system + "\n" + user → 20 + 1 + 40 = 61 chars → 15.
+    resp = client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "m",
+            "system": system,
+            "messages": [{"role": "user", "content": user}],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["input_tokens"] == (20 + 1 + 40) // 4
+
+
+def test_count_tokens_no_max_tokens_required(client: TestClient) -> None:
+    """count_tokens requests omit max_tokens — must not 4xx on its absence."""
+    resp = client.post(
+        "/v1/messages/count_tokens",
+        json={"model": "m", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 200
+
+
+def test_count_tokens_includes_tool_json_length(client: TestClient) -> None:
+    """Declared tools add their JSON length to the counted text, so the
+    same messages yield a strictly higher count when tools are present."""
+    base = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+    without = client.post("/v1/messages/count_tokens", json=base).json()["input_tokens"]
+    with_tools = client.post(
+        "/v1/messages/count_tokens",
+        json={
+            **base,
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "description": "Get the weather for a location",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ],
+        },
+    ).json()["input_tokens"]
+    assert with_tools > without
+
+
+def test_count_tokens_empty_messages_400(client: TestClient) -> None:
+    """An empty messages list is rejected with 400 (loose validation)."""
+    resp = client.post(
+        "/v1/messages/count_tokens",
+        json={"model": "m", "messages": []},
+    )
+    assert resp.status_code == 400
+
+
+def test_count_tokens_missing_messages_400(client: TestClient) -> None:
+    resp = client.post("/v1/messages/count_tokens", json={"model": "m"})
+    assert resp.status_code == 400
+
+
+def test_count_tokens_missing_model_400(client: TestClient) -> None:
+    resp = client.post(
+        "/v1/messages/count_tokens",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 400
+
+
+def test_count_tokens_block_list_content_counted(client: TestClient) -> None:
+    """Text blocks inside a list-form content are counted; non-text
+    (image) blocks contribute nothing — same rule as the char/4 estimator."""
+    text = "X" * 32
+    resp = client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "m",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": text},
+                        {
+                            "type": "image",
+                            "source": {"type": "url", "url": "https://x/y.png"},
+                        },
+                    ],
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["input_tokens"] == 32 // 4


### PR DESCRIPTION
…l_choice, cache_control)

Native Anthropic-compatible backends (Ollama v0.14+, LM Studio 0.4.1+, llama.cpp, vLLM) ship /v1/messages but lack count_tokens, tool_choice and prompt caching. CodeRouter now fills these gaps; all features are opt-in with 'off' defaults and zero new dependencies (Core 5 deps unchanged).

- S1: POST /v1/messages/count_tokens (was 404). Returns Anthropic-shape {"input_tokens": N}; accurate when provider tokenizer_path is set, char/4 heuristic otherwise. Structured log: count-tokens-served.
- S2: tool_choice capability gate (Capabilities.tool_choice + registry field + provider_supports_tool_choice, fallback kind==anthropic) and profile option tool_choice_action: off|warn|emulate. emulate rewrites forced tool_choice (any/tool) into a system-prompt instruction for non-supporting backends; original request stays intact for fallback to capable providers. New degraded reason: unsupported-backend.
- S3: cache_control_action: off|strip. strip removes cache_control markers before sending to non-supporting providers (log: cache-control-stripped). Deliberately no tokens-saved accounting.

Tests: 1438 passed, 1 skipped, 0 failed (baseline 1402 + 37 new, zero regressions). ruff clean. pyproject.toml unchanged.