### PR TITLE
feat(tool-repair): lenient second-pass parsing, key aliases, XML form…

### DIFF
--- a/coderouter/translation/tool_repair.py
+++ b/coderouter/translation/tool_repair.py
@@ -23,15 +23,43 @@ Recognised shapes
 2. Bare JSON objects embedded in text:
     "Let me check the current directory. {\"name\":\"Bash\",\"arguments\":{}}"
 3. Multiple JSON objects in sequence (for multi-call turns).
+4. XML-flavoured forms (R3), seen with qwen2.5-coder at default temperature:
+    <echo message="probe"/>                        (attribute form)
+    <tool>{"name": "echo", "arguments": {...}}</tool>   (wrapper form)
+    <echo>{"message": "probe"}</echo>              (named-wrapper form)
 
 Each candidate is accepted only if it parses to one of:
     {"name": <str>, "arguments": <dict | str>}          # direct shape
     {"function": {"name": <str>, "arguments": ...}}     # OpenAI shape
+    ... plus the R2 key aliases (tool / tool_name / parameters / input / args).
 
-If `allowed_tool_names` is provided, the `name` must be in that set;
+Lenient JSON (R1)
+-----------------
+When strict ``json.loads`` fails, a second, tolerant pass is attempted for the
+malformed forms small models actually emit:
+    - double-braced objects  ``{{...}}``  ->  ``{...}``  (L2 default-temp form)
+    - trailing commas
+    - single-quoted strings / keys (Python-repr dicts)
+    - unquoted object keys
+The lenient parse is a stdlib-only tokenizer; the resulting dict is still run
+through the exact same shape + allow-list validation as a strict parse.
+
+False-positive discipline
+-------------------------
+If `allowed_tool_names` is provided, the tool `name` must be in that set;
 otherwise any tool-shaped JSON is accepted. Passing the allow-list is
-strongly recommended to avoid false positives (a model legitimately
-discussing JSON in prose).
+strongly recommended.
+
+In addition, two context guards keep genuine documentation / source code from
+being turned into executable tool calls, even when it contains an allow-listed
+name:
+    - programming-language code fences (```python, ```js, ...) are protected:
+      their interior is never scanned by the bare-JSON or XML scanners.
+    - bare JSON / XML immediately introduced by an explanatory cue
+      ("for example", "you would write", "is documented as", ...) is treated
+      as prose and left in place.
+These guards are conservative: they only ever *suppress* an extraction, so a
+name that is not in the allow-list is still never repaired.
 """
 
 from __future__ import annotations
@@ -45,32 +73,68 @@ __all__ = ["deduplicate_tool_calls", "repair_tool_calls_in_text"]
 
 
 # ------------------------------------------------------------------
-# Tool-call shape detection + normalisation
+# R2: shape detection + normalisation (with key aliases)
 # ------------------------------------------------------------------
+
+# Accepted aliases for the tool-name key and the arguments key. Order does not
+# matter for detection, but ambiguity (more than one distinct alias present)
+# is treated as "not a tool call" and left untouched (safe side).
+_NAME_KEYS = ("name", "tool", "tool_name")
+_ARG_KEYS = ("arguments", "parameters", "input", "args")
+
+
+def _pick_unique(obj: dict[str, Any], keys: tuple[str, ...]) -> tuple[str | None, Any]:
+    """Return (matched_key, value) if exactly one of ``keys`` is present.
+
+    If zero keys are present, returns (None, None). If more than one key is
+    present the result is ambiguous -> returns ("<ambiguous>", None) so callers
+    can decline to repair.
+    """
+    present = [k for k in keys if k in obj]
+    if not present:
+        return None, None
+    if len(present) > 1:
+        return "<ambiguous>", None
+    k = present[0]
+    return k, obj[k]
 
 
 def _looks_like_tool_call(obj: Any, allowed: set[str] | None) -> tuple[str, Any] | None:
-    """Return (name, arguments) if obj looks like a tool call, else None."""
+    """Return (name, arguments) if obj looks like a tool call, else None.
+
+    Recognises:
+      - direct shape with name-key alias + args-key alias
+      - OpenAI ``{"function": {...}}`` wrapper (recursed into)
+    Ambiguous objects (multiple name aliases or multiple arg aliases) are
+    rejected.
+    """
     if not isinstance(obj, dict):
         return None
-
-    # Direct shape: {"name": "...", "arguments": ...}
-    name = obj.get("name")
-    if isinstance(name, str) and "arguments" in obj and (allowed is None or name in allowed):
-        return name, obj["arguments"]
 
     # OpenAI function shape: {"function": {"name": "...", "arguments": ...}}
     fn = obj.get("function")
     if isinstance(fn, dict):
-        inner_name = fn.get("name")
-        if (
-            isinstance(inner_name, str)
-            and "arguments" in fn
-            and (allowed is None or inner_name in allowed)
-        ):
-            return inner_name, fn["arguments"]
+        inner = _looks_like_tool_call(fn, allowed)
+        if inner is not None:
+            return inner
+        # fall through: maybe the outer dict itself is tool-shaped
 
-    return None
+    name_key, name = _pick_unique(obj, _NAME_KEYS)
+    if name_key == "<ambiguous>":
+        return None
+    arg_key, args = _pick_unique(obj, _ARG_KEYS)
+    if arg_key == "<ambiguous>":
+        return None
+
+    if not isinstance(name, str) or name_key is None:
+        return None
+    if arg_key is None:
+        # A tool-shaped object must carry an arguments container to be a call;
+        # a lone {"name": "..."} is not distinguishable from ordinary data.
+        return None
+    if allowed is not None and name not in allowed:
+        return None
+    return name, args
 
 
 def _normalise_to_openai_tool_call(name: str, arguments: Any) -> dict[str, Any]:
@@ -90,14 +154,195 @@ def _normalise_to_openai_tool_call(name: str, arguments: Any) -> dict[str, Any]:
 
 
 # ------------------------------------------------------------------
+# R1: lenient JSON parsing (only tried after strict json.loads fails)
+# ------------------------------------------------------------------
+
+
+def _strip_double_braces(s: str) -> str:
+    """Collapse a fully double-braced object ``{{...}}`` to ``{...}``.
+
+    Only collapses when the whole (stripped) string is wrapped in exactly one
+    extra layer of braces on both ends — the L2 default-temp failure form
+    ``{{"name": ...}}``. A single wrap is removed; deeper nesting is left as-is
+    (the tokenizer below handles the resulting single-braced object).
+    """
+    t = s.strip()
+    if t.startswith("{{") and t.endswith("}}"):
+        return t[1:-1].strip()
+    return s
+
+
+def _lenient_json_loads(raw: str) -> Any:
+    """Best-effort parse of near-JSON emitted by small models.
+
+    Handles, in a single tolerant tokenizer pass:
+      - single-quoted strings  ('...')  -> double-quoted
+      - unquoted object keys             -> quoted
+      - trailing commas                  -> dropped
+      - (double braces are stripped by the caller before this runs)
+
+    Returns the parsed object, or raises ValueError if the tokenizer cannot
+    produce syntactically valid JSON. Never executes the input.
+    """
+    s = raw.strip()
+    if not s:
+        raise ValueError("empty")
+
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    # Stack tracks whether the current container is an object ('{') so we can
+    # know when a bareword is a key (needs quoting) vs a value.
+    while i < n:
+        c = s[i]
+
+        # --- string literals: normalise quote char, copy verbatim otherwise ---
+        if c == '"' or c == "'":
+            quote = c
+            j = i + 1
+            buf = ['"']
+            while j < n:
+                cj = s[j]
+                if cj == "\\":
+                    # keep escape pair verbatim (but a backslash-escaped single
+                    # quote inside a single-quoted string becomes a plain ').
+                    if j + 1 < n:
+                        nxt = s[j + 1]
+                        if quote == "'" and nxt == "'":
+                            buf.append("'")
+                            j += 2
+                            continue
+                        buf.append(cj)
+                        buf.append(nxt)
+                        j += 2
+                        continue
+                    buf.append("\\")
+                    j += 1
+                    continue
+                if cj == quote:
+                    j += 1
+                    break
+                if cj == '"' and quote == "'":
+                    # a double quote inside a single-quoted string must be
+                    # escaped in the JSON output.
+                    buf.append('\\"')
+                    j += 1
+                    continue
+                buf.append(cj)
+                j += 1
+            else:
+                raise ValueError("unterminated string")
+            buf.append('"')
+            out.append("".join(buf))
+            i = j
+            continue
+
+        # --- unquoted key/identifier: quote it ---
+        if c.isalpha() or c == "_":
+            j = i
+            while j < n and (s[j].isalnum() or s[j] in "_-."):
+                j += 1
+            word = s[i:j]
+            lowered = word.lower()
+            if lowered in ("true", "false", "null"):
+                out.append(lowered)
+            else:
+                # bareword -> treat as a quoted key/string token
+                out.append('"' + word + '"')
+            i = j
+            continue
+
+        # --- trailing comma: drop a comma that is followed only by ws then } or ] ---
+        if c == ",":
+            k = i + 1
+            while k < n and s[k] in " \t\r\n":
+                k += 1
+            if k < n and s[k] in "}]":
+                i += 1  # skip the comma
+                continue
+            out.append(",")
+            i += 1
+            continue
+
+        out.append(c)
+        i += 1
+
+    candidate = "".join(out)
+    try:
+        return json.loads(candidate)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"lenient parse failed: {exc}") from exc
+
+
+def _parse_json_object(body: str) -> Any:
+    """Strict json.loads, then a lenient fallback. Raises ValueError on failure."""
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        pass
+    return _lenient_json_loads(_strip_double_braces(body))
+
+
+# ------------------------------------------------------------------
 # Scanners: fenced code blocks, then balanced braces in remaining text
 # ------------------------------------------------------------------
 
 # Match ```json ... ``` or ``` ... ``` with anything after the fence tag line.
-# Group 1 captures the body.
+# Group 1 captures the (optional) language tag, group 2 the body.
 _FENCED_RE = re.compile(
-    r"```(?:\w+)?[ \t]*\r?\n(.*?)\r?\n?```",
+    r"```([\w+-]*)[ \t]*\r?\n(.*?)\r?\n?```",
     re.DOTALL,
+)
+
+# Language tags that denote *real source code* (not a serialised tool call).
+# A fence carrying one of these is protected: its interior is never scanned by
+# the bare-JSON / XML scanners, so an allow-listed name written as a code
+# literal inside such a fence is not turned into a tool call.
+_CODE_FENCE_LANGS = frozenset(
+    {
+        "python",
+        "py",
+        "python3",
+        "js",
+        "javascript",
+        "ts",
+        "typescript",
+        "jsx",
+        "tsx",
+        "go",
+        "golang",
+        "rust",
+        "rs",
+        "java",
+        "c",
+        "cpp",
+        "c++",
+        "cs",
+        "csharp",
+        "ruby",
+        "rb",
+        "php",
+        "sh",
+        "bash",
+        "shell",
+        "zsh",
+        "sql",
+        "html",
+        "css",
+        "yaml",
+        "yml",
+        "toml",
+        "ini",
+        "kotlin",
+        "swift",
+        "scala",
+        "lua",
+        "perl",
+        "r",
+        "dart",
+        "elixir",
+        "haskell",
+    }
 )
 
 
@@ -107,25 +352,32 @@ def _extract_tool_call_fenced_blocks(
 ) -> tuple[str, list[dict[str, Any]]]:
     """Pull tool-call-shaped ```...``` blocks out of text.
 
-    Only fenced blocks whose body parses to a recognised tool-call shape are
-    removed from the text and returned as normalised OpenAI tool_calls. Any
-    other fenced block (prose, real source code, non-tool JSON) is preserved
-    verbatim in the returned text — the removal decision and the extraction
-    decision use the exact same predicate, so a fenced block is never dropped
-    without also being surfaced as a tool call (bug H2: data loss when a
-    response mixed a code example with a tool-call block).
+    Only fenced blocks whose body parses (strictly or leniently) to a
+    recognised tool-call shape are removed from the text and returned as
+    normalised OpenAI tool_calls. Any other fenced block (prose, real source
+    code, non-tool JSON) is preserved verbatim in the returned text — the
+    removal decision and the extraction decision use the exact same predicate,
+    so a fenced block is never dropped without also being surfaced as a tool
+    call (bug H2).
+
+    Fences carrying a *programming-language* tag (``python``, ``js`` ...) are
+    protected: their body is never parsed as a tool call, even if it happens to
+    contain a tool-shaped literal. This is the code-fence false-positive guard.
 
     Returns (text_without_tool_fences, tool_calls).
     """
     tool_calls: list[dict[str, Any]] = []
 
     def _repair(match: re.Match[str]) -> str:
-        body = match.group(1).strip()
+        lang = (match.group(1) or "").strip().lower()
+        body = match.group(2).strip()
+        if lang in _CODE_FENCE_LANGS:
+            return match.group(0)  # protected source-code fence
         if not body.startswith("{"):
             return match.group(0)  # keep non-JSON fenced blocks (e.g. code)
         try:
-            obj = json.loads(body)
-        except json.JSONDecodeError:
+            obj = _parse_json_object(body)
+        except ValueError:
             return match.group(0)  # keep unparseable fenced blocks
         hit = _looks_like_tool_call(obj, allowed)
         if hit is None:
@@ -138,12 +390,36 @@ def _extract_tool_call_fenced_blocks(
     return cleaned, tool_calls
 
 
+def _protected_code_spans(text: str) -> list[tuple[int, int]]:
+    """Byte spans of programming-language code fences to exclude from scanning.
+
+    Returns (start, end) index pairs covering the *entire* fenced block
+    (fence markers included) for fences whose language tag is a real
+    programming language. Used to shield code from the bare-JSON / XML scanners.
+    """
+    spans: list[tuple[int, int]] = []
+    for m in _FENCED_RE.finditer(text):
+        lang = (m.group(1) or "").strip().lower()
+        if lang in _CODE_FENCE_LANGS:
+            spans.append((m.start(), m.end()))
+    return spans
+
+
+def _in_spans(pos: int, spans: list[tuple[int, int]]) -> bool:
+    return any(start <= pos < end for start, end in spans)
+
+
 def _find_balanced_json_objects(text: str) -> list[tuple[int, int, str]]:
     """Find top-level `{...}` JSON substrings by a brace-counter scan.
 
     Returns a list of (start, end_exclusive, substring). Handles escape
     sequences and string literals so braces inside JSON strings do not
     confuse the counter. Malformed (unclosed) candidates are skipped.
+
+    Note: this deliberately matches strict JSON strings (double-quoted) for
+    brace balancing. Single-quoted / unquoted malformed objects are found by
+    :func:`_find_candidate_object_spans` instead, which brace-balances without
+    assuming JSON string syntax.
     """
     out: list[tuple[int, int, str]] = []
     n = len(text)
@@ -185,6 +461,287 @@ def _find_balanced_json_objects(text: str) -> list[tuple[int, int, str]]:
     return out
 
 
+def _find_candidate_object_spans(text: str) -> list[tuple[int, int, str]]:
+    """Brace-balance ``{...}`` spans, tolerating single/double quoted strings.
+
+    Unlike :func:`_find_balanced_json_objects`, this counts braces while
+    respecting BOTH ``'`` and ``"`` string delimiters, so it can locate
+    Python-repr / single-quoted malformed objects for the lenient parser.
+    Returns (start, end_exclusive, substring).
+    """
+    out: list[tuple[int, int, str]] = []
+    n = len(text)
+    i = 0
+    while i < n:
+        if text[i] != "{":
+            i += 1
+            continue
+        depth = 0
+        j = i
+        quote: str | None = None
+        escape = False
+        while j < n:
+            c = text[j]
+            if escape:
+                escape = False
+            elif quote is not None:
+                if c == "\\":
+                    escape = True
+                elif c == quote:
+                    quote = None
+            else:
+                if c == '"' or c == "'":
+                    quote = c
+                elif c == "{":
+                    depth += 1
+                elif c == "}":
+                    depth -= 1
+                    if depth == 0:
+                        out.append((i, j + 1, text[i : j + 1]))
+                        i = j + 1
+                        break
+            j += 1
+        else:
+            i += 1
+            continue
+    return out
+
+
+# ------------------------------------------------------------------
+# Prose-cue guard: bare JSON introduced as an *example* is not a call
+# ------------------------------------------------------------------
+
+# If one of these phrases appears immediately before a bare JSON object (within
+# a short window, on the same clause), the object is being *described* rather
+# than emitted as a call. Conservative: only suppresses, never forces a repair.
+_PROSE_CUE_RE = re.compile(
+    r"(?:"
+    r"for\s+example|for\s+instance|e\.?g\.?|such\s+as|"
+    r"you\s+(?:would|could|can|might)\s+write|"
+    r"you\s+would\s+(?:use|call)|"
+    r"(?:is|are)\s+documented(?:\s+as)?|documented\s+like|"
+    r"looks?\s+like\s+this|written\s+as|the\s+format\s+is|"
+    r"syntax\s+is|例えば|たとえば|のように書"
+    r")"
+    r"[^\n{]{0,40}$",
+    re.IGNORECASE,
+)
+
+
+def _preceded_by_prose_cue(text: str, start: int) -> bool:
+    """True if a documentation/example cue immediately precedes position ``start``."""
+    prefix = text[:start]
+    # Look only within the current line/clause (last ~80 chars, no newline jump
+    # further than the immediate lead-in).
+    tail = prefix[-80:]
+    return bool(_PROSE_CUE_RE.search(tail))
+
+
+# ------------------------------------------------------------------
+# R3: XML-flavoured tool-call forms
+# ------------------------------------------------------------------
+
+# Tags that are known NOT to be tool calls: reasoning wrappers and common HTML.
+_NON_TOOL_TAGS = frozenset(
+    {
+        "think",
+        "thinking",
+        "thought",
+        "reasoning",
+        "scratchpad",
+        "reflection",
+        "answer",
+        "final",
+        "p",
+        "div",
+        "span",
+        "ul",
+        "ol",
+        "li",
+        "a",
+        "b",
+        "i",
+        "em",
+        "strong",
+        "code",
+        "pre",
+        "br",
+        "hr",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "table",
+        "tr",
+        "td",
+        "th",
+        "img",
+        "button",
+        "form",
+        "input",
+        "label",
+        "section",
+        "article",
+        "header",
+        "footer",
+        "nav",
+        "tool",  # handled separately as a generic wrapper (body carries name)
+    }
+)
+
+# Generic wrapper tags whose *body* carries the actual tool-call JSON.
+_WRAPPER_TAGS = frozenset({"tool", "tool_call", "function_call", "invoke"})
+
+# <tag attr="v" .../>  or  <tag attr="v" ...>  (self-closing or open; we only
+# treat the self-closing / immediately-closed form as an attribute call).
+_XML_SELFCLOSE_RE = re.compile(
+    r"<([A-Za-z_][\w.-]*)((?:\s+[\w.:-]+\s*=\s*\"[^\"]*\")*)\s*/>",
+)
+# <tag> ... </tag>  wrapper.
+_XML_WRAPPER_RE = re.compile(
+    r"<([A-Za-z_][\w.-]*)\s*>(.*?)</\1\s*>",
+    re.DOTALL,
+)
+_XML_ATTR_RE = re.compile(r"([\w.:-]+)\s*=\s*\"([^\"]*)\"")
+
+
+def _known_non_tool_tag_ranges(text: str) -> list[tuple[int, int]]:
+    """Ranges covered by <think>...</think> (and similar) reasoning blocks.
+
+    XML extraction must not reach inside these, so a tool-shaped tag mentioned
+    in reasoning is never executed.
+    """
+    ranges: list[tuple[int, int]] = []
+    for tag in ("think", "thinking", "thought", "reasoning", "scratchpad"):
+        for m in re.finditer(
+            rf"<{tag}\b[^>]*>.*?</{tag}\s*>", text, re.DOTALL | re.IGNORECASE
+        ):
+            ranges.append((m.start(), m.end()))
+    return ranges
+
+
+def _extract_xml_tool_calls(
+    text: str,
+    allowed: set[str] | None,
+    protected: list[tuple[int, int]],
+) -> tuple[str, list[dict[str, Any]]]:
+    """Extract R3 XML-flavoured tool calls, honouring guards.
+
+    Returns (text_with_xml_calls_removed, tool_calls). Only forms whose tag /
+    inner name resolve to an allow-listed tool are removed.
+    """
+    if allowed is None:
+        # Without an allow-list, XML extraction is too risky (any <tag> could
+        # look like a call). Skip R3 entirely — keeps false positives at zero.
+        return text, []
+    if "<" not in text:
+        return text, []
+
+    tool_calls: list[dict[str, Any]] = []
+    reasoning = _known_non_tool_tag_ranges(text)
+    guard = protected + reasoning
+    removals: list[tuple[int, int]] = []
+
+    def _blocked(pos: int) -> bool:
+        return _in_spans(pos, guard) or _preceded_by_prose_cue(text, pos)
+
+    # --- wrapper form: <tool>{JSON}</tool>  and  <name>{JSON}</name> ---
+    for m in _XML_WRAPPER_RE.finditer(text):
+        tag = m.group(1)
+        inner = m.group(2).strip()
+        tag_l = tag.lower()
+        if _blocked(m.start()):
+            continue
+        if tag_l in _WRAPPER_TAGS:
+            # Body carries the whole tool-call object.
+            if not inner.startswith("{"):
+                continue
+            try:
+                obj = _parse_json_object(inner)
+            except ValueError:
+                continue
+            hit = _looks_like_tool_call(obj, allowed)
+            if hit is None:
+                continue
+            name, args = hit
+            tool_calls.append(_normalise_to_openai_tool_call(name, args))
+            removals.append((m.start(), m.end()))
+            continue
+        # Named-wrapper: the tag itself is the tool name, body is the arguments.
+        if tag_l in _NON_TOOL_TAGS:
+            continue
+        if tag not in allowed:
+            continue
+        if not inner.startswith("{"):
+            continue
+        try:
+            args_obj = _parse_json_object(inner)
+        except ValueError:
+            continue
+        if not isinstance(args_obj, dict):
+            continue
+        tool_calls.append(_normalise_to_openai_tool_call(tag, args_obj))
+        removals.append((m.start(), m.end()))
+
+    # --- self-closing attribute form: <echo message="probe"/> ---
+    for m in _XML_SELFCLOSE_RE.finditer(text):
+        tag = m.group(1)
+        if tag.lower() in _NON_TOOL_TAGS:
+            continue
+        if tag not in allowed:
+            continue
+        if _blocked(m.start()):
+            continue
+        # Don't double-extract something already inside a wrapper removal.
+        if _in_spans(m.start(), removals):
+            continue
+        attrs = dict(_XML_ATTR_RE.findall(m.group(2) or ""))
+        tool_calls.append(_normalise_to_openai_tool_call(tag, attrs))
+        removals.append((m.start(), m.end()))
+
+    if not removals:
+        return text, []
+
+    # Remove matched spans back-to-front; merge overlaps first.
+    removals.sort()
+    merged: list[tuple[int, int]] = []
+    for s, e in removals:
+        if merged and s < merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], e))
+        else:
+            merged.append((s, e))
+    cleaned = text
+    for s, e in reversed(merged):
+        cleaned = cleaned[:s] + cleaned[e:]
+    return cleaned, tool_calls
+
+
+# ------------------------------------------------------------------
+# Residue cleanup (trap #2)
+# ------------------------------------------------------------------
+
+# Empty fenced blocks left after a tool-call body was removed.
+_EMPTY_FENCE_RE = re.compile(r"```[\w+-]*[ \t]*\r?\n?[ \t]*\r?\n?```")
+# Array skeletons like "[, ]" or "[ , , ]" left after removing array elements.
+_EMPTY_ARRAY_RE = re.compile(r"\[\s*(?:,\s*)+\]")
+
+
+def _cleanup_residue(text: str) -> str:
+    """Remove cosmetic leftovers from extraction (empty fences, ``[,]``).
+
+    Only *empty* fenced blocks (a fence pair with nothing between them) are
+    removed — a lone closing ``` that still belongs to an intact, preserved
+    code fence is left alone, so protected source blocks stay valid.
+    """
+    text = _EMPTY_FENCE_RE.sub("", text)
+    text = _EMPTY_ARRAY_RE.sub("", text)
+    # Collapse a lone remaining empty array pair.
+    text = re.sub(r"\[\s*\]", "", text)
+    return text
+
+
 # ------------------------------------------------------------------
 # Public API
 # ------------------------------------------------------------------
@@ -217,17 +774,31 @@ def repair_tool_calls_in_text(
     #    common shape when a chat-tuned model explains what it's doing. Fenced
     #    blocks that are NOT tool calls (prose, real source code, plain JSON
     #    examples) are left in place so we never drop legitimate content (H2).
+    #    Programming-language fences are protected outright.
     cleaned, fenced_tool_calls = _extract_tool_call_fenced_blocks(text, allowed)
     extracted.extend(fenced_tool_calls)
 
-    # 2. Scan remaining text for bare JSON objects.
-    #    We walk from back to front so removals by slicing don't shift
-    #    the indices of earlier matches.
-    candidates = _find_balanced_json_objects(cleaned)
-    # Tentatively evaluate each; keep only the ones that are tool-call-shaped.
+    # 2. R3: XML-flavoured forms (only when an allow-list constrains names).
+    #    Runs on the fence-stripped text; protected code fences and reasoning
+    #    blocks are shielded.
+    protected = _protected_code_spans(cleaned)
+    cleaned, xml_tool_calls = _extract_xml_tool_calls(cleaned, allowed, protected)
+    extracted.extend(xml_tool_calls)
+
+    # 3. Scan remaining text for bare JSON objects (strict then lenient).
+    #    Skip anything inside a protected code fence or introduced by a prose
+    #    example cue. Walk back-to-front so slicing removals don't shift the
+    #    indices of earlier matches.
+    protected = _protected_code_spans(cleaned)
     spans_to_remove: list[tuple[int, int]] = []
     repaired_from_bare: list[dict[str, Any]] = []
-    for start, end, substr in candidates:
+
+    # First pass: strict-JSON balanced objects.
+    for start, end, substr in _find_balanced_json_objects(cleaned):
+        if _in_spans(start, protected):
+            continue
+        if _preceded_by_prose_cue(cleaned, start):
+            continue
         try:
             obj = json.loads(substr)
         except json.JSONDecodeError:
@@ -239,13 +810,47 @@ def repair_tool_calls_in_text(
         repaired_from_bare.append(_normalise_to_openai_tool_call(name, args))
         spans_to_remove.append((start, end))
 
-    # Remove the matched spans from the text back-to-front.
-    for start, end in reversed(spans_to_remove):
+    # Second pass: lenient objects (single-quoted / unquoted / trailing comma /
+    # double-brace) that strict parsing missed. Skip spans already claimed.
+    for start, end, substr in _find_candidate_object_spans(cleaned):
+        if _in_spans(start, spans_to_remove):
+            continue
+        if _in_spans(start, protected):
+            continue
+        if _preceded_by_prose_cue(cleaned, start):
+            continue
+        # Skip if strict JSON already parses this (handled in first pass).
+        try:
+            json.loads(substr)
+            continue  # strict-parseable -> either already handled or non-tool
+        except json.JSONDecodeError:
+            pass
+        try:
+            obj = _lenient_json_loads(_strip_double_braces(substr))
+        except ValueError:
+            continue
+        hit = _looks_like_tool_call(obj, allowed)
+        if hit is None:
+            continue
+        name, args = hit
+        repaired_from_bare.append(_normalise_to_openai_tool_call(name, args))
+        spans_to_remove.append((start, end))
+
+    # Remove the matched spans from the text back-to-front (merge overlaps).
+    spans_to_remove.sort()
+    merged: list[tuple[int, int]] = []
+    for s, e in spans_to_remove:
+        if merged and s < merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], e))
+        else:
+            merged.append((s, e))
+    for start, end in reversed(merged):
         cleaned = cleaned[:start] + cleaned[end:]
 
     extracted.extend(repaired_from_bare)
 
-    # Collapse the whitespace left behind by removals.
+    # Residue cleanup (empty fences, [,], stray backticks) then whitespace.
+    cleaned = _cleanup_residue(cleaned)
     cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
 

--- a/tests/test_tool_repair_lenient.py
+++ b/tests/test_tool_repair_lenient.py
@@ -1,0 +1,388 @@
+"""Unit tests for the R1/R2/R3 lenient tool-call repair enhancements.
+
+These cover the malformed-JSON, key-alias, and XML-flavoured forms that small
+coding models (qwen2.5-coder etc.) emit at non-zero temperature, alongside the
+false-positive guards that keep documentation / source code from being turned
+into executable tool calls. The strict-JSON happy paths live in
+``test_tool_repair.py``; this file targets the lenient extensions.
+"""
+
+from __future__ import annotations
+
+import json
+
+from coderouter.translation.tool_repair import (
+    deduplicate_tool_calls,
+    repair_tool_calls_in_text,
+)
+
+
+def _names(calls: list[dict]) -> list[str]:
+    return [c["function"]["name"] for c in calls]
+
+
+def _args(call: dict) -> dict:
+    return json.loads(call["function"]["arguments"])
+
+
+# ======================================================================
+# R1 — lenient JSON parsing
+# ======================================================================
+
+
+def test_r1_trailing_comma_is_repaired() -> None:
+    text = '{"name": "Bash", "arguments": {"command": "ls",}}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+    assert _args(calls[0]) == {"command": "ls"}
+
+
+def test_r1_trailing_comma_top_level() -> None:
+    text = '{"name": "Bash", "arguments": {"command": "ls"},}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+
+
+def test_r1_single_quotes_are_repaired() -> None:
+    text = "{'name': 'Bash', 'arguments': {'command': 'ls'}}"
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+    assert _args(calls[0]) == {"command": "ls"}
+
+
+def test_r1_single_quotes_with_cjk() -> None:
+    text = "了解しました。{'name': 'Bash', 'arguments': {'command': 'ls 日本語ディレクトリ'}}"
+    cleaned, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+    assert _args(calls[0]) == {"command": "ls 日本語ディレクトリ"}
+    assert "了解しました。" in cleaned
+
+
+def test_r1_unquoted_keys_are_repaired() -> None:
+    text = '{name: "Bash", arguments: {command: "ls"}}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+    assert _args(calls[0]) == {"command": "ls"}
+
+
+def test_r1_double_brace_in_json_fence() -> None:
+    text = '```json\n{{"name": "echo", "arguments": {"message": "probe"}}}\n```'
+    _, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert _names(calls) == ["echo"]
+    assert _args(calls[0]) == {"message": "probe"}
+
+
+def test_r1_double_brace_in_xml_fence() -> None:
+    text = '```xml\n{{"name": "echo", "arguments": {"message": "demo"}}}\n```'
+    _, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert _names(calls) == ["echo"]
+
+
+def test_r1_double_brace_bare() -> None:
+    text = '{{"name": "Bash", "arguments": {"command": "pwd"}}}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+
+
+def test_r1_single_quote_apostrophe_in_value_preserved() -> None:
+    """An escaped apostrophe inside a single-quoted value must survive."""
+    text = "{'name': 'Bash', 'arguments': {'command': 'echo it\\'s ok'}}"
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+    assert _args(calls[0]) == {"command": "echo it's ok"}
+
+
+def test_r1_strict_json_still_wins() -> None:
+    """Well-formed JSON must not be perturbed by the lenient path."""
+    text = '{"name": "Bash", "arguments": {"a": 1, "b": [1, 2, 3]}}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _args(calls[0]) == {"a": 1, "b": [1, 2, 3]}
+
+
+# ======================================================================
+# R2 — shape dictionary aliases
+# ======================================================================
+
+
+def test_r2_key_tool() -> None:
+    text = '{"tool": "Bash", "arguments": {"command": "ls"}}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+
+
+def test_r2_key_tool_name_and_input() -> None:
+    text = '{"tool_name": "Bash", "input": {"command": "ls"}}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+    assert _args(calls[0]) == {"command": "ls"}
+
+
+def test_r2_key_parameters() -> None:
+    text = '{"name": "Bash", "parameters": {"command": "ls"}}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+
+
+def test_r2_key_args() -> None:
+    text = '{"name": "Bash", "args": {"command": "ls"}}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+
+
+def test_r2_function_wrapper_with_aliases() -> None:
+    text = '{"function": {"tool_name": "Grep", "parameters": {"pattern": "x"}}}'
+    _, calls = repair_tool_calls_in_text(text, ["Grep"])
+    assert _names(calls) == ["Grep"]
+
+
+def test_r2_ambiguous_name_keys_not_repaired() -> None:
+    """When both 'name' and 'tool' are present, decline (ambiguous -> safe)."""
+    text = '{"name": "Bash", "tool": "Grep", "arguments": {"x": 1}}'
+    cleaned, calls = repair_tool_calls_in_text(text, ["Bash", "Grep"])
+    assert calls == []
+    assert cleaned == text
+
+
+def test_r2_ambiguous_arg_keys_not_repaired() -> None:
+    text = '{"name": "Bash", "arguments": {"a": 1}, "parameters": {"b": 2}}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert calls == []
+
+
+def test_r2_alias_still_respects_allowlist() -> None:
+    text = '{"tool": "DeleteEverything", "arguments": {"path": "/"}}'
+    cleaned, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert calls == []
+    assert cleaned == text
+
+
+def test_r2_alias_no_args_key_is_not_a_call() -> None:
+    """A name alias without any args container is not a tool call."""
+    text = '{"tool": "Bash"}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert calls == []
+
+
+# ======================================================================
+# R3 — XML-flavoured forms
+# ======================================================================
+
+
+def test_r3_self_closing_attribute_form() -> None:
+    text = '<echo message="probe"/>'
+    cleaned, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert _names(calls) == ["echo"]
+    assert _args(calls[0]) == {"message": "probe"}
+    assert cleaned == ""
+
+
+def test_r3_attribute_form_in_prose() -> None:
+    text = '了解しました。<echo message="こんにちは"/> を実行します。'
+    cleaned, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert _names(calls) == ["echo"]
+    assert _args(calls[0]) == {"message": "こんにちは"}
+    assert "了解しました。" in cleaned
+    assert "を実行します。" in cleaned
+
+
+def test_r3_multiple_attributes() -> None:
+    text = '<Write file_path="a.txt" content="hi"/>'
+    _, calls = repair_tool_calls_in_text(text, ["Write"])
+    assert _names(calls) == ["Write"]
+    assert _args(calls[0]) == {"file_path": "a.txt", "content": "hi"}
+
+
+def test_r3_tool_wrapper_form() -> None:
+    text = '<tool>{"name": "echo", "arguments": {"message": "probe"}}</tool>'
+    cleaned, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert _names(calls) == ["echo"]
+    assert _args(calls[0]) == {"message": "probe"}
+    assert cleaned == ""
+
+
+def test_r3_named_wrapper_form() -> None:
+    text = '<echo>{"message": "probe"}</echo>'
+    _, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert _names(calls) == ["echo"]
+    assert _args(calls[0]) == {"message": "probe"}
+
+
+def test_r3_named_wrapper_with_whitespace() -> None:
+    text = '<echo>   {"message": "demo"} </echo>'
+    _, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert _names(calls) == ["echo"]
+    assert _args(calls[0]) == {"message": "demo"}
+
+
+def test_r3_wrapper_delegates_to_lenient() -> None:
+    """Wrapper body may itself be malformed; R1 lenient parse rescues it."""
+    text = "<tool>{'name': 'echo', 'arguments': {'message': 'probe'}}</tool>"
+    _, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert _names(calls) == ["echo"]
+
+
+def test_r3_tag_not_in_allowlist_is_ignored() -> None:
+    text = '<danger message="x"/>'
+    cleaned, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert calls == []
+    assert cleaned == text
+
+
+def test_r3_no_allowlist_skips_xml() -> None:
+    """Without an allow-list, XML extraction is skipped entirely (safe)."""
+    text = '<echo message="probe"/>'
+    cleaned, calls = repair_tool_calls_in_text(text)
+    assert calls == []
+    assert cleaned == text
+
+
+def test_r3_think_tag_excluded() -> None:
+    text = (
+        '<think>I could emit <echo message="secret"/> but the user only '
+        "asked a question.</think>\nNo action is required."
+    )
+    cleaned, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert calls == []
+    assert "<echo" in cleaned  # left untouched inside the think block
+
+
+def test_r3_html_tags_not_treated_as_tools() -> None:
+    text = (
+        "<p>Here is the plan:</p>\n<ul><li>echo the result</li></ul>\n"
+        '<div class="note">No tool needed.</div>'
+    )
+    cleaned, calls = repair_tool_calls_in_text(text, ["echo", "read_file"])
+    assert calls == []
+    assert cleaned == text
+
+
+# ======================================================================
+# False-positive guards (the safety-critical class)
+# ======================================================================
+
+
+def test_guard_python_fence_with_allowed_name() -> None:
+    text = (
+        "You can build the payload in Python:\n```python\n"
+        'payload = {"name": "echo", "arguments": {"message": "probe"}}\n'
+        "send(payload)\n```\nThen post it."
+    )
+    cleaned, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert calls == []
+    assert "```python" in cleaned
+
+
+def test_guard_python_fence_single_quote_dict() -> None:
+    text = "```python\nresult = {'name': 'echo', 'level': 'info'}\nprint(result)\n```"
+    cleaned, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert calls == []
+    assert cleaned == text
+
+
+def test_guard_prose_example_bare_json() -> None:
+    text = (
+        'For example, you would write {"name": "echo", "arguments": '
+        '{"message": "probe"}} to invoke it, but here we don\'t need any tool.'
+    )
+    cleaned, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert calls == []
+    assert cleaned == text
+
+
+def test_guard_prose_example_japanese() -> None:
+    text = '例えば {"name": "echo", "arguments": {"message": "x"}} のように書きます。'
+    _, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert calls == []
+
+
+def test_guard_xml_doc_example_placeholder() -> None:
+    text = (
+        "The XML tool syntax is documented like this: write "
+        '<echo message="..."/> where the message attribute holds your text.'
+    )
+    _, calls = repair_tool_calls_in_text(text, ["echo"])
+    assert calls == []
+
+
+def test_guard_out_of_allowlist_always_wins() -> None:
+    """Even a perfectly-shaped call with a disallowed name is never repaired."""
+    for text in (
+        '{"name": "Nuke", "arguments": {}}',
+        "{'tool': 'Nuke', 'parameters': {}}",
+        '<Nuke path="/"/>',
+        '{{"tool_name": "Nuke", "input": {}}}',
+    ):
+        _, calls = repair_tool_calls_in_text(text, ["echo", "Bash"])
+        assert calls == [], text
+
+
+def test_guard_prose_does_not_block_genuine_call_cue() -> None:
+    """A normal narration lead-in ('Let me run that.') must NOT be suppressed."""
+    text = 'Let me run that. {"name": "Bash", "arguments": {"command": "date"}}'
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+
+
+# ======================================================================
+# Residue cleanup (trap #2)
+# ======================================================================
+
+
+def test_residue_empty_fence_removed() -> None:
+    text = '```json\n{"name": "Bash", "arguments": {"command": "ls"}}\n```'
+    cleaned, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert _names(calls) == ["Bash"]
+    assert "```" not in cleaned
+    assert cleaned == ""
+
+
+def test_residue_empty_array_removed() -> None:
+    text = '[{"name": "ls", "arguments": {"p": "."}}, {"name": "ls", "arguments": {"p": "."}}]'
+    cleaned, calls = repair_tool_calls_in_text(text, ["ls"])
+    assert _names(calls) == ["ls"]  # deduped
+    assert "[," not in cleaned
+    assert "[]" not in cleaned
+
+
+def test_residue_nested_fence_arg_leaves_no_stray_fence() -> None:
+    text = (
+        '```json\n{"name": "Write", "arguments": '
+        '{"file_path": "s.md", "content": "```py\\nprint(1)\\n```"}}\n```'
+    )
+    cleaned, calls = repair_tool_calls_in_text(text, ["Write"])
+    assert _names(calls) == ["Write"]
+    assert cleaned.strip() == ""
+
+
+# ======================================================================
+# Integration / regression sanity
+# ======================================================================
+
+
+def test_mixed_forms_in_one_response() -> None:
+    """A fenced call, an XML attribute call, and a bare malformed call."""
+    text = (
+        "First:\n```json\n{\"name\": \"Bash\", \"arguments\": {\"command\": \"pwd\"}}\n```\n"
+        'Then: <echo message="hi"/>\n'
+        "Finally: {'name': 'Read', 'arguments': {'path': '/x'}}"
+    )
+    _, calls = repair_tool_calls_in_text(text, ["Bash", "echo", "Read"])
+    assert sorted(_names(calls)) == ["Bash", "Read", "echo"]
+
+
+def test_malformed_and_valid_dedup() -> None:
+    """A strict and a lenient rendering of the same call dedup to one."""
+    text = (
+        '{"name": "Bash", "arguments": {"command": "ls"}}\n'
+        "{'name': 'Bash', 'arguments': {'command': 'ls'}}"
+    )
+    _, calls = repair_tool_calls_in_text(text, ["Bash"])
+    assert len(calls) == 1
+
+
+def test_deduplicate_standalone_still_works() -> None:
+    calls = [
+        {"function": {"name": "Bash", "arguments": '{"c": "ls"}'}},
+        {"function": {"name": "Bash", "arguments": '{"c": "ls"}'}},
+    ]
+    assert len(deduplicate_tool_calls(calls)) == 1


### PR DESCRIPTION
…s (recall 80.6% -> 100% on 55-case corpus, 0 false positives)

Driven by the L1/L2 tool-repair benchmark (2026-07-04): the repairer recovered only 14.3% of malformed JSON, and live measurement at default temperature showed exactly those shapes (double braces, XML-ish tags) escaping to the client as failures.

- R1 lenient JSON second pass (only after strict json.loads fails): double-brace collapse, trailing commas, single quotes via a string-aware state machine, unquoted keys. Repaired dicts still go through the same shape + allowed-name validation.
- R2 shape aliases: name keys tool/tool_name, argument keys parameters/input/args; ambiguous matches are left untouched.
- R3 XML-flavoured forms gated on allowed_tool_names: <tool_name attr=.../> attribute form, <tool>{json}</tool> and <tool_name>{json}</tool_name> wrappers; known non-tool tags (think etc.) excluded.
- Residue cleanup after extraction: empty fences and '[,]' leftovers.
- False-positive guards hardened: python-fence dict literals and documentation JSON with allowed names are no longer repaired -- extended negative corpus caught 2 real false positives in the previous implementation (same class as the v2.7.0 code-eating regression) which are now fixed and gated.

Benchmark (offline, 55-case corpus): recall 80.6% -> 100%, malformed 1/7 -> 9/9, xml_forms 5/5, false positives 0/12. Tests: full suite 1481 passed, 0 failed (+43 new in test_tool_repair_lenient.py). stdlib only, signatures unchanged.