### PR TITLE
feat(ingress): /v1/models passthrough of upstream model ids for empty…

### DIFF
--- a/coderouter/ingress/openai_routes.py
+++ b/coderouter/ingress/openai_routes.py
@@ -78,22 +78,99 @@ def _resolve_stream_timeout_s(engine: FallbackEngine, profile: str | None) -> fl
     return max(_STREAM_TIMEOUT_MIN_S, float(per_call) * _STREAM_TIMEOUT_MULTIPLIER)
 
 
+# --- /v1/models upstream passthrough -------------------------------------
+#
+# Providers with an *empty* ``model`` field are passthrough providers: the
+# upstream (llama-server, LM Studio, ...) decides which model is loaded and
+# CodeRouter never sends a model name. For those providers the historic
+# behaviour — returning the provider *name* — makes external benchmarks
+# indistinguishable across loaded GGUFs (the launcher_gui setup always
+# reported ``llama-cpp-local`` regardless of the selected model). We now ask
+# the upstream's own ``/models`` endpoint for its real model id(s) and
+# surface those instead.
+#
+# Guards: only for ``kind == "openai_compat"`` with ``model == ""``; a short
+# per-upstream TTL cache keeps repeated SDK probes cheap; ANY failure (refused
+# connection, timeout, unexpected shape) falls back to the historic
+# provider-name entry, so this is strictly additive. Providers with a
+# configured model keep the exact previous behaviour.
+
+_UPSTREAM_MODELS_TTL_S = 30.0
+_UPSTREAM_MODELS_TIMEOUT_S = 2.0
+# base_url -> (expires_monotonic, ids)
+_upstream_models_cache: dict[str, tuple[float, list[str]]] = {}
+
+
+async def _fetch_upstream_model_ids(base_url: str) -> list[str]:
+    """GET {base_url}/models and return the upstream model ids.
+
+    Raises on any transport / shape problem — the caller treats every
+    exception as "fall back to the provider-name entry".
+    """
+    import httpx  # local import keeps module import time flat
+
+    url = base_url.rstrip("/") + "/models"
+    async with httpx.AsyncClient(timeout=_UPSTREAM_MODELS_TIMEOUT_S) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        payload = resp.json()
+    ids = [
+        str(item["id"])
+        for item in payload.get("data", [])
+        if isinstance(item, dict) and item.get("id")
+    ]
+    if not ids:
+        raise ValueError(f"upstream {url} returned no model ids")
+    return ids
+
+
+async def _upstream_model_ids_cached(base_url: str) -> list[str]:
+    """TTL-cached wrapper around :func:`_fetch_upstream_model_ids`."""
+    now = time.monotonic()
+    hit = _upstream_models_cache.get(base_url)
+    if hit is not None and hit[0] > now:
+        return hit[1]
+    ids = await _fetch_upstream_model_ids(base_url)
+    _upstream_models_cache[base_url] = (now + _UPSTREAM_MODELS_TTL_S, ids)
+    return ids
+
+
 @router.get("/models")
 async def list_models(request: Request) -> dict[str, object]:
-    """Minimal /v1/models so OpenAI SDKs that probe it don't choke."""
+    """/v1/models: provider names, with upstream passthrough for empty-model
+    providers (see the passthrough note above)."""
     config = request.app.state.config
-    return {
-        "object": "list",
-        "data": [
+    created = int(time.time())
+    data: list[dict[str, object]] = []
+    for p in config.providers:
+        if p.model == "" and p.kind == "openai_compat":
+            try:
+                ids = await _upstream_model_ids_cached(str(p.base_url))
+            except Exception:  # any failure means "no passthrough"
+                logger.debug(
+                    "models passthrough failed; falling back to provider name",
+                    extra={"provider": p.name},
+                )
+            else:
+                data.extend(
+                    {
+                        "id": model_id,
+                        "object": "model",
+                        "created": created,
+                        "owned_by": f"coderouter/{p.name}",
+                    }
+                    for model_id in ids
+                )
+                continue
+        data.append(
             {
                 "id": p.name,
                 "object": "model",
-                "created": int(time.time()),
+                "created": created,
                 "owned_by": "coderouter",
             }
-            for p in config.providers
-        ],
-    }
+        )
+    return {"object": "list", "data": data}
 
 
 @router.post("/chat/completions", response_model=None)

--- a/tests/test_models_passthrough.py
+++ b/tests/test_models_passthrough.py
@@ -1,0 +1,144 @@
+"""Tests for /v1/models upstream passthrough (empty-model providers).
+
+A provider whose ``model`` field is empty (the launcher_gui llama-server
+setup) is a passthrough provider: the upstream decides which model is
+loaded. /v1/models should surface the upstream's real model id(s) for such
+providers so external benchmarks can tell loaded GGUFs apart, while keeping
+the historic provider-name entries for everything else — and falling back
+to the provider name whenever the upstream cannot be reached.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from coderouter.config.schemas import CodeRouterConfig, FallbackChain, ProviderConfig
+from coderouter.ingress import openai_routes
+from coderouter.ingress.app import create_app
+
+
+def _config(*providers: ProviderConfig) -> CodeRouterConfig:
+    return CodeRouterConfig(
+        allow_paid=False,
+        default_profile="default",
+        providers=list(providers),
+        profiles=[FallbackChain(name="default", providers=[providers[0].name])],
+    )
+
+
+def _client(
+    config: CodeRouterConfig, monkeypatch: pytest.MonkeyPatch
+) -> TestClient:
+    monkeypatch.setattr(
+        "coderouter.ingress.app.load_config", lambda path=None: config
+    )
+    app = create_app()
+    app.state.config = config
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    openai_routes._upstream_models_cache.clear()
+
+
+def _passthrough_provider(name: str = "llama-cpp-local") -> ProviderConfig:
+    return ProviderConfig(
+        name=name,
+        base_url="http://localhost:8080/v1",
+        model="",  # passthrough — llama-server decides the model
+    )
+
+
+def _named_provider(name: str = "ollama-qwen") -> ProviderConfig:
+    return ProviderConfig(
+        name=name,
+        base_url="http://localhost:11434/v1",
+        model="qwen2.5-coder:7b",
+    )
+
+
+def test_empty_model_provider_surfaces_upstream_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(base_url: str) -> list[str]:
+        assert base_url == "http://localhost:8080/v1"
+        return ["qwen2.5-coder-7b-q4_k_m.gguf"]
+
+    monkeypatch.setattr(openai_routes, "_fetch_upstream_model_ids", fake_fetch)
+    client = _client(_config(_passthrough_provider()), monkeypatch)
+
+    body = client.get("/v1/models").json()
+    ids = [m["id"] for m in body["data"]]
+    assert ids == ["qwen2.5-coder-7b-q4_k_m.gguf"]
+    assert body["data"][0]["owned_by"] == "coderouter/llama-cpp-local"
+
+
+def test_named_model_provider_keeps_historic_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_fetch(base_url: str) -> list[str]:  # pragma: no cover
+        raise AssertionError("passthrough must not fire for named models")
+
+    monkeypatch.setattr(openai_routes, "_fetch_upstream_model_ids", fail_fetch)
+    client = _client(_config(_named_provider()), monkeypatch)
+
+    body = client.get("/v1/models").json()
+    assert [m["id"] for m in body["data"]] == ["ollama-qwen"]
+    assert body["data"][0]["owned_by"] == "coderouter"
+
+
+def test_upstream_failure_falls_back_to_provider_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(base_url: str) -> list[str]:
+        raise ConnectionError("upstream down")
+
+    monkeypatch.setattr(openai_routes, "_fetch_upstream_model_ids", fake_fetch)
+    client = _client(_config(_passthrough_provider()), monkeypatch)
+
+    body = client.get("/v1/models").json()
+    assert [m["id"] for m in body["data"]] == ["llama-cpp-local"]
+    assert body["data"][0]["owned_by"] == "coderouter"
+
+
+def test_mixed_providers_mix_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(base_url: str) -> list[str]:
+        return ["loaded-model.gguf"]
+
+    monkeypatch.setattr(openai_routes, "_fetch_upstream_model_ids", fake_fetch)
+    client = _client(
+        _config(_passthrough_provider(), _named_provider()), monkeypatch
+    )
+
+    body = client.get("/v1/models").json()
+    assert [m["id"] for m in body["data"]] == ["loaded-model.gguf", "ollama-qwen"]
+
+
+def test_upstream_ids_are_ttl_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def fake_fetch(base_url: str) -> list[str]:
+        calls.append(base_url)
+        return ["loaded-model.gguf"]
+
+    monkeypatch.setattr(openai_routes, "_fetch_upstream_model_ids", fake_fetch)
+    client = _client(_config(_passthrough_provider()), monkeypatch)
+
+    client.get("/v1/models")
+    client.get("/v1/models")
+    assert len(calls) == 1, "second probe within the TTL must hit the cache"
+
+
+def test_multiple_upstream_ids_all_listed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(base_url: str) -> list[str]:
+        return ["model-a.gguf", "model-b.gguf"]
+
+    monkeypatch.setattr(openai_routes, "_fetch_upstream_model_ids", fake_fetch)
+    client = _client(_config(_passthrough_provider()), monkeypatch)
+
+    body = client.get("/v1/models").json()
+    assert [m["id"] for m in body["data"]] == ["model-a.gguf", "model-b.gguf"]


### PR DESCRIPTION
…-model providers

Providers with an empty `model` field (the launcher_gui llama-server setup) are passthrough providers — the upstream decides which model is loaded, and /v1/models used to return only the static provider name (e.g. 'llama-cpp-local'), making external benchmarks indistinguishable across loaded GGUFs.

Now, for kind=openai_compat providers with model == "", /v1/models queries the upstream's own /models endpoint (2s timeout, 30s TTL cache) and surfaces the real model id(s) with owned_by=coderouter/<provider>. Any failure falls back to the historic provider-name entry; providers with a configured model keep the exact previous shape. Strictly additive, no new dependencies.

6 new tests (passthrough, historic shape, failure fallback, mixed, TTL cache, multi-id).