### PR TITLE
docs(bench): refresh tool-repair benchmark with L3 results and R4-era…

### DIFF
--- a/benchmarks/tool-repair/README.md
+++ b/benchmarks/tool-repair/README.md
@@ -8,8 +8,9 @@ field — and how often a live model needs that rescue at all.
 Two layers:
 
 - **L1 — `run_offline.py`**: deterministic, no network, stdlib only. Runs the
-  repairer over a fixed corpus of broken outputs (`corpus.jsonl`, 55 cases in
-  8 categories + 12 negatives) and scores **recovery** and **false
+  repairer over a fixed corpus of broken outputs (`corpus.jsonl`, 84 cases:
+  59 expect-repair across 11 categories + 25 negatives, including 10
+  adversarial-review counterexamples) and scores **recovery** and **false
   positives**. This is the regression gate for the repairer itself; it also
   runs in CI via `tests/test_toolrepair_bench.py`.
 - **L2 — `run_live.py`**: talks to a real endpoint (a backend directly, or
@@ -66,21 +67,39 @@ Notes:
   the path, not the sampler. Use `--temperature none` for backend-default
   sampling.
 - Requires `httpx` (already a CodeRouter runtime dep).
+- `bench_l3_p1.sh` runs the whole model matrix (direct + router per model);
+  `REPS=5` for a smoke pass, `P2=1` to include the second-priority models.
 
-## Measured results (2026-07-04, M3 Max, 100 requests per cell)
+## Measured results (2026-07-05, M3 Max, 100 requests per cell, zero errors)
 
-Kept under `results/` as evidence for the write-ups.
+Kept under `results/` as evidence for the write-ups. Repairer-version A/B
+snapshots live in `results/archive-v2.7.0/` and `results/archive-v2.7.1/`;
+top-level files are the latest (v2.7.2 / R4, plus the fallback-chain run).
 
-| model | direct | via CodeRouter | reading |
-|---|:-:|:-:|---|
-| qwen2.5-coder:7b | 0% usable calls | **100%** | weak models: repair does all the work |
-| qwen3-coder:30b | 100% | **100%** | strong models: zero degradation |
-| gemma4:26b | 80% | 80% | empty responses — repair can't fix absent text (fallback territory) |
+| model | direct | v2.7.0 | v2.7.1 | **v2.7.2 (R4)** | reading |
+|---|:-:|:-:|:-:|:-:|---|
+| qwen2.5-coder:7b | 0% | **100%** | 100% | 100% | fenced text-JSON: base repairer does all the work |
+| qwen2.5-coder:1.5b | 0% | **100%** | 100% | 100% | second 0→100 model, size-independent |
+| mistral:7b | 0% | 80% | 80% | **100%** | colon call-syntax (`echo(message: 'x')`) closed by R4c |
+| phi4-mini:3.8b | 0% | 20% | 40% | **80%** | +20pt = R2 aliases, +40pt = R4c; the last 20% is the semantically-corrupted case the repairer refuses **by design** |
+| llama3.2:3b / 3.1:8b | 100% | 100% | 100% | 100% | zero degradation (negative result: they don't break at temp 0) |
+| qwen3-coder:30b | 100% | 100% | 100% | 100% | zero degradation |
+| gemma4:26b | 80% | 80% | 80% | 80% | empty 200s — no text to repair |
+| gemma4:26b → qwen3-30b chain | — | — | — | **100%** | `empty_response_action: fallback` rescues all 20 blank turns |
 
-Offline (post-v2.7.1 repairer): recall **100%** (43/43), false positives
-**0/12**. The pre-v2.7.1 repairer scored 80.6% overall and 14.3% on the
-`malformed` category — that gap is what drove the lenient-repair upgrade
-shipped in v2.7.1.
+Three-tier summary the numbers support: **(1)** broken-but-present tool
+calls are repaired (four 0→100/0→80 models), **(2)** healthy models pass
+through undegraded, **(3)** what repair cannot touch — blank responses,
+semantically corrupted arguments — is fallback territory, and the chain row
+shows fallback closing it.
+
+Offline (post-v2.7.2 repairer): recall **100%** (59/59), false positives
+**0/25**. The pre-R4 repairer scored 78.0% on the same corpus (nested-XML
+0/5, JSON-envelope 1/4, call-syntax 0/5) — that gap, measured live in the
+mistral/phi4 rows above, is what drove the R4 upgrade shipped in v2.7.2.
+
+Note: gemma3:27b was excluded — its Ollama build ships without the `tools`
+capability and 400s any tool-bearing request (verify with `ollama show`).
 
 ## Growing the corpus
 

--- a/benchmarks/tool-repair/bench_l3_p1.sh
+++ b/benchmarks/tool-repair/bench_l3_p1.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# L3 P1 一括計測スクリプト(直結 vs CodeRouter、temperature=0)
+# 実行前提:
+#   - リポジトリルートで実行
+#   - Ollama 稼働中(localhost:11434)
+#   - CodeRouter 稼働中: coderouter serve --port 8088 --config \
+#       benchmarks/tool-repair/providers.bench.yaml
+# 使い方:
+#   bash benchmarks/tool-repair/bench_l3_p1.sh          # P1 のみ
+#   P2=1 bash benchmarks/tool-repair/bench_l3_p1.sh    # P2 も実行
+set -euo pipefail
+
+BENCH="benchmarks/tool-repair"
+REPS="${REPS:-20}"
+TEMP="${TEMP:-0}"
+ROUTER_URL="${ROUTER_URL:-http://localhost:8088}"
+OLLAMA_URL="${OLLAMA_URL:-http://localhost:11434/v1}"
+
+# model:profile ペア
+P1_TARGETS=(
+  "llama3.2:3b|bench-llama32-3b"
+  "mistral:7b|bench-mistral7b"
+  "qwen2.5-coder:1.5b|bench-qwen25-coder-15b"
+)
+P2_TARGETS=(
+  "llama3.1:8b|bench-llama31-8b"
+  # gemma3:27b は tools capability 無し(400/502)のため除外。gemma系は gemma4:26b を使用
+  "phi4-mini:latest|bench-phi4mini"
+)
+
+TARGETS=("${P1_TARGETS[@]}")
+[ "${P2:-0}" = "1" ] && TARGETS+=("${P2_TARGETS[@]}")
+
+run_pair() {
+  local model="$1" profile="$2"
+  echo "=== ${model} / 直結(openai wire) ==="
+  python3 "${BENCH}/run_live.py" \
+    --base-url "${OLLAMA_URL}" --wire openai \
+    --model "${model}" --reps "${REPS}" --temperature "${TEMP}" \
+    --tag direct --out-dir "${BENCH}"
+
+  echo "=== ${model} / CodeRouter(anthropic wire, profile=${profile}) ==="
+  python3 "${BENCH}/run_live.py" \
+    --base-url "${ROUTER_URL}" --wire anthropic \
+    --model "${model}" --profile "${profile}" \
+    --reps "${REPS}" --temperature "${TEMP}" \
+    --tag coderouter --out-dir "${BENCH}"
+}
+
+for t in "${TARGETS[@]}"; do
+  model="${t%%|*}"; profile="${t##*|}"
+  run_pair "${model}" "${profile}"
+done
+
+echo "完了。結果: ${BENCH}/results_live_*_{direct,coderouter}.{json,md}"

--- a/benchmarks/tool-repair/providers.bench.yaml
+++ b/benchmarks/tool-repair/providers.bench.yaml
@@ -1,20 +1,43 @@
-# L2 tool-call benchmark providers.yaml
+# L3 tool-call benchmark providers.yaml (壊れモデル横断計測)
 # ---------------------------------------------------------------------------
-# Three profiles, one per benchmarked model. CodeRouter treats the client-sent
-# `model` field as a routing placeholder (the provider's `model` always wins),
-# so the bench selects the backend model via the X-CodeRouter-Profile header
-# (run_live.py --profile <name>), NOT via --model.
+# L2 の providers.bench.yaml の上位互換(既存 3 プロファイル維持 + L3 追加)。
+# CodeRouter はクライアント送信の `model` をルーティング placeholder として扱う
+# (provider 側 `model` が常に優先)ため、モデル選択は X-CodeRouter-Profile
+# ヘッダ(run_live.py --profile <name>)で行う。
 #
 # Usage:
 #   coderouter serve --port 8088 --config \
-#     _OUTPUTS/CodeRouter-toolrepair-bench/bench/providers.bench.yaml
+#     benchmarks/tool-repair/providers.bench.yaml
 #
-# Guards / auto-router are intentionally left at defaults (off) so the
-# measurement isolates the translation + tool-repair path.
+# guards / auto-router はデフォルト(off)のまま — 変換+修復経路の分離計測。
 
-default_profile: bench-qwen7b
+default_profile: bench-llama32-3b
 
 profiles:
+  # --- L3 P1(壊れやすい順) ---
+  - name: bench-llama32-3b
+    providers: [ollama-llama32-3b]
+
+  - name: bench-mistral7b
+    providers: [ollama-mistral7b]
+
+  - name: bench-qwen25-coder-15b
+    providers: [ollama-qwen25-coder-15b]
+
+  # --- L3 P2 ---
+  - name: bench-llama31-8b
+    providers: [ollama-llama31-8b]
+
+  # 計測不可: gemma3:27b は tools capability 無し(ollama show で確認、2026-07-05)。
+  # tools 付きリクエストに 400 を返す → CodeRouter 経由では 502。gemma 系は
+  # gemma4:26b(tools 対応)を使用。
+  # - name: bench-gemma3-27b
+  #   providers: [ollama-gemma3-27b]
+
+  - name: bench-phi4mini
+    providers: [ollama-phi4mini]
+
+  # --- L2 既存(回帰比較用に維持) ---
   - name: bench-qwen7b
     providers: [ollama-qwen25-coder-7b]
 
@@ -24,7 +47,48 @@ profiles:
   - name: bench-gemma26b
     providers: [ollama-gemma4-26b]
 
+  # --- Empty-response fallback chain ---
+  # Requires `empty_response_action` support (feature/empty-response-fallback,
+  # PR pending as of 2026-07-05). Uncomment once merged. Measured result:
+  # gemma4:26b 80% -> 100% native (20/20 blank turns rescued by qwen3-30b).
+  # - name: bench-gemma-chain
+  #   providers: [ollama-gemma4-26b, ollama-qwen3-coder-30b]
+  #   empty_response_action: fallback
+
 providers:
+  # --- L3 P1 ---
+  - name: ollama-llama32-3b
+    kind: openai_compat
+    base_url: http://localhost:11434/v1
+    model: llama3.2:3b
+
+  - name: ollama-mistral7b
+    kind: openai_compat
+    base_url: http://localhost:11434/v1
+    model: mistral:7b
+
+  - name: ollama-qwen25-coder-15b
+    kind: openai_compat
+    base_url: http://localhost:11434/v1
+    model: qwen2.5-coder:1.5b
+
+  # --- L3 P2 ---
+  - name: ollama-llama31-8b
+    kind: openai_compat
+    base_url: http://localhost:11434/v1
+    model: llama3.1:8b
+
+  # - name: ollama-gemma3-27b
+  #   kind: openai_compat
+  #   base_url: http://localhost:11434/v1
+  #   model: gemma3:27b
+
+  - name: ollama-phi4mini
+    kind: openai_compat
+    base_url: http://localhost:11434/v1
+    model: phi4-mini:latest
+
+  # --- L2 既存 ---
   - name: ollama-qwen25-coder-7b
     kind: openai_compat
     base_url: http://localhost:11434/v1

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma3_27b_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma3_27b_anthropic_coderouter.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T03:54:15.004672+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "gemma3:27b",
+  "temperature": "0",
+  "profile": "bench-gemma3-27b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 0,
+    "fail": 0,
+    "error": 100,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 0,
+      "fail": 0,
+      "error": 20
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 0,
+      "fail": 0,
+      "error": 20
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 0,
+      "fail": 0,
+      "error": 20
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 0,
+      "fail": 0,
+      "error": 20
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 0,
+      "error": 20
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "error",
+      "detail": "Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma3_27b_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma3_27b_anthropic_coderouter.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — gemma3:27b
+
+- Generated: 2026-07-05T03:54:15.004672+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 100 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 0 | 0 | 20 |
+| complex_args | 0 | 0 | 0 | 20 |
+| multi_tool_select | 0 | 0 | 0 | 20 |
+| japanese_instruction | 0 | 0 | 0 | 20 |
+| no_tool_temptation | 0 | 0 | 0 | 20 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/
+- `simple_echo` [error]: Server error '502 Bad Gateway' for url 'http://localhost:8088/v1/messages' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma3_27b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma3_27b_openai_direct.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T03:53:54.373594+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "gemma3:27b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 0,
+    "fail": 0,
+    "error": 100,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 0,
+      "fail": 0,
+      "error": 20
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 0,
+      "fail": 0,
+      "error": 20
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 0,
+      "fail": 0,
+      "error": 20
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 0,
+      "fail": 0,
+      "error": 20
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 0,
+      "error": 20
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "error",
+      "detail": "Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions'\nFor more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma3_27b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma3_27b_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — gemma3:27b
+
+- Generated: 2026-07-05T03:53:54.373594+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 100 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 0 | 0 | 20 |
+| complex_args | 0 | 0 | 0 | 20 |
+| multi_tool_select | 0 | 0 | 0 | 20 |
+| japanese_instruction | 0 | 0 | 0 | 20 |
+| no_tool_temptation | 0 | 0 | 0 | 20 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT
+- `simple_echo` [error]: Client error '400 Bad Request' for url 'http://localhost:11434/v1/chat/completions' For more information check: https://developer.mozilla.org/en-US/docs/Web/HTT

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma4_26b_anthropic_coderouter-r1.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma4_26b_anthropic_coderouter-r1.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-04T14:01:57.790848+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "gemma4:26b",
+  "temperature": "0",
+  "profile": "bench-gemma26b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 80,
+    "repair": 0,
+    "fail": 20,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.8,
+    "repair_rate": 0.0,
+    "fail_rate": 0.2
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 0,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 1,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 2,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 3,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 4,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 5,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 6,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 7,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 8,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 9,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 10,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 11,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 12,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 13,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 14,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 15,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 16,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 17,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 18,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 19,
+      "verdict": "fail",
+      "text_sample": ""
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma4_26b_anthropic_coderouter-r1.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma4_26b_anthropic_coderouter-r1.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — gemma4:26b
+
+- Generated: 2026-07-04T14:01:57.790848+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 80 | 80.0% |
+| repair | 0 | 0.0% |
+| fail | 20 | 20.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma4_26b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma4_26b_openai_direct.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-04T13:46:42.201096+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "gemma4:26b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 80,
+    "repair": 0,
+    "fail": 20,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.8,
+    "repair_rate": 0.0,
+    "fail_rate": 0.2
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 0,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 1,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 2,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 3,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 4,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 5,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 6,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 7,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 8,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 9,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 10,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 11,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 12,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 13,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 14,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 15,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 16,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 17,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 18,
+      "verdict": "fail",
+      "text_sample": ""
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 19,
+      "verdict": "fail",
+      "text_sample": ""
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma4_26b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_gemma4_26b_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — gemma4:26b
+
+- Generated: 2026-07-04T13:46:42.201096+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 80 | 80.0% |
+| repair | 0 | 0.0% |
+| fail | 20 | 20.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 
+- `no_tool_temptation` [fail]: 

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.1_8b_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.1_8b_anthropic_coderouter.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T03:53:34.111988+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "llama3.1:8b",
+  "temperature": "0",
+  "profile": "bench-llama31-8b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.1_8b_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.1_8b_anthropic_coderouter.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — llama3.1:8b
+
+- Generated: 2026-07-05T03:53:34.111988+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.1_8b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.1_8b_openai_direct.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T03:51:49.769139+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "llama3.1:8b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.1_8b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.1_8b_openai_direct.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — llama3.1:8b
+
+- Generated: 2026-07-05T03:51:49.769139+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.2_3b_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.2_3b_anthropic_coderouter.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T03:47:06.324071+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "llama3.2:3b",
+  "temperature": "0",
+  "profile": "bench-llama32-3b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.2_3b_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.2_3b_anthropic_coderouter.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — llama3.2:3b
+
+- Generated: 2026-07-05T03:47:06.324071+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.2_3b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.2_3b_openai_direct.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T03:46:21.678432+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "llama3.2:3b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.2_3b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_llama3.2_3b_openai_direct.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — llama3.2:3b
+
+- Generated: 2026-07-05T03:46:21.678432+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_mistral_7b_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_mistral_7b_anthropic_coderouter.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T03:49:04.383464+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "mistral:7b",
+  "temperature": "0",
+  "profile": "bench-mistral7b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 80,
+    "repair": 0,
+    "fail": 20,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.8,
+    "repair_rate": 0.0,
+    "fail_rate": 0.2
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 0,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 1,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 2,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 3,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 4,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 5,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 6,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 7,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 8,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 9,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 10,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 11,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 12,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 13,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 14,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 15,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 16,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 17,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 18,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 19,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_mistral_7b_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_mistral_7b_anthropic_coderouter.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — mistral:7b
+
+- Generated: 2026-07-05T03:49:04.383464+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 80 | 80.0% |
+| repair | 0 | 0.0% |
+| fail | 20 | 20.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_mistral_7b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_mistral_7b_openai_direct.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T03:48:05.462578+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "mistral:7b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 80,
+    "fail": 20,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 0.8,
+    "fail_rate": 0.2
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_mistral_7b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_mistral_7b_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — mistral:7b
+
+- Generated: 2026-07-05T03:48:05.462578+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 80 | 80.0% |
+| fail | 20 | 20.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 20 | 0 | 0 |
+| complex_args | 0 | 20 | 0 | 0 |
+| multi_tool_select | 0 | 20 | 0 | 0 |
+| japanese_instruction | 0 | 20 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_phi4-mini_latest_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_phi4-mini_latest_anthropic_coderouter.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T03:55:49.466813+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "phi4-mini:latest",
+  "temperature": "0",
+  "profile": "bench-phi4mini",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 20,
+    "repair": 20,
+    "fail": 60,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.2,
+    "repair_rate": 0.2,
+    "fail_rate": 0.6
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_phi4-mini_latest_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_phi4-mini_latest_anthropic_coderouter.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — phi4-mini:latest
+
+- Generated: 2026-07-05T03:55:49.466813+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 20 | 20.0% |
+| repair | 20 | 20.0% |
+| fail | 60 | 60.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 20 | 0 | 0 |
+| complex_args | 0 | 0 | 20 | 0 |
+| multi_tool_select | 0 | 0 | 20 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_phi4-mini_latest_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_phi4-mini_latest_openai_direct.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T03:55:04.304776+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "phi4-mini:latest",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 40,
+    "fail": 60,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 0.4,
+    "fail_rate": 0.6
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_phi4-mini_latest_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_phi4-mini_latest_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — phi4-mini:latest
+
+- Generated: 2026-07-05T03:55:04.304776+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 40 | 40.0% |
+| fail | 60 | 60.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 20 | 0 | 0 |
+| complex_args | 0 | 0 | 20 | 0 |
+| multi_tool_select | 0 | 0 | 20 | 0 |
+| japanese_instruction | 0 | 20 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_1.5b_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_1.5b_anthropic_coderouter.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T03:50:14.436746+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "qwen2.5-coder:1.5b",
+  "temperature": "0",
+  "profile": "bench-qwen25-coder-15b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_1.5b_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_1.5b_anthropic_coderouter.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — qwen2.5-coder:1.5b
+
+- Generated: 2026-07-05T03:50:14.436746+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_1.5b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_1.5b_openai_direct.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T03:49:39.549959+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "qwen2.5-coder:1.5b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 100,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 1.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_1.5b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_1.5b_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — qwen2.5-coder:1.5b
+
+- Generated: 2026-07-05T03:49:39.549959+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 100 | 100.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 20 | 0 | 0 |
+| complex_args | 0 | 20 | 0 | 0 |
+| multi_tool_select | 0 | 20 | 0 | 0 |
+| japanese_instruction | 0 | 20 | 0 | 0 |
+| no_tool_temptation | 0 | 20 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_anthropic_coderouter-r1-default-temp.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_anthropic_coderouter-r1-default-temp.json
@@ -1,0 +1,65 @@
+{
+  "generated_at": "2026-07-04T13:13:46.931028+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "qwen2.5-coder:7b",
+  "temperature": "none",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 99,
+    "repair": 0,
+    "fail": 1,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.99,
+    "repair_rate": 0.0,
+    "fail_rate": 0.01
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 19,
+      "repair": 0,
+      "fail": 1,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 10,
+      "verdict": "fail",
+      "text_sample": "```xml\n<tools>\n  <function name=\"echo\" arguments='{\"message\": \"demo\"}' />\n</tools>\n```"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_anthropic_coderouter-r1-default-temp.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_anthropic_coderouter-r1-default-temp.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — qwen2.5-coder:7b
+
+- Generated: 2026-07-04T13:13:46.931028+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 99 | 99.0% |
+| repair | 0 | 0.0% |
+| fail | 1 | 1.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 19 | 0 | 1 | 0 |
+
+## Sample non-native / failed responses
+
+- `no_tool_temptation` [fail]: ```xml <tools>   <function name="echo" arguments='{"message": "demo"}' /> </tools> ```

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_anthropic_coderouter.json
@@ -1,0 +1,57 @@
+{
+  "generated_at": "2026-07-04T13:05:47.410203+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "qwen2.5-coder:7b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_anthropic_coderouter.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — qwen2.5-coder:7b
+
+- Generated: 2026-07-04T13:05:47.410203+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_openai_direct.json
@@ -1,0 +1,178 @@
+{
+  "generated_at": "2026-07-04T12:24:56.783488+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "qwen2.5-coder:7b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 100,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 1.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "repair",
+      "text_sample": "{\"name\": \"echo\", \"arguments\": {\"message\": \"probe\"}}"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen2.5-coder_7b_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — qwen2.5-coder:7b
+
+- Generated: 2026-07-04T12:24:56.783488+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 100 | 100.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 20 | 0 | 0 |
+| complex_args | 0 | 20 | 0 | 0 |
+| multi_tool_select | 0 | 20 | 0 | 0 |
+| japanese_instruction | 0 | 20 | 0 | 0 |
+| no_tool_temptation | 0 | 20 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}
+- `simple_echo` [repair]: {"name": "echo", "arguments": {"message": "probe"}}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen3-coder_30b_anthropic_coderouter-r1.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen3-coder_30b_anthropic_coderouter-r1.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-04T13:41:48.263718+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "qwen3-coder:30b",
+  "temperature": "0",
+  "profile": "bench-qwen30b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen3-coder_30b_anthropic_coderouter-r1.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen3-coder_30b_anthropic_coderouter-r1.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — qwen3-coder:30b
+
+- Generated: 2026-07-04T13:41:48.263718+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen3-coder_30b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen3-coder_30b_openai_direct.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-04T13:39:21.992235+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "qwen3-coder:30b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen3-coder_30b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.0/results_live_qwen3-coder_30b_openai_direct.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — qwen3-coder:30b
+
+- Generated: 2026-07-04T13:39:21.992235+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.1_8b_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.1_8b_anthropic_coderouter.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T04:25:39.807055+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "llama3.1:8b",
+  "temperature": "0",
+  "profile": "bench-llama31-8b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.1_8b_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.1_8b_anthropic_coderouter.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — llama3.1:8b
+
+- Generated: 2026-07-05T04:25:39.807055+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.1_8b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.1_8b_openai_direct.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T04:24:06.990782+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "llama3.1:8b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.1_8b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.1_8b_openai_direct.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — llama3.1:8b
+
+- Generated: 2026-07-05T04:24:06.990782+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.2_3b_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.2_3b_anthropic_coderouter.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T04:18:35.126407+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "llama3.2:3b",
+  "temperature": "0",
+  "profile": "bench-llama32-3b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.2_3b_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.2_3b_anthropic_coderouter.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — llama3.2:3b
+
+- Generated: 2026-07-05T04:18:35.126407+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.2_3b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.2_3b_openai_direct.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T04:17:25.537033+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "llama3.2:3b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.2_3b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_llama3.2_3b_openai_direct.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — llama3.2:3b
+
+- Generated: 2026-07-05T04:17:25.537033+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_mistral_7b_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_mistral_7b_anthropic_coderouter.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T04:21:21.437773+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "mistral:7b",
+  "temperature": "0",
+  "profile": "bench-mistral7b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 80,
+    "repair": 0,
+    "fail": 20,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.8,
+    "repair_rate": 0.0,
+    "fail_rate": 0.2
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 0,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 1,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 2,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 3,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 4,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 5,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 6,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 7,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 8,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 9,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 10,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 11,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 12,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 13,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 14,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 15,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 16,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 17,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 18,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    },
+    {
+      "prompt": "no_tool_temptation",
+      "rep": 19,
+      "verdict": "fail",
+      "text_sample": " The `echo` function echoes back the provided message.\n\n```\necho(message: 'demo')\n```"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_mistral_7b_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_mistral_7b_anthropic_coderouter.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — mistral:7b
+
+- Generated: 2026-07-05T04:21:21.437773+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 80 | 80.0% |
+| repair | 0 | 0.0% |
+| fail | 20 | 20.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```
+- `no_tool_temptation` [fail]:  The `echo` function echoes back the provided message.  ``` echo(message: 'demo') ```

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_mistral_7b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_mistral_7b_openai_direct.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T04:20:04.457860+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "mistral:7b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 80,
+    "fail": 20,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 0.8,
+    "fail_rate": 0.2
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_mistral_7b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_mistral_7b_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — mistral:7b
+
+- Generated: 2026-07-05T04:20:04.457860+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 80 | 80.0% |
+| fail | 20 | 20.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 20 | 0 | 0 |
+| complex_args | 0 | 20 | 0 | 0 |
+| multi_tool_select | 0 | 20 | 0 | 0 |
+| japanese_instruction | 0 | 20 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_phi4-mini_latest_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_phi4-mini_latest_anthropic_coderouter.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T04:27:10.325489+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "phi4-mini:latest",
+  "temperature": "0",
+  "profile": "bench-phi4mini",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 40,
+    "repair": 0,
+    "fail": 60,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.4,
+    "repair_rate": 0.0,
+    "fail_rate": 0.6
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "complex_args",
+      "rep": 0,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 1,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 2,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 3,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 4,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 5,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 6,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 7,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 8,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 9,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 10,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 11,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 12,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 13,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 14,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 15,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 16,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 17,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 18,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 19,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_phi4-mini_latest_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_phi4-mini_latest_anthropic_coderouter.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — phi4-mini:latest
+
+- Generated: 2026-07-05T04:27:10.325489+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 40 | 40.0% |
+| repair | 0 | 0.0% |
+| fail | 60 | 60.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 0 | 0 | 20 | 0 |
+| multi_tool_select | 0 | 0 | 20 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_phi4-mini_latest_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_phi4-mini_latest_openai_direct.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T04:26:25.945017+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "phi4-mini:latest",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 40,
+    "fail": 60,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 0.4,
+    "fail_rate": 0.6
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_phi4-mini_latest_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_phi4-mini_latest_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — phi4-mini:latest
+
+- Generated: 2026-07-05T04:26:25.945017+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 40 | 40.0% |
+| fail | 60 | 60.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 20 | 0 | 0 |
+| complex_args | 0 | 0 | 20 | 0 |
+| multi_tool_select | 0 | 0 | 20 | 0 |
+| japanese_instruction | 0 | 20 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_qwen2.5-coder_1.5b_anthropic_coderouter.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_qwen2.5-coder_1.5b_anthropic_coderouter.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T04:22:30.105414+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "qwen2.5-coder:1.5b",
+  "temperature": "0",
+  "profile": "bench-qwen25-coder-15b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_qwen2.5-coder_1.5b_anthropic_coderouter.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_qwen2.5-coder_1.5b_anthropic_coderouter.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — qwen2.5-coder:1.5b
+
+- Generated: 2026-07-05T04:22:30.105414+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_qwen2.5-coder_1.5b_openai_direct.json
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_qwen2.5-coder_1.5b_openai_direct.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T04:21:55.739162+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "qwen2.5-coder:1.5b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 100,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 1.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/archive-v2.7.1/results_live_qwen2.5-coder_1.5b_openai_direct.md
+++ b/benchmarks/tool-repair/results/archive-v2.7.1/results_live_qwen2.5-coder_1.5b_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — qwen2.5-coder:1.5b
+
+- Generated: 2026-07-05T04:21:55.739162+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 100 | 100.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 20 | 0 | 0 |
+| complex_args | 0 | 20 | 0 | 0 |
+| multi_tool_select | 0 | 20 | 0 | 0 |
+| japanese_instruction | 0 | 20 | 0 | 0 |
+| no_tool_temptation | 0 | 20 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```

--- a/benchmarks/tool-repair/results/results_live_gemma4_26b_anthropic_chain.json
+++ b/benchmarks/tool-repair/results/results_live_gemma4_26b_anthropic_chain.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T06:26:31.784773+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "gemma4:26b",
+  "temperature": "0",
+  "profile": "bench-gemma-chain",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/results_live_gemma4_26b_anthropic_chain.md
+++ b/benchmarks/tool-repair/results/results_live_gemma4_26b_anthropic_chain.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — gemma4:26b
+
+- Generated: 2026-07-05T06:26:31.784773+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/results_live_llama3.1_8b_openai_direct.json
+++ b/benchmarks/tool-repair/results/results_live_llama3.1_8b_openai_direct.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T04:24:06.990782+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "llama3.1:8b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/results_live_llama3.1_8b_openai_direct.md
+++ b/benchmarks/tool-repair/results/results_live_llama3.1_8b_openai_direct.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — llama3.1:8b
+
+- Generated: 2026-07-05T04:24:06.990782+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/results_live_llama3.2_3b_openai_direct.json
+++ b/benchmarks/tool-repair/results/results_live_llama3.2_3b_openai_direct.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T04:17:25.537033+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "llama3.2:3b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/results_live_llama3.2_3b_openai_direct.md
+++ b/benchmarks/tool-repair/results/results_live_llama3.2_3b_openai_direct.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — llama3.2:3b
+
+- Generated: 2026-07-05T04:17:25.537033+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/results_live_mistral_7b_anthropic_coderouter-r4.json
+++ b/benchmarks/tool-repair/results/results_live_mistral_7b_anthropic_coderouter-r4.json
@@ -1,0 +1,59 @@
+{
+  "generated_at": "2026-07-05T05:37:28.520696+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "mistral:7b",
+  "temperature": "0",
+  "profile": "bench-mistral7b",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 100,
+    "repair": 0,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 1.0,
+    "repair_rate": 0.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": []
+}

--- a/benchmarks/tool-repair/results/results_live_mistral_7b_anthropic_coderouter-r4.md
+++ b/benchmarks/tool-repair/results/results_live_mistral_7b_anthropic_coderouter-r4.md
@@ -1,0 +1,29 @@
+# L2 Live Tool-Call Benchmark — mistral:7b
+
+- Generated: 2026-07-05T05:37:28.520696+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 100 | 100.0% |
+| repair | 0 | 0.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 20 | 0 | 0 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+_all responses were native tool_calls_

--- a/benchmarks/tool-repair/results/results_live_mistral_7b_openai_direct.json
+++ b/benchmarks/tool-repair/results/results_live_mistral_7b_openai_direct.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T04:20:04.457860+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "mistral:7b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 80,
+    "fail": 20,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 0.8,
+    "fail_rate": 0.2
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "repair",
+      "text_sample": " [{\"name\":\"echo\",\"arguments\":{\"message\":\"probe\"}}]"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/results_live_mistral_7b_openai_direct.md
+++ b/benchmarks/tool-repair/results/results_live_mistral_7b_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — mistral:7b
+
+- Generated: 2026-07-05T04:20:04.457860+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 80 | 80.0% |
+| fail | 20 | 20.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 20 | 0 | 0 |
+| complex_args | 0 | 20 | 0 | 0 |
+| multi_tool_select | 0 | 20 | 0 | 0 |
+| japanese_instruction | 0 | 20 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]
+- `simple_echo` [repair]:  [{"name":"echo","arguments":{"message":"probe"}}]

--- a/benchmarks/tool-repair/results/results_live_phi4-mini_latest_anthropic_coderouter-r4.json
+++ b/benchmarks/tool-repair/results/results_live_phi4-mini_latest_anthropic_coderouter-r4.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T05:40:49.162037+00:00",
+  "base_url": "http://localhost:8088",
+  "wire": "anthropic",
+  "model": "phi4-mini:latest",
+  "temperature": "0",
+  "profile": "bench-phi4mini",
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 80,
+    "repair": 0,
+    "fail": 20,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.8,
+    "repair_rate": 0.0,
+    "fail_rate": 0.2
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 20,
+      "repair": 0,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "complex_args",
+      "rep": 0,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 1,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 2,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 3,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 4,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 5,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 6,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 7,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 8,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 9,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 10,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 11,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 12,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 13,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 14,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 15,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 16,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 17,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 18,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    },
+    {
+      "prompt": "complex_args",
+      "rep": 19,
+      "verdict": "fail",
+      "text_sample": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/results_live_phi4-mini_latest_anthropic_coderouter-r4.md
+++ b/benchmarks/tool-repair/results/results_live_phi4-mini_latest_anthropic_coderouter-r4.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — phi4-mini:latest
+
+- Generated: 2026-07-05T05:40:49.162037+00:00
+- Endpoint: http://localhost:8088  (wire=anthropic)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 80 | 80.0% |
+| repair | 0 | 0.0% |
+| fail | 20 | 20.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 20 | 0 | 0 | 0 |
+| complex_args | 0 | 0 | 20 | 0 |
+| multi_tool_select | 20 | 0 | 0 | 0 |
+| japanese_instruction | 20 | 0 | 0 | 0 |
+| no_tool_temptation | 20 | 0 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})
+- `complex_args` [fail]: write_note({"path":"notes/日本語.txt","text":"line1\ndefine("quotes", 1234) and a comma, plus {braces}\n"})

--- a/benchmarks/tool-repair/results/results_live_phi4-mini_latest_openai_direct.json
+++ b/benchmarks/tool-repair/results/results_live_phi4-mini_latest_openai_direct.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T04:26:25.945017+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "phi4-mini:latest",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 40,
+    "fail": 60,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 0.4,
+    "fail_rate": 0.6
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 0,
+      "fail": 20,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "repair",
+      "text_sample": "```json\n{\"name\": \"echo\", \"parameters\": {\"message\": \"probe\"}}\n```"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/results_live_phi4-mini_latest_openai_direct.md
+++ b/benchmarks/tool-repair/results/results_live_phi4-mini_latest_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — phi4-mini:latest
+
+- Generated: 2026-07-05T04:26:25.945017+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 40 | 40.0% |
+| fail | 60 | 60.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 20 | 0 | 0 |
+| complex_args | 0 | 0 | 20 | 0 |
+| multi_tool_select | 0 | 0 | 20 | 0 |
+| japanese_instruction | 0 | 20 | 0 | 0 |
+| no_tool_temptation | 0 | 0 | 20 | 0 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```
+- `simple_echo` [repair]: ```json {"name": "echo", "parameters": {"message": "probe"}} ```

--- a/benchmarks/tool-repair/results/results_live_qwen2.5-coder_1.5b_openai_direct.json
+++ b/benchmarks/tool-repair/results/results_live_qwen2.5-coder_1.5b_openai_direct.json
@@ -1,0 +1,180 @@
+{
+  "generated_at": "2026-07-05T04:21:55.739162+00:00",
+  "base_url": "http://localhost:11434/v1",
+  "wire": "openai",
+  "model": "qwen2.5-coder:1.5b",
+  "temperature": "0",
+  "profile": null,
+  "reps": 20,
+  "prompts": [
+    "simple_echo",
+    "complex_args",
+    "multi_tool_select",
+    "japanese_instruction",
+    "no_tool_temptation"
+  ],
+  "totals": {
+    "native": 0,
+    "repair": 100,
+    "fail": 0,
+    "error": 0,
+    "total": 100,
+    "native_rate": 0.0,
+    "repair_rate": 1.0,
+    "fail_rate": 0.0
+  },
+  "per_prompt": {
+    "simple_echo": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "complex_args": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "multi_tool_select": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "japanese_instruction": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    },
+    "no_tool_temptation": {
+      "native": 0,
+      "repair": 20,
+      "fail": 0,
+      "error": 0
+    }
+  },
+  "samples": [
+    {
+      "prompt": "simple_echo",
+      "rep": 0,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 1,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 2,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 3,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 4,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 5,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 6,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 7,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 8,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 9,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 10,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 11,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 12,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 13,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 14,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 15,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 16,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 17,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 18,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    },
+    {
+      "prompt": "simple_echo",
+      "rep": 19,
+      "verdict": "repair",
+      "text_sample": "```json\n{\n  \"name\": \"echo\",\n  \"arguments\": {\n    \"message\": \"probe\"\n  }\n}\n```"
+    }
+  ]
+}

--- a/benchmarks/tool-repair/results/results_live_qwen2.5-coder_1.5b_openai_direct.md
+++ b/benchmarks/tool-repair/results/results_live_qwen2.5-coder_1.5b_openai_direct.md
@@ -1,0 +1,48 @@
+# L2 Live Tool-Call Benchmark — qwen2.5-coder:1.5b
+
+- Generated: 2026-07-05T04:21:55.739162+00:00
+- Endpoint: http://localhost:11434/v1  (wire=openai)
+- Reps per prompt: 20   Prompts: simple_echo, complex_args, multi_tool_select, japanese_instruction, no_tool_temptation
+- Total responses: 100
+
+## Totals
+
+| verdict | count | rate |
+|---|---|---|
+| native | 0 | 0.0% |
+| repair | 100 | 100.0% |
+| fail | 0 | 0.0% |
+| error | 0 | — |
+
+## Per-prompt
+
+| prompt | native | repair | fail | error |
+|---|---|---|---|---|
+| simple_echo | 0 | 20 | 0 | 0 |
+| complex_args | 0 | 20 | 0 | 0 |
+| multi_tool_select | 0 | 20 | 0 | 0 |
+| japanese_instruction | 0 | 20 | 0 | 0 |
+| no_tool_temptation | 0 | 20 | 0 | 0 |
+
+## Sample non-native / failed responses
+
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```
+- `simple_echo` [repair]: ```json {   "name": "echo",   "arguments": {     "message": "probe"   } } ```

--- a/benchmarks/tool-repair/results/results_offline.json
+++ b/benchmarks/tool-repair/results/results_offline.json
@@ -1,13 +1,13 @@
 {
-  "generated_at": "2026-07-04T23:46:03.699617+00:00",
-  "total_cases": 55,
+  "generated_at": "2026-07-05T06:33:13.469742+00:00",
+  "total_cases": 84,
   "overall": {
-    "recovered": 43,
-    "correct_pass": 12,
+    "recovered": 59,
+    "correct_pass": 25,
     "missed": 0,
     "false_positive": 0,
-    "positives": 43,
-    "negatives": 12,
+    "positives": 59,
+    "negatives": 25,
     "recall": 1.0,
     "false_positive_rate": 0.0
   },
@@ -43,11 +43,11 @@
       "false_positive_rate": null
     },
     "malformed": {
-      "recovered": 9,
+      "recovered": 11,
       "correct_pass": 0,
       "missed": 0,
       "false_positive": 0,
-      "positives": 9,
+      "positives": 11,
       "negatives": 0,
       "recall": 1.0,
       "false_positive_rate": null
@@ -84,11 +84,11 @@
     },
     "negative": {
       "recovered": 0,
-      "correct_pass": 12,
+      "correct_pass": 24,
       "missed": 0,
       "false_positive": 0,
       "positives": 0,
-      "negatives": 12,
+      "negatives": 24,
       "recall": null,
       "false_positive_rate": 0.0
     },
@@ -101,6 +101,36 @@
       "negatives": 0,
       "recall": 1.0,
       "false_positive_rate": null
+    },
+    "nested_xml": {
+      "recovered": 5,
+      "correct_pass": 0,
+      "missed": 0,
+      "false_positive": 0,
+      "positives": 5,
+      "negatives": 0,
+      "recall": 1.0,
+      "false_positive_rate": null
+    },
+    "json_wrappers": {
+      "recovered": 4,
+      "correct_pass": 0,
+      "missed": 0,
+      "false_positive": 0,
+      "positives": 4,
+      "negatives": 0,
+      "recall": 1.0,
+      "false_positive_rate": null
+    },
+    "python_call": {
+      "recovered": 5,
+      "correct_pass": 1,
+      "missed": 0,
+      "false_positive": 0,
+      "positives": 5,
+      "negatives": 1,
+      "recall": 1.0,
+      "false_positive_rate": 0.0
     }
   },
   "cases": [
@@ -853,6 +883,388 @@
       "cleaned_text": "```python\nresult = {'name': 'echo', 'level': 'info'}\nprint(result)\n```",
       "dedup_verified": null,
       "note": "```python fence with a single-quoted dict that has an allow-listed 'name' but NO arguments/parameters key. Lenient parser must still enforce shape+fence guard. Must NOT repair."
+    },
+    {
+      "id": "nested_xml_01_tools_function",
+      "category": "nested_xml",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['echo']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "echo"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "L2 default-temp residual fail (2026-07-04). Tag is container; tool name lives in the name attribute. R4 target #1."
+    },
+    {
+      "id": "nested_xml_02_double_quote_args",
+      "category": "nested_xml",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['Bash']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "Bash"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "Nested form with double-quoted (escaped) arguments attribute."
+    },
+    {
+      "id": "nested_xml_03_bare_function_tag",
+      "category": "nested_xml",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['echo']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "echo"
+      ],
+      "cleaned_text": "I'll run it now.",
+      "dedup_verified": null,
+      "note": "Bare <function> tag without <tools> container, prose before."
+    },
+    {
+      "id": "nested_xml_04_tool_tag_name_attr",
+      "category": "nested_xml",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['read_file']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "read_file"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "Generic <tool> tag with name attribute and args (not arguments) key."
+    },
+    {
+      "id": "nested_xml_05_multiple_functions",
+      "category": "nested_xml",
+      "outcome": "recovered",
+      "reason": "produced 2 call(s): ['echo', 'echo']",
+      "expect_repaired": true,
+      "produced_calls": 2,
+      "produced_names": [
+        "echo",
+        "echo"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "Two calls inside one <tools> container."
+    },
+    {
+      "id": "json_wrappers_01_tool_calls_array",
+      "category": "json_wrappers",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['echo']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "echo"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "Model echoes the OpenAI response envelope as text (Llama pattern). R4 target #2."
+    },
+    {
+      "id": "json_wrappers_02_function_call_legacy",
+      "category": "json_wrappers",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['echo']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "echo"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "OpenAI legacy function_call shape; arguments is a JSON string (double parse needed). R4 target #3."
+    },
+    {
+      "id": "json_wrappers_03_fenced_two_calls",
+      "category": "json_wrappers",
+      "outcome": "recovered",
+      "reason": "produced 2 call(s): ['echo', 'echo']",
+      "expect_repaired": true,
+      "produced_calls": 2,
+      "produced_names": [
+        "echo",
+        "echo"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "Fenced envelope with two calls in the array."
+    },
+    {
+      "id": "json_wrappers_04_top_level_array",
+      "category": "json_wrappers",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['echo']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "echo"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "Bare top-level JSON array of call objects."
+    },
+    {
+      "id": "python_call_01_tool_code_default_api",
+      "category": "python_call",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['echo']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "echo"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "Gemma tool_code idiom: python kwargs call wrapped in print(default_api.*). R4 target #4 — repair ONLY inside tool_code fence."
+    },
+    {
+      "id": "python_call_02_tool_code_plain",
+      "category": "python_call",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['echo']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "echo"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "tool_code fence, plain kwargs call without default_api prefix."
+    },
+    {
+      "id": "malformed_10_index_field",
+      "category": "malformed",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['echo']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "echo"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "Gemma-style extra index field. Verified working 2026-07-05 — regression guard."
+    },
+    {
+      "id": "malformed_11_trailing_garbage",
+      "category": "malformed",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['echo']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "echo"
+      ],
+      "cleaned_text": "###END_OF_TURN###",
+      "dedup_verified": null,
+      "note": "Mistral-style gibberish/sentinel appended after valid call JSON."
+    },
+    {
+      "id": "negative_13_bare_python_call",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "You can invoke it directly, e.g. echo(message=\"probe\") returns the same string.",
+      "dedup_verified": null,
+      "note": "Bare python-call syntax in prose. Too ambiguous outside a tool_code fence — must NOT repair (safe side)."
+    },
+    {
+      "id": "negative_14_command_style",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "Run this:\necho --message \"probe\"",
+      "dedup_verified": null,
+      "note": "Mistral command-style text. Indistinguishable from shell instructions to the user — permanently out of repair scope (2026-07-05 弱点分析 #5)."
+    },
+    {
+      "id": "python_call_03_untagged_fence_kwargs",
+      "category": "python_call",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['echo']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "echo"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "呼び出し構文族: Python kwargs形・無タグフェンス。tool_code フェンス外でも fence+allowed名なら修復対象(R4 スコープ拡大判断 2026-07-05)。"
+    },
+    {
+      "id": "python_call_04_colon_style_mistral",
+      "category": "python_call",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['echo']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "echo"
+      ],
+      "cleaned_text": "The `echo` function echoes back the provided message.",
+      "dedup_verified": null,
+      "note": "呼び出し構文族: コロン区切り(Ruby/Swift風)。mistral:7b L3 実測形(no_tool_temptation 20/20)。説明文+呼びの境界例 — negative_15 と両立できなければ本ケースを stretch に降格(FP 0% 優先)。"
+    },
+    {
+      "id": "python_call_05_json_object_arg",
+      "category": "python_call",
+      "outcome": "recovered",
+      "reason": "produced 1 call(s): ['write_note']",
+      "expect_repaired": true,
+      "produced_calls": 1,
+      "produced_names": [
+        "write_note"
+      ],
+      "cleaned_text": "",
+      "dedup_verified": null,
+      "note": "呼び出し構文族: JSONオブジェクト引数(JS風)・単独行。phi4-mini L3 実測形の健全版。内部JSONがパース可能な場合のみ修復。"
+    },
+    {
+      "id": "python_call_06_corrupted_inner_json",
+      "category": "python_call",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "write_note({\"path\":\"notes/日本語.txt\",\"text\":\"line1\\ndefine(\"quotes\", 1234) and a comma, plus {braces}\\n\"})",
+      "dedup_verified": null,
+      "note": "phi4-mini L3 実測の生データ: 内部JSONが引用符ネスト崩壊でパース不能。形だけ直すと壊れた引数で実行される — 修復しないのが安全側(意味崩壊は修復層の対象外、2026-07-05 設計判断)。"
+    },
+    {
+      "id": "negative_15_example_cue_call_syntax",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "For example, you would write:\n\n```\necho(message: 'demo')\n```\n\nbut don't actually run it now — this is just the syntax.",
+      "dedup_verified": null,
+      "note": "呼び出し構文族の FP ガード: 明示的な例示cue(For example / don't run)付き。python_call_04 との弁別が R4 の最難関 — 両立不能なら negative が勝つ。"
+    },
+    {
+      "id": "negative_16_inline_prose_call_syntax",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "The echo(message) signature takes one string; calling echo(message=\"hi\") simply returns \"hi\" unchanged.",
+      "dedup_verified": null,
+      "note": "呼び出し構文族の FP ガード: 文中インラインの呼び形(フェンス無し・独立行でもない)。散文に埋まった形は修復しない。"
+    },
+    {
+      "id": "negative_17_below_convention",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "Below is the calling convention.\n\n```\necho(message: 'demo')\n```",
+      "dedup_verified": null,
+      "note": "Sonnetレビュー反例A3系: 'calling convention' はドキュメント文脈cue。cue辞書拡充の回帰ゲート。"
+    },
+    {
+      "id": "negative_18_as_follows",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "The calling convention is as follows:\n\n```\necho(message=\"demo\")\n```",
+      "dedup_verified": null,
+      "note": "Sonnetレビュー反例A4: 'as follows:' cue。"
+    },
+    {
+      "id": "negative_19_sample_payload_envelope",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "Here's a sample response payload you might receive:\n{\"tool_calls\": [{\"name\": \"echo\", \"arguments\": {\"message\": \"example\"}}]}",
+      "dedup_verified": null,
+      "note": "Sonnetレビュー反例C1: 'sample ... payload' cue付きJSONエンベロープ例示(R4bのFPガード)。"
+    },
+    {
+      "id": "negative_20_this_format_fenced",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "The button config uses this format:\n\n```\necho(message: 'demo')\n```",
+      "dedup_verified": null,
+      "note": "Sonnetレビュー反例A15: 'this format:' cue。"
+    },
+    {
+      "id": "negative_21_long_leadin_for_example",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "For example, here is a very very very very very very very very long lead-in sentence that goes on and on before finally showing the call:\n\n```\necho(message=\"probe\")\n```",
+      "dedup_verified": null,
+      "note": "Sonnetレビュー反例A14: cue検出窓80文字問題の回帰ゲート(窓拡大 or 行頭検査で抑止すべき)。"
+    },
+    {
+      "id": "negative_22_xml_doc_example",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "Here's how function calls look in this format:\n<function name=\"echo\" arguments='{\"message\":\"x\"}'/>",
+      "dedup_verified": null,
+      "note": "Sonnetレビュー反例B3: 言い回し違いの例示cue(R4aのFPガード)。"
+    },
+    {
+      "id": "negative_23_sample_payload_blankline",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "Here's a sample response payload you might receive:\n\n{\"tool_calls\": [{\"name\": \"echo\", \"arguments\": {\"message\": \"example\"}}]}",
+      "dedup_verified": null,
+      "note": "再レビュー発見: negative_19 の空行(\\n\\n)バリアント。cue検出窓バグ(window(1)アンカー+window(2) pop off-by-one)の回帰ゲート。"
+    },
+    {
+      "id": "negative_24_xml_doc_example_blankline",
+      "category": "negative",
+      "outcome": "correct_pass",
+      "reason": "no tool call produced, as expected",
+      "expect_repaired": false,
+      "produced_calls": 0,
+      "produced_names": [],
+      "cleaned_text": "Here's how function calls look in this format:\n\n<function name=\"echo\" arguments='{\"message\":\"x\"}'/>",
+      "dedup_verified": null,
+      "note": "再レビュー発見: negative_22 の空行バリアント(XML経路)。同上の回帰ゲート。"
     }
   ]
 }

--- a/benchmarks/tool-repair/results/results_offline.md
+++ b/benchmarks/tool-repair/results/results_offline.md
@@ -1,10 +1,10 @@
 # L1 Offline Tool-Repair Benchmark
 
-- Generated: 2026-07-04T23:46:03.699617+00:00
-- Total cases: 55
-- Overall recall (recovered / expect-repair): 43/43 = 100.0%
-- Overall false-positive rate (fp / expect-pass): 0/12 = 0.0%
-- Missed: 0  |  Correct-pass: 12
+- Generated: 2026-07-05T06:33:13.469742+00:00
+- Total cases: 84
+- Overall recall (recovered / expect-repair): 59/59 = 100.0%
+- Overall false-positive rate (fp / expect-pass): 0/25 = 0.0%
+- Missed: 0  |  Correct-pass: 25
 
 ## Per-category
 
@@ -13,12 +13,15 @@
 | fenced_json | 6 | 6 | 0 | 100.0% | 0 | 0 | n/a |
 | bare_json | 5 | 5 | 0 | 100.0% | 0 | 0 | n/a |
 | multiple_calls | 6 | 6 | 0 | 100.0% | 0 | 0 | n/a |
-| malformed | 9 | 9 | 0 | 100.0% | 0 | 0 | n/a |
+| malformed | 11 | 11 | 0 | 100.0% | 0 | 0 | n/a |
 | nested_fence | 4 | 4 | 0 | 100.0% | 0 | 0 | n/a |
 | thinking_leak | 4 | 4 | 0 | 100.0% | 0 | 0 | n/a |
 | cjk_arguments | 4 | 4 | 0 | 100.0% | 0 | 0 | n/a |
-| negative | 12 | 0 | 0 | n/a | 12 | 0 | 0.0% |
+| negative | 24 | 0 | 0 | n/a | 24 | 0 | 0.0% |
 | xml_forms | 5 | 5 | 0 | 100.0% | 0 | 0 | n/a |
+| nested_xml | 5 | 5 | 0 | 100.0% | 0 | 0 | n/a |
+| json_wrappers | 4 | 4 | 0 | 100.0% | 0 | 0 | n/a |
+| python_call | 6 | 5 | 0 | 100.0% | 1 | 0 | 0.0% |
 
 ## Missed cases (0)
 


### PR DESCRIPTION
… assets

- providers.bench.yaml: extend to the full L3 model matrix (llama3.2/3.1, mistral, qwen2.5-coder:1.5b, phi4-mini + the original three), gemma3:27b documented as excluded (no tools capability in the Ollama build), chain profile included commented-out pending empty_response_action merge
- bench_l3_p1.sh: one-shot direct-vs-router matrix runner (REPS/P2 env vars)
- results/: latest evidence set — R4 runs (mistral 100%, phi4-mini 80%), empty-response fallback chain run (gemma4 100%), direct baselines for the new models; repairer-version A/B snapshots under archive-v2.7.0/ and archive-v2.7.1/; results_offline regenerated on the 84-case corpus (recall 59/59, FP 0/25)
- README: 2026-07-05 version-A/B results table + three-tier reading, corpus counts updated (84 cases, 25 negatives)