### PR TITLE
feat(launcher): auto-register started backends as routable providers

### DIFF
--- a/coderouter/ingress/launcher_routes.py
+++ b/coderouter/ingress/launcher_routes.py
@@ -655,6 +655,28 @@ async def api_backends(request: Request) -> dict[str, Any]:
     return {"backends": result}
 
 
+def _launcher_provider_config(backend: str, port: int) -> Any:
+    """Build the provider entry for a launcher-started backend.
+
+    ``model`` is left EMPTY on purpose: llama-server / vllm / mlx decide
+    which model is actually loaded, and the empty-model /v1/models
+    passthrough then surfaces the upstream's real model id to benchmark
+    clients — swap the GGUF, no config edit needed.
+
+    Name embeds backend + port (``launcher-llamacpp-8085``) so restarting
+    on the same port REPLACES the entry instead of piling up duplicates.
+    """
+    from coderouter.config.schemas import ProviderConfig
+
+    safe_backend = backend.replace(".", "")
+    return ProviderConfig(
+        name=f"launcher-{safe_backend}-{port}",
+        base_url=f"http://localhost:{port}/v1",
+        model="",
+        timeout_s=120.0,
+    )
+
+
 @router.post("/api/launcher/start")
 async def api_start(req: StartRequest, request: Request) -> dict[str, Any]:
     """Start a new backend process."""
@@ -717,7 +739,35 @@ async def api_start(req: StartRequest, request: Request) -> dict[str, Any]:
     _background_tasks.add(_task)
     _task.add_done_callback(_background_tasks.discard)
 
-    return {"id": proc_id, "pid": p.pid, "command": cmd}
+    # Provider auto-sync: register the just-started backend as a routable
+    # provider so requests can reach it without hand-editing providers.yaml
+    # (in-memory only — see FallbackEngine.register_provider docstring).
+    # Sync failure must never fail the start itself.
+    provider_sync: dict[str, Any] | None = None
+    engine = getattr(request.app.state, "engine", None)
+    if engine is not None and hasattr(engine, "register_provider"):
+        try:
+            provider_sync = engine.register_provider(
+                _launcher_provider_config(req.backend, req.port)
+            )
+            proc.log_tail.append(
+                "[launcher] provider sync: "
+                f"{provider_sync['provider']} -> profile "
+                f"'{provider_sync['profile']}' (in-memory)"
+            )
+        except Exception as exc:
+            logger.warning(
+                "launcher provider sync failed",
+                extra={"backend": req.backend, "port": req.port, "error": str(exc)},
+            )
+            proc.log_tail.append(f"[launcher] provider sync failed: {exc}")
+
+    return {
+        "id": proc_id,
+        "pid": p.pid,
+        "command": cmd,
+        "provider_sync": provider_sync,
+    }
 
 
 @router.post("/api/launcher/stop/{proc_id}")

--- a/coderouter/routing/fallback.py
+++ b/coderouter/routing/fallback.py
@@ -1173,6 +1173,80 @@ class FallbackEngine:
         # v2.0-K: persistent state store (None = in-memory only).
         self._state_store: StateStore | None = None
 
+    def register_provider(
+        self, provider: ProviderConfig, profile_name: str = "launcher"
+    ) -> dict[str, Any]:
+        """Register (or update) a provider at runtime — launcher auto-sync.
+
+        Motivation: the embedded launcher can start a llama.cpp / vllm /
+        mlx backend on an arbitrary port, but routing is driven entirely
+        by providers.yaml — historically the operator had to hand-edit the
+        config or the new backend was simply unreachable (observed in the
+        wild as "launcher started on 8085, providers.yaml pointed at
+        8080"). This method closes that gap in-process:
+
+        - the provider entry is appended to ``config.providers`` (or, when
+          a provider with the same *name* already exists, its config entry
+          and cached adapter are REPLACED — the launcher restarting a
+          backend on the same port lands here),
+        - an adapter is built and cached alongside the static ones,
+        - the ``profile_name`` chain is created on demand, and the
+          provider is moved to the FRONT of that chain (most recently
+          launched backend wins the launcher profile).
+
+        Deliberately **in-memory only** — no providers.yaml rewrite. A
+        YAML round-trip would destroy operator comments (and a
+        comment-preserving writer means a new dependency), and the
+        launcher's process registry is itself in-memory by design: both
+        the process and its provider entry share the lifetime of this
+        server process. ``default_profile`` is never touched — routing to
+        the launcher profile stays an explicit opt-in
+        (``X-CodeRouter-Profile: launcher`` or body ``profile``).
+
+        Returns a small summary dict for the launcher API response.
+        """
+        from coderouter.config.schemas import FallbackChain
+
+        replaced = False
+        for i, existing in enumerate(self.config.providers):
+            if existing.name == provider.name:
+                self.config.providers[i] = provider
+                replaced = True
+                break
+        if not replaced:
+            self.config.providers.append(provider)
+        self._adapters[provider.name] = build_adapter(provider)
+
+        try:
+            chain = self.config.profile_by_name(profile_name)
+        except KeyError:
+            chain = FallbackChain(name=profile_name, providers=[provider.name])
+            self.config.profiles.append(chain)
+        else:
+            if provider.name in chain.providers:
+                chain.providers.remove(provider.name)
+            chain.providers.insert(0, provider.name)
+
+        logger.info(
+            "launcher provider sync: registered %s -> %s (profile %r)",
+            provider.name,
+            provider.base_url,
+            profile_name,
+            extra={
+                "provider": provider.name,
+                "base_url": str(provider.base_url),
+                "profile": profile_name,
+                "replaced": replaced,
+            },
+        )
+        return {
+            "provider": provider.name,
+            "base_url": str(provider.base_url),
+            "profile": profile_name,
+            "replaced": replaced,
+            "persisted": False,  # in-memory only, by design (see docstring)
+        }
+
     @property
     def plugins(self) -> PluginRegistry:
         """Return the plugin registry, lazily building an empty one if absent.

--- a/tests/test_launcher_provider_sync.py
+++ b/tests/test_launcher_provider_sync.py
@@ -1,0 +1,124 @@
+"""Tests for launcher provider auto-sync (FallbackEngine.register_provider).
+
+The embedded launcher starts backends on arbitrary ports, but routing is
+config-driven — before this feature the operator had to hand-edit
+providers.yaml (the observed failure: launcher on 8085, config pointing at
+8080). register_provider closes the gap in-memory: provider entry + adapter
++ a "launcher" profile whose head is always the most recently started
+backend. default_profile must never be touched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from coderouter.config.schemas import CodeRouterConfig, FallbackChain, ProviderConfig
+from coderouter.ingress.launcher_routes import _launcher_provider_config
+from coderouter.routing.fallback import FallbackEngine
+
+
+def _base_config() -> CodeRouterConfig:
+    return CodeRouterConfig(
+        allow_paid=False,
+        default_profile="default",
+        providers=[
+            ProviderConfig(
+                name="static-local",
+                base_url="http://localhost:11434/v1",
+                model="qwen2.5-coder:7b",
+            ),
+        ],
+        profiles=[FallbackChain(name="default", providers=["static-local"])],
+    )
+
+
+def _engine() -> FallbackEngine:
+    return FallbackEngine(_base_config())
+
+
+def test_register_new_provider_adds_config_adapter_and_profile() -> None:
+    engine = _engine()
+    summary = engine.register_provider(
+        _launcher_provider_config("llama.cpp", 8085)
+    )
+
+    names = [p.name for p in engine.config.providers]
+    assert "launcher-llamacpp-8085" in names
+    assert "launcher-llamacpp-8085" in engine._adapters
+    chain = engine.config.profile_by_name("launcher")
+    assert chain.providers == ["launcher-llamacpp-8085"]
+    assert summary["replaced"] is False
+    assert summary["persisted"] is False
+
+
+def test_reregister_same_name_replaces_instead_of_duplicating() -> None:
+    engine = _engine()
+    engine.register_provider(_launcher_provider_config("llama.cpp", 8085))
+    summary = engine.register_provider(
+        _launcher_provider_config("llama.cpp", 8085)
+    )
+
+    names = [p.name for p in engine.config.providers]
+    assert names.count("launcher-llamacpp-8085") == 1
+    chain = engine.config.profile_by_name("launcher")
+    assert chain.providers.count("launcher-llamacpp-8085") == 1
+    assert summary["replaced"] is True
+
+
+def test_most_recent_backend_moves_to_front_of_launcher_profile() -> None:
+    engine = _engine()
+    engine.register_provider(_launcher_provider_config("llama.cpp", 8085))
+    engine.register_provider(_launcher_provider_config("vllm", 8081))
+
+    chain = engine.config.profile_by_name("launcher")
+    assert chain.providers[0] == "launcher-vllm-8081"
+    assert chain.providers == ["launcher-vllm-8081", "launcher-llamacpp-8085"]
+
+
+def test_default_profile_is_never_touched() -> None:
+    engine = _engine()
+    engine.register_provider(_launcher_provider_config("llama.cpp", 8085))
+
+    assert engine.config.default_profile == "default"
+    default_chain = engine.config.profile_by_name("default")
+    assert default_chain.providers == ["static-local"]
+
+
+def test_provider_config_shape_enables_models_passthrough() -> None:
+    pconf = _launcher_provider_config("llama.cpp", 8085)
+    # Empty model == passthrough provider: /v1/models will surface the
+    # upstream's loaded model id, and outbound requests omit the name.
+    assert pconf.model == ""
+    assert pconf.kind == "openai_compat"
+    assert str(pconf.base_url) == "http://localhost:8085/v1"
+
+
+def test_static_providers_and_adapters_survive_sync() -> None:
+    engine = _engine()
+    engine.register_provider(_launcher_provider_config("llama.cpp", 8085))
+
+    assert "static-local" in engine._adapters
+    assert any(p.name == "static-local" for p in engine.config.providers)
+
+
+def test_custom_profile_name_is_respected() -> None:
+    engine = _engine()
+    summary = engine.register_provider(
+        _launcher_provider_config("mlx", 9000), profile_name="bench"
+    )
+    assert summary["profile"] == "bench"
+    assert engine.config.profile_by_name("bench").providers == [
+        "launcher-mlx-9000"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("backend", "port", "expected"),
+    [
+        ("llama.cpp", 8085, "launcher-llamacpp-8085"),
+        ("vllm", 8081, "launcher-vllm-8081"),
+        ("mlx", 9000, "launcher-mlx-9000"),
+    ],
+)
+def test_provider_naming(backend: str, port: int, expected: str) -> None:
+    assert _launcher_provider_config(backend, port).name == expected


### PR DESCRIPTION
The embedded launcher (/api/launcher/start) can start llama.cpp / vllm / mlx on any port, but routing is driven entirely by providers.yaml — the operator had to hand-edit the config, and a stale entry meant the new backend was unreachable (observed: launcher on 8085, config pointing at 8080).

Now a successful start registers the backend in-process:

- FallbackEngine.register_provider(): appends (or replaces, keyed by name) the provider entry, builds+caches its adapter, and moves it to the FRONT of an on-demand 'launcher' profile. default_profile is never touched — routing to launcher backends stays an explicit opt-in (X-CodeRouter-Profile: launcher).
- Provider entries are named launcher-<backend>-<port> with model:"" so the /v1/models upstream passthrough surfaces the real loaded model id (swap the GGUF, no config edit).
- Deliberately in-memory only: a YAML rewrite would destroy operator comments, and the launcher process registry is in-memory by design — provider and process share the server's lifetime.
- Sync failures never fail the start; the result rides on the start response as provider_sync and in the process log tail.

10 new tests, no new dependencies.