### PR TITLE
feat(routing): per-request empty-response fallback (empty_response_ac…

### DIFF
--- a/coderouter/config/schemas.py
+++ b/coderouter/config/schemas.py
@@ -718,6 +718,57 @@ class FallbackChain(BaseModel):
         ),
     )
 
+    # --- ⑧ (empty-response): per-request empty-response fallback ------------
+    #
+    # Some local backends (observed: gemma4:26b on ``no_tool_temptation``
+    # prompts) return a 200 with a structurally-valid but *content-empty*
+    # Anthropic response — no tool_use and no non-whitespace text — for a
+    # fraction of requests. The drift guard's ``empty_response_rate`` is a
+    # windowed aggregate (default threshold 0.3, ``min_window_fill`` 6): it
+    # promotes/reloads a backend once the *rate* is bad, but cannot rescue a
+    # single blank turn in-flight. This knob adds a per-request in-flight
+    # fallback that re-dispatches the *same* request to the next provider in
+    # the chain the moment an empty response is detected.
+    #
+    # Design: "empty" is judged on *content*, not usage.output_tokens (which
+    # some backends report unreliably). A response is empty when its content
+    # list is empty, or every block is either a whitespace-only ``text`` block
+    # or a ``thinking`` block — i.e. nothing the client can act on. A single
+    # ``tool_use`` block or one non-whitespace ``text`` block makes it non-empty.
+    #
+    #   * ``off``      — no detection, no fallback, no log. Backward-compatible
+    #                    default (byte-for-byte identical to pre-⑧ behavior).
+    #   * ``warn``     — detect + emit an ``empty-response-detected`` log line
+    #                    only; the empty response is returned unchanged.
+    #   * ``fallback`` — on an empty response, log ``empty-response-detected``
+    #                    and continue to the next provider (the empty response
+    #                    is *not* recorded as an error). If every provider in
+    #                    the chain returns empty, the last empty response is
+    #                    returned as-is (a 200 blank is a legitimate answer)
+    #                    with ``chain_exhausted=True`` on the log line. On the
+    #                    streaming path, ``fallback`` buffers events until real
+    #                    content is observed, so an empty stream can be swapped
+    #                    to the next provider without the client seeing bytes.
+    #
+    # Default ``off`` preserves complete backward compatibility; the original
+    # request object is never mutated, so a later provider always receives the
+    # untouched request.
+    empty_response_action: Literal["off", "warn", "fallback"] = Field(
+        default="off",
+        description=(
+            "⑧ (empty-response): action when a provider returns a 200 with "
+            "empty content (no tool_use and no non-whitespace text; a "
+            "thinking-only response counts as empty). ``off`` (default) does "
+            "nothing. ``warn`` emits an ``empty-response-detected`` log only "
+            "and returns the empty response. ``fallback`` re-dispatches the "
+            "same request to the next provider (empty is not counted as an "
+            "error); if the whole chain returns empty, the last empty response "
+            "is returned unchanged. Streaming buffers events until real "
+            "content appears so empty streams can be swapped provider-side "
+            "without the client seeing any bytes."
+        ),
+    )
+
     # --- S2 (shim): tool_choice capability gate + emulation -----------------
     #
     # Anthropic clients (Claude Code, SDKs) can pin the model to a specific

--- a/coderouter/logging.py
+++ b/coderouter/logging.py
@@ -1373,6 +1373,46 @@ def log_partial_stitch_surfaced(
 
 
 # ---------------------------------------------------------------------------
+# ⑧ (empty-response): per-request empty-response fallback log shape
+#
+# Fired when a provider returns a 200 with content-empty output (no
+# tool_use and no non-whitespace text). The single event lane carries the
+# ``action`` (warn|fallback) that triggered it, whether the empty response
+# came from the streaming or non-streaming path, and ``chain_exhausted``
+# — True only when every provider in the chain returned empty and the last
+# empty response is being returned to the client as-is.
+# ---------------------------------------------------------------------------
+
+
+def log_empty_response_detected(
+    logger: logging.Logger,
+    provider: str,
+    *,
+    action: str,
+    stream: bool,
+    chain_exhausted: bool = False,
+) -> None:
+    """Emit an ``empty-response-detected`` warn line.
+
+    Fired when ``empty_response_action`` is ``warn`` or ``fallback`` and a
+    provider returns a structurally-valid but content-empty response. The
+    ``action`` field records which knob value produced the line; ``stream``
+    distinguishes the SSE path from the non-streaming path; ``chain_exhausted``
+    is True only when the whole chain returned empty and the last empty
+    response is being returned unchanged.
+    """
+    logger.warning(
+        "empty-response-detected",
+        extra={
+            "provider": provider,
+            "action": action,
+            "stream": stream,
+            "chain_exhausted": chain_exhausted,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
 # v2.0-I: Continuous probe log shapes
 #
 # Two event lanes mirror the backend-health triplet:

--- a/coderouter/metrics/collector.py
+++ b/coderouter/metrics/collector.py
@@ -52,6 +52,7 @@ Event inventory (dispatch table in :meth:`MetricsCollector._dispatch`)
     ``drift-promoted`` (v2.0-G)  → ``drift_promoted_total``
     ``drift-reload-attempted``   → ``drift_reload_total`` / success
     ``partial-stitch-surfaced``  → ``partial_stitch_surfaced_total`` (v2.0-H)
+    ``empty-response-detected``  → ``empty_responses_total`` + per-provider (⑧)
     ``probe-completed`` (v2.0-I) → ``probe_total`` / ``probe_success`` / ``probe_failure``
                                    + per-provider latency gauge
     ``probe-round-completed``    → ``probe_rounds_total`` (v2.0-I)
@@ -109,6 +110,7 @@ _KNOWN_EVENTS: Final[frozenset[str]] = frozenset(
         "drift-promoted",
         "drift-reload-attempted",
         "partial-stitch-surfaced",
+        "empty-response-detected",
         "probe-completed",
         "probe-round-completed",
         "probe-capabilities-drift",
@@ -272,6 +274,13 @@ class MetricsCollector(logging.Handler):
         # client instead of a generic error event.
         self._partial_stitch_surfaced_total: int = 0
 
+        # ⑧ (empty-response): count of per-request empty-response detections
+        # (both ``warn`` and ``fallback`` actions). Aggregate + per-provider
+        # so a dashboard can spot which backend blanks out. Counts every
+        # detection event, including the terminal chain-exhausted one.
+        self._empty_responses_total: int = 0
+        self._empty_responses_by_provider: Counter[str] = Counter()
+
         # v2.0-I: continuous probe counters. Per-provider probe attempts
         # and outcomes, plus a round counter for the dashboard's
         # "probes/min" panel.
@@ -329,6 +338,7 @@ class MetricsCollector(logging.Handler):
             "drift-promoted": self._on_drift_promoted,
             "drift-reload-attempted": self._on_drift_reload_attempted,
             "partial-stitch-surfaced": self._on_partial_stitch_surfaced,
+            "empty-response-detected": self._on_empty_response_detected,
             "probe-completed": self._on_probe_completed,
             "probe-round-completed": self._on_probe_round_completed,
             "probe-capabilities-drift": self._on_probe_capabilities_drift,
@@ -670,6 +680,17 @@ class MetricsCollector(logging.Handler):
         self._partial_stitch_surfaced_total += 1
         self._push_recent("partial-stitch-surfaced", extras, record)
 
+    def _on_empty_response_detected(
+        self, extras: dict[str, Any], record: logging.LogRecord
+    ) -> None:
+        # ⑧ (empty-response): a content-empty 200 was detected under a
+        # ``warn`` / ``fallback`` action.
+        self._empty_responses_total += 1
+        provider = _str(extras.get("provider"))
+        if provider:
+            self._empty_responses_by_provider[provider] += 1
+        self._push_recent("empty-response-detected", extras, record)
+
     def _on_probe_completed(
         self, extras: dict[str, Any], record: logging.LogRecord
     ) -> None:
@@ -888,6 +909,11 @@ class MetricsCollector(logging.Handler):
                     "drift_reload_success_total": self._drift_reload_success_total,
                     # v2.0-H (L6): partial stitch surfaced.
                     "partial_stitch_surfaced_total": self._partial_stitch_surfaced_total,
+                    # ⑧ (empty-response): per-request empty-response fallback.
+                    "empty_responses_total": self._empty_responses_total,
+                    "empty_responses_by_provider": dict(
+                        self._empty_responses_by_provider
+                    ),
                     # v2.0-I: continuous probe counters.
                     "probe_total": dict(self._probe_total),
                     "probe_success": dict(self._probe_success),
@@ -1042,6 +1068,9 @@ class MetricsCollector(logging.Handler):
             self._tokens_saved_by_mechanism.clear()
             # v2.0-H (L6)
             self._partial_stitch_surfaced_total = 0
+            # ⑧ (empty-response)
+            self._empty_responses_total = 0
+            self._empty_responses_by_provider.clear()
             # v2.0-I
             self._probe_total.clear()
             self._probe_success.clear()

--- a/coderouter/routing/fallback.py
+++ b/coderouter/routing/fallback.py
@@ -76,6 +76,7 @@ from coderouter.logging import (
     log_chain_memory_pressure_blocked,
     log_chain_paid_gate_blocked,
     log_demote_unhealthy_provider,
+    log_empty_response_detected,
     log_memory_pressure_detected,
     log_skip_budget_exceeded,
     log_skip_memory_pressure,
@@ -973,6 +974,82 @@ def _warn_if_uniform_auth_failure(errors: list[AdapterError], *, profile: str) -
     )
 
 
+# ---------------------------------------------------------------------------
+# ⑧ (empty-response): content-based emptiness judgement + stream buffering
+# ---------------------------------------------------------------------------
+
+
+def _block_field(block: Any, key: str) -> Any:
+    """Read ``key`` from a content block whether it is a dict or a model.
+
+    Anthropic content blocks reach the engine as plain dicts (openai_compat
+    translation, most test fakes) or as pydantic-ish objects (native
+    passthrough). This mirrors the accessor pattern already used by the
+    drift fingerprint at the success-path tail.
+    """
+    if isinstance(block, dict):
+        return block.get(key)
+    return getattr(block, key, None)
+
+
+def _anthropic_response_is_empty(resp: AnthropicResponse) -> bool:
+    """Return True when ``resp`` carries no client-actionable content.
+
+    "Empty" is judged on content, never on ``usage.output_tokens`` (some
+    backends report that unreliably). A response is empty when:
+        - its ``content`` list is empty / falsy, or
+        - every block is either a whitespace-only ``text`` block or a
+          ``thinking`` block.
+
+    A single ``tool_use`` block, or one ``text`` block with any
+    non-whitespace character, makes the response non-empty. Unknown block
+    types are treated conservatively as *content* (non-empty) so a novel
+    actionable block is never silently swallowed.
+    """
+    content = getattr(resp, "content", None)
+    if not content:
+        return True
+    for block in content:
+        btype = _block_field(block, "type")
+        if btype == "text":
+            text = _block_field(block, "text") or ""
+            if text.strip():
+                return False
+            # whitespace-only text → keep scanning
+            continue
+        if btype == "thinking":
+            # thinking-only carries nothing the client can act on
+            continue
+        # tool_use or any other (unknown → conservatively non-empty) block
+        return False
+    return True
+
+
+def _stream_event_is_real_content(event: AnthropicStreamEvent) -> bool:
+    """Return True when ``event`` is the first byte of actionable content.
+
+    Real content is either a ``content_block_start`` opening a ``tool_use``
+    block, or a ``content_block_delta`` carrying a non-whitespace text
+    delta. ``message_start`` / ``ping`` / empty-text openers do not count —
+    they are the buffered preamble that an empty stream also emits.
+    """
+    data = getattr(event, "data", None) or {}
+    etype = data.get("type") if isinstance(data, dict) else None
+    if etype == "content_block_start":
+        block = data.get("content_block") or {}
+        return isinstance(block, dict) and block.get("type") == "tool_use"
+    if etype == "content_block_delta":
+        delta = data.get("delta") or {}
+        if isinstance(delta, dict):
+            # text_delta with non-whitespace text is real content;
+            # input_json_delta (tool args) is real content too.
+            if delta.get("type") == "text_delta":
+                return bool((delta.get("text") or "").strip())
+            if delta.get("type") == "input_json_delta":
+                return True
+    return False
+
+
 class FallbackEngine:
     """Sequential fallback router — the core of CodeRouter.
 
@@ -1717,6 +1794,20 @@ class FallbackEngine:
             getattr(profile, "cache_control_action", "off"),
         )
 
+    def _resolve_empty_response_action(self, profile_name: str | None) -> str:
+        """⑧ (empty-response): resolve ``empty_response_action`` for a profile.
+
+        Defaults to ``off`` so a missing / stub profile (e.g. a
+        ``__new__``-constructed test engine) yields the backward-compatible
+        no-op. Resolved once at the top of each Anthropic entry point.
+        """
+        chosen = profile_name or self.config.default_profile
+        try:
+            profile = self.config.profile_by_name(chosen)
+        except (KeyError, ValueError):
+            return "off"
+        return getattr(profile, "empty_response_action", "off")
+
     def _resolve_chain(self, profile_name: str | None) -> list[BaseAdapter]:
         """Return the list of adapters to try, in order, for this profile.
 
@@ -2431,6 +2522,11 @@ class FallbackEngine:
         tool_choice_action, cache_control_action = self._resolve_shim_actions(
             request.profile
         )
+        # ⑧ (empty-response): resolve the per-request empty-response action
+        # once. ``last_empty_resp`` holds the most recent content-empty 200
+        # under ``fallback`` so a fully-empty chain returns it verbatim.
+        empty_response_action = self._resolve_empty_response_action(request.profile)
+        last_empty_resp: AnthropicResponse | None = None
 
         for adapter, will_degrade in chain:
             is_native = isinstance(adapter, AnthropicAdapter)
@@ -2585,6 +2681,26 @@ class FallbackEngine:
                 stream=False,
                 response_fingerprint=_fp(_fp_text) if _fp_text else None,
             )
+            # ⑧ (empty-response): per-request empty-response handling. Runs
+            # after the drift observation above (which still gets the real
+            # output_tokens=0 signal for the windowed empty_response_rate)
+            # but before the cache-observed / observer fanout, so a
+            # ``fallback`` swap does not emit a "completed" line for a
+            # response the client never sees.
+            if empty_response_action != "off" and _anthropic_response_is_empty(resp):
+                if empty_response_action == "fallback":
+                    # Remember this empty response so a fully-empty chain can
+                    # return it verbatim, then try the next provider. Not
+                    # recorded in ``errors`` — a 200 blank is not a failure.
+                    last_empty_resp = resp
+                    log_empty_response_detected(
+                        logger, adapter.name, action="fallback", stream=False
+                    )
+                    continue
+                # ``warn``: log only; fall through and return the empty resp.
+                log_empty_response_detected(
+                    logger, adapter.name, action="warn", stream=False
+                )
             # v1.9-A: pair every successful Anthropic response with a
             # cache-observed log line. Native Anthropic / LM Studio
             # /v1/messages report cache_read_input_tokens /
@@ -2624,6 +2740,20 @@ class FallbackEngine:
                 stream=False,
             )
             return resp
+
+        # ⑧ (empty-response): the chain is exhausted. Under ``fallback``,
+        # if every provider that answered returned an empty 200, return the
+        # last empty response verbatim (a 200 blank is a legitimate answer)
+        # rather than raising — errors is empty in that case anyway.
+        if last_empty_resp is not None:
+            log_empty_response_detected(
+                logger,
+                last_empty_resp.coderouter_provider or "unknown",
+                action="fallback",
+                stream=False,
+                chain_exhausted=True,
+            )
+            return last_empty_resp
 
         profile = request.profile or self.config.default_profile
         _warn_if_uniform_auth_failure(errors, profile=profile)
@@ -2676,6 +2806,15 @@ class FallbackEngine:
         tool_choice_action, cache_control_action = self._resolve_shim_actions(
             request.profile
         )
+        # ⑧ (empty-response): resolve the per-request empty-response action.
+        # Only ``fallback`` changes the streaming path (it buffers events
+        # until real content appears); ``off`` / ``warn`` stream unchanged.
+        # ``last_empty_stream_buffer`` holds the buffered preamble of the
+        # most recent empty stream so a fully-empty chain can flush it and
+        # terminate normally rather than raising.
+        empty_response_action = self._resolve_empty_response_action(request.profile)
+        empty_fallback = empty_response_action == "fallback"
+        last_empty_stream_buffer: list[AnthropicStreamEvent] | None = None
 
         for adapter, will_degrade in chain:
             is_native = isinstance(adapter, AnthropicAdapter)
@@ -2828,15 +2967,59 @@ class FallbackEngine:
             self._observe_provider_success(
                 adapter.name, profile=request.profile
             )
-            acc.observe(first)
-            yield first
+            # ⑧ (empty-response): under ``fallback`` we withhold the opening
+            # events (message_start / empty content_block_start / ping) from
+            # the client until the *first real content* event is observed.
+            # Because no bytes have reached the client, an empty stream can
+            # still be swapped for the next provider. ``off`` / ``warn`` keep
+            # the legacy immediate-yield behavior (byte-for-byte unchanged).
+            #
+            # ``content_started`` flips True the moment real content is seen
+            # (or immediately, when the action is not ``fallback``); from
+            # then on events pass straight through and the mid-stream guard
+            # is live exactly as before.
+            content_started = not empty_fallback
+            buffer: list[AnthropicStreamEvent] = []
             # Mid-stream guard identical to stream() — any error after the
-            # first event is terminal.
+            # first *forwarded* event is terminal.
             try:
-                async for ev in event_iter:
+                # Seed the loop with the already-fetched ``first`` event,
+                # then drain the rest of the iterator.
+                pending = first
+                iterator = event_iter.__aiter__()
+                while True:
+                    ev = pending
                     acc.observe(ev)
-                    yield ev
+                    if content_started:
+                        yield ev
+                    else:
+                        buffer.append(ev)
+                        if _stream_event_is_real_content(ev):
+                            # Real content arrived — flush the withheld
+                            # preamble in order, then switch to passthrough.
+                            content_started = True
+                            for buffered_ev in buffer:
+                                yield buffered_ev
+                            buffer = []
+                    try:
+                        pending = await iterator.__anext__()
+                    except StopAsyncIteration:
+                        break
             except AdapterError as exc:
+                if not content_started:
+                    # Empty-stream failure before any real content under
+                    # ``fallback``: nothing reached the client, so treat it
+                    # like an empty response and try the next provider. Do
+                    # NOT raise MidStreamError (that would surface to the
+                    # client). Record the error-only observation for adaptive.
+                    self._adaptive.record_attempt(
+                        adapter.name, latency_ms=None, success=False
+                    )
+                    log_empty_response_detected(
+                        logger, adapter.name, action="fallback", stream=True
+                    )
+                    last_empty_stream_buffer = buffer
+                    continue
                 # M2: mid-stream failure — record an error-only
                 # observation (no latency; first-event success already
                 # recorded) so adaptive error rate reflects the breakage.
@@ -2868,6 +3051,17 @@ class FallbackEngine:
                 raise MidStreamError(
                     adapter.name, exc, partial_content=acc.partial_content
                 ) from exc
+            # ⑧ (empty-response): the stream ended cleanly but no real
+            # content was ever observed under ``fallback`` — the preamble is
+            # still buffered (never sent). Treat as an empty response: keep
+            # the buffer for a possible chain-exhausted flush and try the
+            # next provider.
+            if empty_fallback and not content_started:
+                log_empty_response_detected(
+                    logger, adapter.name, action="fallback", stream=True
+                )
+                last_empty_stream_buffer = buffer
+                continue
             # v2.0-G (L4): drift detection observation (stream success).
             # P1-4: compute response fingerprint for goal_progress_stall.
             _stream_fp_text = " ".join(
@@ -2921,6 +3115,23 @@ class FallbackEngine:
                 latency_ms=None,  # streaming latency is end-of-stream-relative; left to plugin
                 stream=True,
             )
+            return
+
+        # ⑧ (empty-response): the chain is exhausted under ``fallback`` and
+        # every provider produced an empty stream. Flush the last buffered
+        # (empty) preamble so the client gets a well-formed, terminating SSE
+        # sequence (message_start … message_stop) instead of an error — a
+        # 200 blank is a legitimate answer. errors is empty in that case.
+        if last_empty_stream_buffer is not None:
+            log_empty_response_detected(
+                logger,
+                "unknown",
+                action="fallback",
+                stream=True,
+                chain_exhausted=True,
+            )
+            for buffered_ev in last_empty_stream_buffer:
+                yield buffered_ev
             return
 
         profile = request.profile or self.config.default_profile

--- a/tests/test_fallback_empty_response.py
+++ b/tests/test_fallback_empty_response.py
@@ -1,0 +1,561 @@
+"""Engine-level tests for ⑧ the per-request empty-response fallback.
+
+These exercise ``FallbackChain.empty_response_action`` on the Anthropic
+non-streaming (``generate_anthropic``) and streaming (``stream_anthropic``)
+paths:
+
+    - the ``_anthropic_response_is_empty`` content judgement
+      (whitespace-only text = empty, thinking-only = empty, tool_use =
+      non-empty, non-whitespace text = non-empty);
+    - non-streaming ``fallback``: an empty 200 is swapped to the next
+      provider; a fully-empty chain returns the last empty response verbatim;
+    - non-streaming ``warn``: the empty response is logged but returned;
+    - non-streaming ``off``: byte-for-byte legacy behavior (no detection);
+    - streaming ``fallback``: an empty stream is withheld from the client
+      and swapped provider-side; a stream with real content is delivered in
+      full, in order; a fully-empty chain flushes the last buffered preamble
+      and terminates normally;
+    - the ``empty-response-detected`` log line + the metrics counter fire.
+
+The engine fakes and helpers are reused from ``test_fallback_anthropic``;
+this module only adds an empty-response config helper and empty-content
+adapters.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+
+import pytest
+
+from coderouter.adapters.base import (
+    AdapterError,
+    ProviderCallOverrides,
+)
+from coderouter.config.schemas import (
+    CodeRouterConfig,
+    FallbackChain,
+    ProviderConfig,
+)
+from coderouter.metrics.collector import MetricsCollector
+from coderouter.routing import FallbackEngine, NoProvidersAvailableError
+from coderouter.routing.fallback import (
+    _anthropic_response_is_empty,
+    _stream_event_is_real_content,
+)
+from coderouter.translation import (
+    AnthropicMessage,
+    AnthropicRequest,
+    AnthropicResponse,
+    AnthropicStreamEvent,
+    AnthropicUsage,
+)
+from tests.test_fallback_anthropic import (
+    FakeAnthropicAdapter,
+    _default_native_events,
+    _engine_with_adapters,
+)
+
+# ----------------------------------------------------------------------
+# Empty-content fakes
+# ----------------------------------------------------------------------
+
+
+class EmptyAnthropicAdapter(FakeAnthropicAdapter):
+    """Native fake that returns a *content-empty* response / stream.
+
+    ``content`` is fully configurable so a single fake can model an empty
+    list, whitespace-only text, thinking-only, etc. ``empty_stream_events``
+    supplies a stream that never emits real content (preamble + terminator).
+    """
+
+    def __init__(
+        self,
+        config: ProviderConfig,
+        *,
+        content: list[dict] | None = None,
+        empty_stream_events: list[AnthropicStreamEvent] | None = None,
+    ) -> None:
+        super().__init__(config)
+        # default: an empty content list
+        self._empty_content = content if content is not None else []
+        self._empty_stream_events = empty_stream_events
+
+    async def generate_anthropic(
+        self,
+        request: AnthropicRequest,
+        *,
+        overrides: ProviderCallOverrides | None = None,
+    ) -> AnthropicResponse:
+        self.generate_calls.append(request)
+        self.last_overrides = overrides
+        return AnthropicResponse(
+            id="msg_empty",
+            model=self.config.model,
+            content=list(self._empty_content),
+            stop_reason="end_turn",
+            usage=AnthropicUsage(input_tokens=1, output_tokens=0),
+            coderouter_provider=self.name,
+        )
+
+    async def stream_anthropic(
+        self,
+        request: AnthropicRequest,
+        *,
+        overrides: ProviderCallOverrides | None = None,
+    ) -> AsyncIterator[AnthropicStreamEvent]:
+        self.stream_calls.append(request)
+        self.last_overrides = overrides
+        events = self._empty_stream_events or _empty_native_events(self.config.model)
+        for ev in events:
+            yield ev
+
+
+def _empty_native_events(model: str) -> list[AnthropicStreamEvent]:
+    """A compliant Anthropic stream that carries *no* real content.
+
+    message_start → empty-text content_block_start → content_block_stop →
+    message_delta → message_stop. No content_block_delta with text, so
+    ``_stream_event_is_real_content`` is False for every event.
+    """
+    return [
+        AnthropicStreamEvent(
+            type="message_start",
+            data={
+                "type": "message_start",
+                "message": {
+                    "id": "msg_empty",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": model,
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 0, "output_tokens": 0},
+                },
+            },
+        ),
+        AnthropicStreamEvent(
+            type="content_block_start",
+            data={
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+        ),
+        AnthropicStreamEvent(
+            type="content_block_stop",
+            data={"type": "content_block_stop", "index": 0},
+        ),
+        AnthropicStreamEvent(
+            type="message_delta",
+            data={
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "usage": {"output_tokens": 0},
+            },
+        ),
+        AnthropicStreamEvent(
+            type="message_stop",
+            data={"type": "message_stop"},
+        ),
+    ]
+
+
+# ----------------------------------------------------------------------
+# Config helper
+# ----------------------------------------------------------------------
+
+
+def _empty_config(action: str) -> CodeRouterConfig:
+    """Two native providers with the given ``empty_response_action``."""
+    return CodeRouterConfig(
+        allow_paid=False,
+        default_profile="default",
+        providers=[
+            ProviderConfig(
+                name="first",
+                kind="anthropic",
+                base_url="https://api.anthropic.com",
+                model="first-model",
+                api_key_env="ANTHROPIC_API_KEY",
+            ),
+            ProviderConfig(
+                name="second",
+                kind="anthropic",
+                base_url="https://api.anthropic.com",
+                model="second-model",
+                api_key_env="ANTHROPIC_API_KEY",
+            ),
+        ],
+        profiles=[
+            FallbackChain(
+                name="default",
+                providers=["first", "second"],
+                empty_response_action=action,  # type: ignore[arg-type]
+            )
+        ],
+    )
+
+
+def _req(stream: bool = False) -> AnthropicRequest:
+    return AnthropicRequest(
+        max_tokens=64,
+        messages=[AnthropicMessage(role="user", content="hi")],
+        stream=stream,
+    )
+
+
+# ----------------------------------------------------------------------
+# _anthropic_response_is_empty unit tests
+# ----------------------------------------------------------------------
+
+
+def _resp(content: list[dict]) -> AnthropicResponse:
+    return AnthropicResponse(
+        id="m",
+        model="x",
+        content=content,
+        stop_reason="end_turn",
+        usage=AnthropicUsage(input_tokens=1, output_tokens=0),
+        coderouter_provider="p",
+    )
+
+
+def test_is_empty_empty_content_list() -> None:
+    assert _anthropic_response_is_empty(_resp([])) is True
+
+
+def test_is_empty_whitespace_only_text() -> None:
+    assert _anthropic_response_is_empty(_resp([{"type": "text", "text": "   \n\t"}])) is True
+
+
+def test_is_empty_thinking_only() -> None:
+    assert _anthropic_response_is_empty(
+        _resp([{"type": "thinking", "thinking": "hmm..."}])
+    ) is True
+
+
+def test_is_not_empty_real_text() -> None:
+    assert _anthropic_response_is_empty(_resp([{"type": "text", "text": "hello"}])) is False
+
+
+def test_is_not_empty_tool_use() -> None:
+    assert _anthropic_response_is_empty(
+        _resp([{"type": "tool_use", "id": "t1", "name": "run", "input": {}}])
+    ) is False
+
+
+def test_is_not_empty_mixed_thinking_and_text() -> None:
+    # thinking + a real text block → non-empty
+    assert _anthropic_response_is_empty(
+        _resp(
+            [
+                {"type": "thinking", "thinking": "..."},
+                {"type": "text", "text": "answer"},
+            ]
+        )
+    ) is False
+
+
+def test_stream_event_real_content_detection() -> None:
+    text_delta = AnthropicStreamEvent(
+        type="content_block_delta",
+        data={
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "hi"},
+        },
+    )
+    ws_delta = AnthropicStreamEvent(
+        type="content_block_delta",
+        data={
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "  "},
+        },
+    )
+    tool_start = AnthropicStreamEvent(
+        type="content_block_start",
+        data={
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "tool_use", "id": "t", "name": "run", "input": {}},
+        },
+    )
+    msg_start = AnthropicStreamEvent(
+        type="message_start", data={"type": "message_start", "message": {}}
+    )
+    assert _stream_event_is_real_content(text_delta) is True
+    assert _stream_event_is_real_content(tool_start) is True
+    assert _stream_event_is_real_content(ws_delta) is False
+    assert _stream_event_is_real_content(msg_start) is False
+
+
+# ----------------------------------------------------------------------
+# Non-streaming behavior
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nonstream_fallback_empty_recovered_by_next() -> None:
+    """fallback: first returns empty → second's real response is returned."""
+    config = _empty_config("fallback")
+    first = EmptyAnthropicAdapter(config.provider_by_name("first"))
+    second = FakeAnthropicAdapter(config.provider_by_name("second"), text="recovered")
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    resp = await engine.generate_anthropic(_req())
+
+    assert resp.coderouter_provider == "second"
+    assert resp.content == [{"type": "text", "text": "recovered"}]
+    assert first.generate_calls  # first was tried
+    assert second.generate_calls  # second recovered
+
+
+@pytest.mark.asyncio
+async def test_nonstream_fallback_chain_exhausted_returns_last_empty() -> None:
+    """fallback: both empty → the last empty response is returned as-is."""
+    config = _empty_config("fallback")
+    first = EmptyAnthropicAdapter(config.provider_by_name("first"))
+    second = EmptyAnthropicAdapter(config.provider_by_name("second"))
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    resp = await engine.generate_anthropic(_req())
+
+    # last empty (from "second") returned verbatim, no exception
+    assert resp.coderouter_provider == "second"
+    assert resp.content == []
+
+
+@pytest.mark.asyncio
+async def test_nonstream_warn_returns_empty_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """warn: the empty response from the first provider is returned; second
+    is never tried; a log line is emitted."""
+    config = _empty_config("warn")
+    first = EmptyAnthropicAdapter(config.provider_by_name("first"))
+    second = FakeAnthropicAdapter(config.provider_by_name("second"), text="unused")
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    with caplog.at_level(logging.WARNING):
+        resp = await engine.generate_anthropic(_req())
+
+    assert resp.coderouter_provider == "first"
+    assert resp.content == []
+    assert second.generate_calls == []  # warn does not fall through
+    assert any(r.message == "empty-response-detected" for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_nonstream_off_is_unchanged() -> None:
+    """off: the empty response is returned immediately, no detection."""
+    config = _empty_config("off")
+    first = EmptyAnthropicAdapter(config.provider_by_name("first"))
+    second = FakeAnthropicAdapter(config.provider_by_name("second"), text="unused")
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    resp = await engine.generate_anthropic(_req())
+
+    assert resp.coderouter_provider == "first"
+    assert resp.content == []
+    assert second.generate_calls == []
+
+
+@pytest.mark.asyncio
+async def test_nonstream_whitespace_text_treated_empty() -> None:
+    """fallback: a whitespace-only text response is treated as empty."""
+    config = _empty_config("fallback")
+    first = EmptyAnthropicAdapter(
+        config.provider_by_name("first"),
+        content=[{"type": "text", "text": "   \n"}],
+    )
+    second = FakeAnthropicAdapter(config.provider_by_name("second"), text="real")
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    resp = await engine.generate_anthropic(_req())
+
+    assert resp.coderouter_provider == "second"
+
+
+@pytest.mark.asyncio
+async def test_nonstream_tool_use_is_not_empty() -> None:
+    """fallback: a tool_use-only response is NOT empty → returned as-is."""
+    config = _empty_config("fallback")
+    first = EmptyAnthropicAdapter(
+        config.provider_by_name("first"),
+        content=[{"type": "tool_use", "id": "t", "name": "run", "input": {}}],
+    )
+    second = FakeAnthropicAdapter(config.provider_by_name("second"), text="unused")
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    resp = await engine.generate_anthropic(_req())
+
+    assert resp.coderouter_provider == "first"
+    assert second.generate_calls == []
+
+
+@pytest.mark.asyncio
+async def test_nonstream_thinking_only_treated_empty() -> None:
+    """fallback: a thinking-only response is empty → next provider used."""
+    config = _empty_config("fallback")
+    first = EmptyAnthropicAdapter(
+        config.provider_by_name("first"),
+        content=[{"type": "thinking", "thinking": "let me think"}],
+    )
+    second = FakeAnthropicAdapter(config.provider_by_name("second"), text="real")
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    resp = await engine.generate_anthropic(_req())
+
+    assert resp.coderouter_provider == "second"
+
+
+@pytest.mark.asyncio
+async def test_nonstream_fallback_real_first_short_circuits() -> None:
+    """fallback with a non-empty first provider is a pure no-op."""
+    config = _empty_config("fallback")
+    first = FakeAnthropicAdapter(config.provider_by_name("first"), text="fine")
+    second = FakeAnthropicAdapter(config.provider_by_name("second"), text="unused")
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    resp = await engine.generate_anthropic(_req())
+
+    assert resp.coderouter_provider == "first"
+    assert second.generate_calls == []
+
+
+# ----------------------------------------------------------------------
+# Streaming behavior
+# ----------------------------------------------------------------------
+
+
+async def _collect(engine: FallbackEngine, req: AnthropicRequest) -> list[AnthropicStreamEvent]:
+    return [ev async for ev in engine.stream_anthropic(req)]
+
+
+@pytest.mark.asyncio
+async def test_stream_fallback_empty_swapped_to_next() -> None:
+    """fallback: an empty stream is withheld; the second provider's real
+    stream is delivered in full and unchanged."""
+    config = _empty_config("fallback")
+    first = EmptyAnthropicAdapter(config.provider_by_name("first"))
+    second = FakeAnthropicAdapter(config.provider_by_name("second"), text="hello")
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    events = await _collect(engine, _req(stream=True))
+
+    # The client sees exactly the second provider's stream, in order —
+    # none of the first provider's (empty) preamble leaks through.
+    expected = _default_native_events("hello", "second-model")
+    assert [e.type for e in events] == [e.type for e in expected]
+    # real text delta present
+    assert any(
+        e.data.get("delta", {}).get("text") == "hello"
+        for e in events
+        if e.type == "content_block_delta"
+    )
+    assert first.stream_calls  # first was tried
+    assert second.stream_calls  # second recovered
+
+
+@pytest.mark.asyncio
+async def test_stream_fallback_real_content_delivered_in_order() -> None:
+    """fallback with a non-empty first stream: buffering is transparent —
+    every event arrives in the original order."""
+    config = _empty_config("fallback")
+    first = FakeAnthropicAdapter(config.provider_by_name("first"), text="content")
+    second = FakeAnthropicAdapter(config.provider_by_name("second"), text="unused")
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    events = await _collect(engine, _req(stream=True))
+
+    expected = _default_native_events("content", "first-model")
+    assert [e.type for e in events] == [e.type for e in expected]
+    assert second.stream_calls == []  # second never tried
+
+
+@pytest.mark.asyncio
+async def test_stream_fallback_chain_exhausted_terminates_normally() -> None:
+    """fallback: both streams empty → the last buffered (empty) stream is
+    flushed and the SSE terminates normally (no exception)."""
+    config = _empty_config("fallback")
+    first = EmptyAnthropicAdapter(config.provider_by_name("first"))
+    second = EmptyAnthropicAdapter(config.provider_by_name("second"))
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    events = await _collect(engine, _req(stream=True))
+
+    # a well-formed, terminating empty stream reaches the client
+    assert events[0].type == "message_start"
+    assert events[-1].type == "message_stop"
+    assert first.stream_calls and second.stream_calls
+
+
+@pytest.mark.asyncio
+async def test_stream_off_is_unchanged() -> None:
+    """off: the empty stream is streamed through immediately (legacy)."""
+    config = _empty_config("off")
+    first = EmptyAnthropicAdapter(config.provider_by_name("first"))
+    second = FakeAnthropicAdapter(config.provider_by_name("second"), text="unused")
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    events = await _collect(engine, _req(stream=True))
+
+    # first provider's empty stream is delivered verbatim; second untouched
+    assert events[0].type == "message_start"
+    assert events[-1].type == "message_stop"
+    assert second.stream_calls == []
+
+
+@pytest.mark.asyncio
+async def test_stream_fallback_all_empty_then_error_raises_no_providers() -> None:
+    """fallback: first empty (swapped), second raises before content →
+    the chain is exhausted with no buffered stream to flush AND no successful
+    stream, so NoProvidersAvailableError surfaces."""
+    config = _empty_config("fallback")
+    first = FakeAnthropicAdapter(
+        config.provider_by_name("first"),
+        stream_fail_with=AdapterError("boom", provider="first", retryable=True),
+        stream_fail_after=0,
+    )
+    second = FakeAnthropicAdapter(
+        config.provider_by_name("second"),
+        stream_fail_with=AdapterError("boom2", provider="second", retryable=True),
+        stream_fail_after=0,
+    )
+    engine = _engine_with_adapters(config, {"first": first, "second": second})
+
+    with pytest.raises(NoProvidersAvailableError):
+        await _collect(engine, _req(stream=True))
+
+
+# ----------------------------------------------------------------------
+# Metrics integration
+# ----------------------------------------------------------------------
+
+
+def test_metrics_empty_response_counter() -> None:
+    """The collector counts ``empty-response-detected`` events per-provider."""
+    collector = MetricsCollector()
+    rec = logging.LogRecord(
+        name="coderouter",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=1,
+        msg="empty-response-detected",
+        args=(),
+        exc_info=None,
+    )
+    rec.provider = "gemma4"
+    rec.action = "fallback"
+    rec.stream = False
+    rec.chain_exhausted = False
+    collector.emit(rec)
+    collector.emit(rec)
+
+    snap = collector.snapshot()
+    assert snap["counters"]["empty_responses_total"] == 2
+    assert snap["counters"]["empty_responses_by_provider"]["gemma4"] == 2


### PR DESCRIPTION
…tion)

Add FallbackChain.empty_response_action: off | warn | fallback (default off, fully backward compatible). When set to fallback, a 200 response that is content-empty (no tool_use, no non-whitespace text; thinking-only counts as empty) is re-dispatched in-flight to the next provider in the chain.

- Non-streaming: judged on the finalized response object
- Streaming: events are buffered until the first real content token; an unobserved stream that terminates is discarded and the request moves to the next provider
- 'empty' is judged on content, not usage.output_tokens (unreliable on some backends)

Motivation: gemma4:26b returns blank 200s on no_tool_temptation-type prompts (20/20 observed at temperature 0, direct AND via router — L2/L3 bench 2026-07-04/05). The windowed drift guard empty_response_rate cannot rescue a single blank turn in-flight; the repair layer has no text to repair. This is the fallback leg of the three-tier story (repair / no-degradation / fallback).

Tests: 21 new (tests/test_fallback_empty_response.py), 1553 passed total, ruff clean, no new dependencies, default off.