### PR TITLE
docs: align living docs with implementation (audit sweep)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -103,14 +103,14 @@ Full decision matrix → [Do I need CodeRouter?](./docs/start/when-do-i-need-cod
 | **Drift Detection** | Model quality degrading over time → switch provider or flush KV cache (6 signals incl. `goal_progress_stall`; `goal_mode` for tighter thresholds) |
 | **Self-healing** | Backend crashes → auto-exclude + restart + recovery probe → auto-restore |
 | **Tool Loop Guard** | Agent calling the same tool forever → detect and break |
-| **Memory Pressure** | GPU running out of VRAM → switch to lighter model |
+| **Memory Pressure** | Backend hits OOM → temporarily excluded, falls through to the next provider in the chain |
 | **Mid-stream Guard** | Response dies mid-stream → safely return accumulated text |
 
 ### Diagnostics & Visibility
 
 | Feature | What you learn |
 |---|---|
-| **`coderouter doctor`** | 6-probe diagnosis of provider issues + copy-paste YAML patches |
+| **`coderouter doctor`** | 7-probe diagnosis of provider issues + copy-paste YAML patches |
 | **`/dashboard`** | Real-time browser view of what's happening |
 | **`coderouter audit`** | Search guard activation history |
 | **`coderouter replay`** | Compare providers statistically (A/B analysis) / `--suggest-rules` for automated rule suggestions |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 | backend が落ちたらセッション終了 | ローカル → 無料 → 有料へ自動フォールバック |
 | 長時間で context 溢れ・drift・ループ | 6 系統ガード + self-healing |
 | モデル名がハードコード (リタイアで即エラー) | プロファイルで抽象化、差し替え 1 行 |
-| 何が悪いか分からない | `doctor` 6 プローブ + `/dashboard` + audit/replay |
+| 何が悪いか分からない | `doctor` 7 プローブ + `/dashboard` + audit/replay |
 
 直結で困っていないなら CodeRouter は不要です。**長時間・無人・弱いモデル**のどれかに当てはまったら、戻ってきてください。
 
@@ -122,14 +122,14 @@ ANTHROPIC_BASE_URL=http://localhost:8088 ANTHROPIC_AUTH_TOKEN=dummy claude
 | **Drift Detection** | モデルの応答品質が徐々に劣化 → 別 provider に切替 or KV cache flush (6 シグナル、`goal_mode` で目標達成停滞も検知) |
 | **Self-healing** | backend が落ちた → 自動除外 + restart + 回復 probe で自動復帰 |
 | **Tool Loop Guard** | 同じツールを無限に呼び続ける → 検知して停止 |
-| **Memory Pressure** | GPU メモリ不足を検知 → 軽量モデルに切替 |
+| **Memory Pressure** | OOM を出した backend を一時除外 → チェーンの次の provider へフォールスルー |
 | **Mid-stream Guard** | 応答途中で落ちた → 溜まったテキストを安全に返却 |
 
 ### 診断と可視化
 
 | 機能 | 何がわかるか |
 |---|---|
-| **`coderouter doctor`** | プロバイダの問題を 6 プローブで即診断 + 修正パッチ出力 |
+| **`coderouter doctor`** | プロバイダの問題を 7 プローブで即診断 + 修正パッチ出力 |
 | **`/dashboard`** | ブラウザで今何が起きてるかリアルタイム確認 |
 | **`coderouter audit`** | guard 発火履歴を検索 |
 | **`coderouter replay`** | provider 切替の効果を統計比較 (A/B 分析) / `--suggest-rules` でルール最適化提案 |

--- a/docs/backends/claude-code-llamacpp-vllm.md
+++ b/docs/backends/claude-code-llamacpp-vllm.md
@@ -152,7 +152,7 @@ ps aux | grep -E '[l]lama-server|[v]llm'
 
 # CodeRouter 側の状態
 open http://localhost:8088/dashboard            # 誰が落ちているか色で分かる
-coderouter doctor --check-model llama-cpp-local # provider を 6 プローブで診断
+coderouter doctor --check-model llama-cpp-local # provider を 7 プローブで診断
 ```
 
 ---

--- a/docs/backends/launcher-quickstart.md
+++ b/docs/backends/launcher-quickstart.md
@@ -105,7 +105,7 @@ coderouter serve --port 8088
 
 ブラウザで `http://localhost:8088/launcher` を開き、モデルを選んで「▶ 起動」します。
 
-詳細は [Launcher ガイド](./launcher.md)。
+Web版で起動した backend は `providers.yaml` を編集しなくても provider として自動登録されます(v2.7.4)。`X-CodeRouter-Profile: launcher` を指定すればすぐにルーティング対象になります。詳細は [Launcher ガイド](./launcher.md)。
 
 ---
 

--- a/docs/backends/llamacpp-direct.en.md
+++ b/docs/backends/llamacpp-direct.en.md
@@ -23,7 +23,7 @@ Real-machine sessions in v1.8.1 → v1.8.3, plus community reports on X / Reddit
 
 - macOS (Apple Silicon, Metal GPU offload). Linux + CUDA also works — swap `-DGGML_METAL=ON` for `-DGGML_CUDA=ON`.
 - Recommended hardware: M3 Max 64GB (Q4_K_M = 22GB GGUF + KV cache + headroom fits comfortably). 32GB Macs work with less margin.
-- Required tools: `git`, `cmake`, `huggingface-cli` (`uv tool install huggingface_hub[cli]`).
+- Required tools: `git`, `cmake`, the `hf` CLI (`uv tool install huggingface_hub`; the old `huggingface-cli` name has been merged into `hf`).
 - Time: build 5-10 min + GGUF download 5-10 min ≈ 15-20 min total.
 
 ---
@@ -46,14 +46,18 @@ Verify with `./build/bin/llama-server --version`.
 ### Step 2. Download the Unsloth GGUF
 
 ```bash
-# huggingface-cli, if missing
-uv tool install huggingface_hub[cli]
+# hf CLI, if missing (ships inside huggingface_hub)
+uv tool install huggingface_hub
+# or the standalone installer:
+#   curl -LsSf https://hf.co/cli/install.sh | bash
 
 # Q4_K_M variant (UD = Unsloth Dynamic Quantization, ~22 GB)
-huggingface-cli download unsloth/Qwen3.6-35B-A3B-GGUF \
+hf download unsloth/Qwen3.6-35B-A3B-GGUF \
   --include "*UD-Q4_K_M*" "*tokenizer*" "*chat_template*" \
   --local-dir ~/models/qwen3.6-35b-a3b-unsloth
 ```
+
+> **Migrating from the old `huggingface-cli`**: the command was renamed to `hf` and the subcommand structure was updated (`huggingface-cli download` → `hf download`, `huggingface-cli login` → `hf auth login`). This repo's helper script [`gguf_dl.py`](../../gguf_dl.py) wraps the equivalent of `hf download` — just paste an HF URL.
 
 > **Why UD-Q4_K_M?** Unsloth Dynamic Quantization — better accuracy at the same GGUF size than vanilla Q4_K_M. The de facto community standard per the Reddit / X reports.
 >
@@ -165,12 +169,13 @@ coderouter doctor --check-model llamacpp-qwen3-6-35b-a3b
 Expected:
 
 ```
-[1/6] auth+basic-chat …… [OK]
-[2/6] num_ctx ………………… [SKIP]    # port 8080 → not Ollama-shape, by design
-[3/6] tool_calls ………… [OK]    # native tool_calls observed
-[4/6] thinking ………… [SKIP]
-[5/6] reasoning-leak …… [OK]    # reasoning_content detected, adapter strips it
-[6/6] streaming ………… [SKIP]
+[1/7] auth+basic-chat …… [OK]
+[2/7] num_ctx ………………… [SKIP]    # port 8080 → not Ollama-shape, by design
+[3/7] tool_calls ………… [OK]    # native tool_calls observed
+[4/7] thinking ………… [SKIP]
+[5/7] reasoning-leak …… [OK]    # reasoning_content detected, adapter strips it
+[6/7] streaming ………… [SKIP]
+[7/7] cache ………………… [SKIP]    # kind: openai_compat is out of scope (cache_control is Anthropic-only)
 
 Summary: all probes match declarations.
 Exit: 0

--- a/docs/backends/llamacpp-direct.md
+++ b/docs/backends/llamacpp-direct.md
@@ -185,12 +185,13 @@ coderouter doctor --check-model llamacpp-qwen3-6-35b-a3b
 期待される結果：
 
 ```
-[1/6] auth+basic-chat …… [OK]
-[2/6] num_ctx ………………… [SKIP]    ← port 8080 (Ollama 専用 knob は使わない)、設計通り
-[3/6] tool_calls ………… [OK]    ← native tool_calls observed
-[4/6] thinking ………… [SKIP]
-[5/6] reasoning-leak …… [OK]    ← reasoning_content 検出 → adapter で strip 済
-[6/6] streaming ………… [SKIP]
+[1/7] auth+basic-chat …… [OK]
+[2/7] num_ctx ………………… [SKIP]    ← port 8080 (Ollama 専用 knob は使わない)、設計通り
+[3/7] tool_calls ………… [OK]    ← native tool_calls observed
+[4/7] thinking ………… [SKIP]
+[5/7] reasoning-leak …… [OK]    ← reasoning_content 検出 → adapter で strip 済
+[6/7] streaming ………… [SKIP]
+[7/7] cache ………………… [SKIP]    ← kind: openai_compat は対象外 (cache_control は Anthropic 専用)
 
 Summary: all probes match declarations.
 Exit: 0

--- a/docs/backends/lmstudio-direct.en.md
+++ b/docs/backends/lmstudio-direct.en.md
@@ -242,12 +242,13 @@ coderouter doctor --check-model lmstudio-qwen3-5-9b
 Expected:
 
 ```
-[1/6] auth+basic-chat …… [OK]    200 OK (in=19, out=16)
-[2/6] num_ctx ………………… [SKIP]    not Ollama-shape (port 1234) — by design
-[3/6] tool_calls ………… [OK]    native `tool_calls` observed; matches declaration.
-[4/6] thinking ………… [SKIP]    capabilities.thinking=true on openai_compat is informational
-[5/6] reasoning-leak …… [OK]   upstream emits non-standard `reasoning_content`; stripped by v1.8.3 adapter
-[6/6] streaming ………… [SKIP]    streaming-path detection is Ollama-shape gated
+[1/7] auth+basic-chat …… [OK]    200 OK (in=19, out=16)
+[2/7] num_ctx ………………… [SKIP]    not Ollama-shape (port 1234) — by design
+[3/7] tool_calls ………… [OK]    native `tool_calls` observed; matches declaration.
+[4/7] thinking ………… [SKIP]    capabilities.thinking=true on openai_compat is informational
+[5/7] reasoning-leak …… [OK]   upstream emits non-standard `reasoning_content`; stripped by v1.8.3 adapter
+[6/7] streaming ………… [SKIP]    streaming-path detection is Ollama-shape gated
+[7/7] cache ………………… [SKIP]    not applicable — cache_control is Anthropic-shaped (kind: openai_compat)
 
 Summary: all probes match declarations.
 Exit: 0
@@ -262,12 +263,13 @@ coderouter doctor --check-model lmstudio-qwen3-5-9b-anthropic
 Expected:
 
 ```
-[1/6] auth+basic-chat …… [OK]    200 OK (in=19, out=16)
-[2/6] num_ctx ………………… [SKIP]    not Ollama-shape
-[3/6] tool_calls ………… [OK]    native `tool_calls` observed; matches declaration.
-[4/6] thinking ………… [OK]    thinking block emitted; matches declaration.   ← !!
-[5/6] reasoning-leak …… [SKIP]    only openai_compat emits the non-standard reasoning field
-[6/6] streaming ………… [SKIP]
+[1/7] auth+basic-chat …… [OK]    200 OK (in=19, out=16)
+[2/7] num_ctx ………………… [SKIP]    not Ollama-shape
+[3/7] tool_calls ………… [OK]    native `tool_calls` observed; matches declaration.
+[4/7] thinking ………… [OK]    thinking block emitted; matches declaration.   ← !!
+[5/7] reasoning-leak …… [SKIP]    only openai_compat emits the non-standard reasoning field
+[6/7] streaming ………… [SKIP]
+[7/7] cache ………………… [SKIP]    skipped — no explicit `capabilities.prompt_cache: true` declared for this provider
 
 Summary: all probes match declarations.
 Exit: 0

--- a/docs/backends/lmstudio-direct.md
+++ b/docs/backends/lmstudio-direct.md
@@ -242,12 +242,13 @@ coderouter doctor --check-model lmstudio-qwen3-5-9b
 期待される結果:
 
 ```
-[1/6] auth+basic-chat …… [OK]    200 OK (in=19, out=16)
-[2/6] num_ctx ………………… [SKIP]    not Ollama-shape (port 1234)、設計通り
-[3/6] tool_calls ………… [OK]    native `tool_calls` observed; matches declaration.
-[4/6] thinking ………… [SKIP]    capabilities.thinking=true on openai_compat is informational
-[5/6] reasoning-leak …… [OK]   upstream emits non-standard `reasoning_content`; v1.8.3 adapter strips it
-[6/6] streaming ………… [SKIP]    streaming-path detection is Ollama-shape gated
+[1/7] auth+basic-chat …… [OK]    200 OK (in=19, out=16)
+[2/7] num_ctx ………………… [SKIP]    not Ollama-shape (port 1234)、設計通り
+[3/7] tool_calls ………… [OK]    native `tool_calls` observed; matches declaration.
+[4/7] thinking ………… [SKIP]    capabilities.thinking=true on openai_compat is informational
+[5/7] reasoning-leak …… [OK]   upstream emits non-standard `reasoning_content`; v1.8.3 adapter strips it
+[6/7] streaming ………… [SKIP]    streaming-path detection is Ollama-shape gated
+[7/7] cache ………………… [SKIP]    not applicable — cache_control is Anthropic-shaped (kind: openai_compat)
 
 Summary: all probes match declarations.
 Exit: 0
@@ -262,12 +263,13 @@ coderouter doctor --check-model lmstudio-qwen3-5-9b-anthropic
 期待される結果:
 
 ```
-[1/6] auth+basic-chat …… [OK]    200 OK (in=19, out=16)
-[2/6] num_ctx ………………… [SKIP]    not Ollama-shape
-[3/6] tool_calls ………… [OK]    native `tool_calls` observed; matches declaration.
-[4/6] thinking ………… [OK]    thinking block emitted; matches declaration.   ← !!
-[5/6] reasoning-leak …… [SKIP]    only openai_compat emits non-standard reasoning field
-[6/6] streaming ………… [SKIP]
+[1/7] auth+basic-chat …… [OK]    200 OK (in=19, out=16)
+[2/7] num_ctx ………………… [SKIP]    not Ollama-shape
+[3/7] tool_calls ………… [OK]    native `tool_calls` observed; matches declaration.
+[4/7] thinking ………… [OK]    thinking block emitted; matches declaration.   ← !!
+[5/7] reasoning-leak …… [SKIP]    only openai_compat emits non-standard reasoning field
+[6/7] streaming ………… [SKIP]
+[7/7] cache ………………… [SKIP]    skipped — no explicit `capabilities.prompt_cache: true` declared for this provider
 
 Summary: all probes match declarations.
 Exit: 0

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -22,7 +22,7 @@
 │  ┌─────────────┐  ┌──────────────┐  ┌────────────────────┐  │
 │  │ Wire 翻訳   │  │ 6 系統 Guard │  │ Diagnostic Layer   │  │
 │  │             │  │              │  │                    │  │
-│  │ Anthropic   │  │ L1 Context   │  │ doctor 6-probe     │  │
+│  │ Anthropic   │  │ L1 Context   │  │ doctor 7-probe     │  │
 │  │   ↕         │  │ L2 Memory    │  │ continuous probe   │  │
 │  │ OpenAI      │  │ L3 Tool loop │  │ audit log          │  │
 │  │             │  │ L4 Drift     │  │ request journal    │  │
@@ -62,9 +62,9 @@
 | 障害 | 症状 | CodeRouter の対処 | 導入バージョン |
 |---|---|---|---|
 | **L1 Context overflow** | messages が context window に漸近 → backend 400 | warn (80%) → auto trim (90%)、tool_use/tool_result ペア atomic 保全 | v2.0.0 |
-| **L2 Memory pressure** | Ollama/LM Studio が VRAM 不足で OOM | 残メモリ probe → 軽量モデル切替 | v1.10.0 |
+| **L2 Memory pressure** | Ollama/LM Studio が VRAM 不足で OOM | エラー本文の OOM 文字列を検知 (warn / skip、default warn)。`skip` 時は該当 provider を cooldown (既定 120s) で除外 → チェーンの次の provider へフォールスルー | v1.10.0 |
 | **L3 Tool loop** | 同じ tool args を繰り返す stuck loop | 重複検知 → warn / inject / break 3 段階 | v1.10.0 |
-| **L4 Drift** | KV cache 汚染で応答品質劣化 (空応答/短縮/tool silence) | 5 シグナル rolling window → warn / promote / reload | v2.1.0 |
+| **L4 Drift** | KV cache 汚染で応答品質劣化 (空応答/短縮/tool silence) | 6 シグナル rolling window → warn / promote / reload (default off) | v2.1.0 |
 | **L5 Health** | backend crash / 連続失敗 | 状態機械 (HEALTHY→DEGRADED→UNHEALTHY) + self-healing (自動除外 + restart + 回復 probe) | v1.10.0 + v2.2.0 |
 | **L6 Mid-stream** | streaming 途中で backend が落ちる | 蓄積テキスト返却 (partial stitching) + clean error event | v2.1.0 |
 
@@ -154,7 +154,7 @@ curl http://localhost:8088/v1/chat/completions \
 coderouter doctor --check-model ollama-qwen-coder-14b
 ```
 
-指定プロバイダに対し 6 プローブ (各 ≤100 トークン) を走らせ、宣言と実挙動の食い違いをコピペ可能な YAML パッチで出力:
+指定プロバイダに対し 7 プローブ (各 ≤100 トークン) を走らせ、宣言と実挙動の食い違いをコピペ可能な YAML パッチで出力:
 
 ```
 provider: ollama-qwen-coder-14b  (kind=openai_compat, model=qwen2.5-coder:14b)
@@ -172,16 +172,17 @@ suggested patch for ~/.coderouter/providers.yaml:
         tools: true
 ```
 
-### 6 プローブの役割
+### 7 プローブの役割
 
 | プローブ | 何を検査するか |
 |---|---|
 | **auth+basic-chat** | 到達性・認証・基本応答。失敗時は残り全 SKIP |
+| **num_ctx** | 宣言コンテキスト長と実挙動の食い違い (大入力時の暗黙切り詰め検知) |
 | **tool_calls** | ダミーツールでの tool_use 生成能力 |
 | **thinking** | Anthropic `thinking` ブロック受付 (anthropic kind のみ) |
 | **reasoning-leak** | strip 前の生ボディに `reasoning` フィールドが漏れていないか |
+| **streaming** | SSE ストリーミング応答の整合性 |
 | **cache** | Anthropic prompt cache の read/creation 動作 |
-| **context-truncation** | 大入力時の暗黙切り詰めの有無 |
 
 ### 終了コード (CI 投入想定)
 

--- a/docs/concepts/drift-detection.md
+++ b/docs/concepts/drift-detection.md
@@ -12,9 +12,10 @@ Ollama 等のローカル LLM バックエンドは長時間稼働すると以�
 - tool_use を返すべき場面で返さなくなる (tool silence)
 - 異常な stop_reason が増加する
 - エラー率が上昇する
+- 同じ内容の応答を繰り返し前進しなくなる (goal progress stall — response_fingerprint が設定された場合のみ)
 
 これらは個別には致命的ではないものの、蓄積すると agent session が事実上動作不能に陥ります。
-Drift Detection はこれらを 5 つの品質シグナルとして rolling window で監視し、
+Drift Detection はこれらを 6 つの品質シグナルとして rolling window で監視し、
 閾値を超えた時点で corrective action を自動実行します。
 
 ## 設定
@@ -48,18 +49,23 @@ profiles:
 | `normal` | 0.3 | 0.5 | 0.7 | 0.4 | 0.25 | 6 |
 | `high` | 0.2 | 0.7 | 0.5 | 0.3 | 0.15 | 4 |
 
-## 5 品質シグナル
+（各プリセットには `goal_progress_stall` 用の `repetition_rate_threshold` も含まれます: low=0.6 / normal=0.4 / high=0.25）
+
+> **goal_mode**: profile に `goal_mode: true` を設定すると、`drift_detection_sensitivity` に関わらず専用の `goal` プリセット (empty=0.2 / collapse=0.6 / tool_silence=0.5 / stop=0.3 / error=0.15 / repetition=0.2 / min_window_fill=4) が適用されます。goal_mode 自体はシグナルではなく、閾値プリセットを切り替える bool フラグです。`/goal` セッション向けに前進停滞・length collapse を早く拾います。
+
+## 6 品質シグナル
 
 1. **empty_response_rate** — output_tokens=0 の応答率 (error を除外)
 2. **length_collapse_ratio** — window 後半の median output_tokens / 前半の median (比率が閾値未満で collapse)
 3. **tool_silence_rate** — tools[] を含む request に対して tool_use を返さない率
 4. **stop_anomaly_rate** — end_turn / tool_use / max_tokens 以外の stop_reason の率
 5. **error_rate** — provider error の率
+6. **goal_progress_stall** — window 内で以前と同じ fingerprint が再出現した率 (response_fingerprint が設定された observation のみ対象、3 件以上で発火)。model が前進せず同じ応答を繰り返している兆候
 
 ## Severity 判定
 
 - severe signal ×1 (empty_response_rate, length_collapse) → **severe**
-- mild signal ×2 以上 (tool_silence, stop_anomaly, error_rate) → **severe**
+- mild signal ×2 以上 (tool_silence, stop_anomaly, error_rate, goal_progress_stall) → **severe**
 - mild signal ×1 → **mild**
 
 ## Response Header

--- a/docs/guides/free-tier-guide.md
+++ b/docs/guides/free-tier-guide.md
@@ -302,7 +302,7 @@ for p in nim-qwen3-coder-480b nim-kimi-k2 nim-llama-3.3-70b; do
 done
 ```
 
-6 プローブ（auth / num_ctx / tool_calls / thinking / reasoning-leak / streaming）が回り、宣言と実挙動が食い違えば**コピペ可能な YAML パッチ**を出します。全 probe OK なら Exit 0 が返ります。
+7 プローブ（auth / num_ctx / tool_calls / thinking / reasoning-leak / streaming / cache）が回り、宣言と実挙動が食い違えば**コピペ可能な YAML パッチ**を出します。全 probe OK なら Exit 0 が返ります。
 
 2026-04-24 時点の `nim-qwen3-coder-480b` 実出力例（**1Password 経由で env を inject した状態**）:
 

--- a/docs/guides/troubleshooting.en.md
+++ b/docs/guides/troubleshooting.en.md
@@ -30,7 +30,7 @@ When you can't tell where the problem is, start by running `doctor` against the 
 coderouter doctor --check-model ollama-qwen-coder-7b
 ```
 
-`doctor` runs six probes (auth + basic-chat / num_ctx / tool_calls / thinking / reasoning-leak / streaming) against the live provider and emits **copy-paste YAML patches** for any declaration mismatch.
+`doctor` runs seven probes (auth + basic-chat / num_ctx / tool_calls / thinking / reasoning-leak / streaming / cache) against the live provider and emits **copy-paste YAML patches** for any declaration mismatch.
 
 Exit codes collapse into three buckets:
 
@@ -296,7 +296,7 @@ After v1.8.2's thinking-aware probe budgets, `num_ctx` and `streaming` clear, bu
 The doctor probe NEEDS_TUNING readings on `num_ctx` / `streaming` reported in v1.8.1 turned out to be **probe false positives** — Gemma 4 is a thinking model that emits a `reasoning` field, and the v1.8.1 probe budgets (`max_tokens=32` / `128`) were consumed entirely by the reasoning trace before any visible `content` could surface. Real-machine `/v1/messages` round-trip returns "Hello." in 2 seconds; `tool_calls` work natively. v1.8.2 widened the probe budget to 1024 tokens for thinking-flagged models.
 
 **4-2-D. Best practice — "boring models + observation tools."**
-Lead the `coding` chain with `qwen2.5-coder:14b` / `gemma4:26b`, run `coderouter doctor --check-model <name>` for a 6-probe sanity pass, and let the fallback chain pick up paid / cloud free for spillover.
+Lead the `coding` chain with `qwen2.5-coder:14b` / `gemma4:26b`, run `coderouter doctor --check-model <name>` for a 7-probe sanity pass, and let the fallback chain pick up paid / cloud free for spillover.
 
 **4-2-E. Doctor probe limits — thinking model awareness (v1.8.2).**
 Pre-v1.8.2 `num_ctx` / `streaming` probes used `max_tokens=32` / `128`, sufficient for non-thinking models but consumed entirely by `reasoning` token output on thinking models. v1.8.2 introduced `_is_reasoning_model(provider, resolved)` which checks `provider.capabilities.thinking`, `provider.capabilities.reasoning_passthrough`, and the registry-resolved equivalents — when any signals true, the probe budget bumps to 1024. Bundled `model-capabilities.yaml` declares `thinking: true` for `gemma4:*` and `qwen3.6:*`, so users see the corrected behavior without editing their `providers.yaml`. **Meta lesson**: diagnostic tools themselves need to keep being diagnosed (a corollary of plan.md §5.4's "real-machine evidence first" principle).

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -367,7 +367,7 @@ llama_model_load: error loading model: error loading model architecture:
 
 #### 4-2-C. **Gemma 4 26B** は実機で完全動作 (v1.8.2 で確定)
 
-`coderouter doctor --check-model ollama-gemma4-26b` の `tool_calls` probe が無加工で `[OK]`。v1.8.2 で thinking モデル対応 probe バジェット (1024) を入れた後は **`num_ctx` / `streaming` も `[OK]`** で 6 probe 全クリア。`/v1/messages` Anthropic 互換経由で "Hello." を 2 秒応答 (M3 Max 64GB)、`tool_calls native OK`、`reasoning strip` 動作。
+`coderouter doctor --check-model ollama-gemma4-26b` の `tool_calls` probe が無加工で `[OK]`。v1.8.2 で thinking モデル対応 probe バジェット (1024) を入れた後は **`num_ctx` / `streaming` も `[OK]`** で全 probe クリア。`/v1/messages` Anthropic 互換経由で "Hello." を 2 秒応答 (M3 Max 64GB)、`tool_calls native OK`、`reasoning strip` 動作。
 
 ただし **interactive UX は若干重い** — Gemma 4 は thinking モデルなので `reasoning` フィールドにも応答時間を使う + 26B サイズ + Claude Code の agent loop (1 プロンプトで 3〜6 round-trip) で総応答時間が 30〜90 秒 / プロンプトになる。daily driver には `qwen2.5-coder:14b` のほうが速い。**Gemma 4 は tool_calls native + 高品質が要るときの選択肢**。
 
@@ -378,7 +378,7 @@ note 記事の「Gemma 4 が日常の王者」評価は **Claude Code agentic �
 実機運用での提案：
 
 1. **第一候補は枯れたもの**: `qwen2.5-coder:14b` / `qwen2.5-coder:7b` / `gemma4:26b` / `gemma4:e4b`
-2. **doctor で確認**: `cr doctor --check-model <provider>` で 6 probe を回す
+2. **doctor で確認**: `cr doctor --check-model <provider>` で 7 probe を回す
 3. **`--apply` で patch 適用**: NEEDS_TUNING の YAML パッチを非破壊書き戻し (`pip install 'coderouter-cli[doctor]'` 必要)
 4. **新興モデルは慎重に**: HF で見つけた新モデルは Ollama 0.20+ でも未対応のことあり、`ollama run` → server log で確認
 5. **fallback chain で守る**: ローカル primary が落ちても NIM / OpenRouter free に流れるように chain を厚く

--- a/docs/guides/usage-guide.en.md
+++ b/docs/guides/usage-guide.en.md
@@ -88,7 +88,7 @@ General-purpose (not coder-tuned, so typically `capabilities.tools: false` unles
 - **`llama3.2:3b` / `phi4:14b`** — general-purpose, not coder-tuned. Useful as a "fast" profile for short chat replies outside of code sessions.
 - **`gpt-oss:20b`** / **`gpt-oss:120b`** (OpenAI OSS family) — release tags vary by vendor mirror; the 20 B is the hardware sweet spot on a 24 GB GPU. Emits a non-standard `reasoning` field on each choice's `message` / `delta` that the v0.5-C `openai_compat` adapter already strips; probe once with `coderouter doctor` to confirm the strip fires and `reasoning-leak` returns `OK`.
 
-Use `coderouter doctor --check-model <provider>` after adding any new model — its six probes (auth / num_ctx / tool_calls / thinking / reasoning-leak / streaming) will tell you which `capabilities.*` flags and `extra_body.options.*` values the model actually wants. The doctor's verdicts are the source of truth; the table in §3 is the known-good starting point it checks you against.
+Use `coderouter doctor --check-model <provider>` after adding any new model — its seven probes (auth / num_ctx / tool_calls / thinking / reasoning-leak / streaming / cache) will tell you which `capabilities.*` flags and `extra_body.options.*` values the model actually wants. The doctor's verdicts are the source of truth; the table in §3 is the known-good starting point it checks you against.
 
 MoE footprint reminder: "N total / M active" means the router streams like an M-parameter model in latency terms but needs N-parameter weights resident in VRAM. Qwen3 30B-A3B loads like a 30 B but runs like a 3 B — an unusually good deal on Apple Silicon where memory bandwidth is the bottleneck, but only if you actually have the ~18 GB Q4 weights-fit budget.
 

--- a/docs/guides/usage-guide.md
+++ b/docs/guides/usage-guide.md
@@ -89,7 +89,7 @@ Reasoning チューニングの distill（既定で `<think>` ブロックを吐
 - **`llama3.2:3b` / `phi4:14b`** — 汎用、コーダチューニングではない。コード以外の短いチャット返信の「fast」プロファイルとして有用。
 - **`gpt-oss:20b`** / **`gpt-oss:120b`**（OpenAI OSS 系）— ベンダーミラーでタグが異なる; 24 GB GPU のスイートスポットは 20B。各 choice の `message` / `delta` に非標準 `reasoning` フィールドを吐きますが、v0.5-C の `openai_compat` アダプタが既に剥がします; `coderouter doctor` で 1 回プローブし strip が発火して `reasoning-leak` が `OK` を返すことを確認してください。
 
-新しいモデルを追加したら必ず `coderouter doctor --check-model <provider>` を走らせてください — 6 プローブ（auth / num_ctx / tool_calls / thinking / reasoning-leak / streaming）が、モデルが実際に欲しがる `capabilities.*` と `extra_body.options.*` を教えてくれます。doctor の判定が真実の源で、§3 の表はそれと突き合わせるための既知良好な起点にすぎません。
+新しいモデルを追加したら必ず `coderouter doctor --check-model <provider>` を走らせてください — 7 プローブ（auth / num_ctx / tool_calls / thinking / reasoning-leak / streaming / cache）が、モデルが実際に欲しがる `capabilities.*` と `extra_body.options.*` を教えてくれます。doctor の判定が真実の源で、§3 の表はそれと突き合わせるための既知良好な起点にすぎません。
 
 MoE フットプリントの補足: 「N 総 / M アクティブ」とは、レイテンシ的には M パラメータ相当で流れる一方、VRAM には N パラメータ分の重みを常駐させる必要がある、という意味です。Qwen3 30B-A3B は 30B のようにロードし 3B のように動く — メモリ帯域がボトルネックの Apple Silicon では異例にお得ですが、~18 GB Q4 の重み保持予算が実際にあることが前提です。
 
@@ -316,7 +316,7 @@ NVIDIA NIM の開発者枠（40 req/min）を無料層の上に重ねると、�
 
 CodeRouter は 2 つの検証ツールを同梱:
 
-**プロバイダ単位の診断** — `coderouter doctor --check-model <provider>`。6 プローブ連鎖（auth / num_ctx / tool_calls / thinking / reasoning-leak / streaming）を 1 プロバイダに対して走らせ、判定表と不一致時のコピペ YAML パッチを出力。`providers.yaml` を編集するたびに使うのが良い。
+**プロバイダ単位の診断** — `coderouter doctor --check-model <provider>`。7 プローブ連鎖（auth / num_ctx / tool_calls / thinking / reasoning-leak / streaming / cache）を 1 プロバイダに対して走らせ、判定表と不一致時のコピペ YAML パッチを出力。`providers.yaml` を編集するたびに使うのが良い。
 
 ```bash
 uv run coderouter doctor --check-model ollama-qwen-coder-7b

--- a/docs/start/quickstart.en.md
+++ b/docs/start/quickstart.en.md
@@ -120,9 +120,9 @@ uv run coderouter serve --port 8088
 
 Prefix with `uv run` and you don't need `source .venv/bin/activate` (or use direnv for auto-activation).
 
-> **Naming note**: the PyPI distribution is `coderouter-cli` because the bare `coderouter` PyPI slot was already taken by an unrelated HTTP routing library. **The command and Python import name are both `coderouter`** (`from coderouter import ...` / `coderouter serve ...`); only the `pip install` name differs. See [CHANGELOG `[v1.7.0]`](../CHANGELOG.md#v170--2026-04-25-pypi-公開-uvx-coderouter-cli-一発で動く).
+> **Naming note**: the PyPI distribution is `coderouter-cli` because the bare `coderouter` PyPI slot was already taken by an unrelated HTTP routing library. **The command and Python import name are both `coderouter`** (`from coderouter import ...` / `coderouter serve ...`); only the `pip install` name differs. See [CHANGELOG `[v1.7.0]`](../../CHANGELOG.md#v170--2026-04-25-pypi-公開-uvx-coderouter-cli-一発で動く).
 >
-> **v1.8.0 introduced use-case-aware 4 profiles**: pick at startup with `coderouter serve --mode coding|general|multi|reasoning` (default is `multi`). See [CHANGELOG `[v1.8.0]`](../CHANGELOG.md) and [`examples/providers.yaml`](../../examples/providers.yaml) comments for the rationale.
+> **v1.8.0 introduced use-case-aware 4 profiles**: pick at startup with `coderouter serve --mode coding|general|multi|reasoning` (default is `multi`). See [CHANGELOG `[v1.8.0]`](../../CHANGELOG.md) and [`examples/providers.yaml`](../../examples/providers.yaml) comments for the rationale.
 
 ### 3. Drop in a `providers.yaml`
 

--- a/docs/start/quickstart.md
+++ b/docs/start/quickstart.md
@@ -117,9 +117,9 @@ uv run coderouter serve --port 8088
 
 毎回 `uv run` プレフィックスを付ければ venv activate は不要 (direnv や shell 起動フックでの自動 activate も一案)。
 
-> **補足**: PyPI 上のパッケージ名は `coderouter-cli` ですが、**コマンド名と Python import 名は `coderouter` のまま**です (`from coderouter import ...` / `coderouter serve ...`)。`pip install` 時の名前だけ若干違う、という形。詳しくは [CHANGELOG `[v1.7.0]`](../CHANGELOG.md#v170--2026-04-25-pypi-公開-uvx-coderouter-cli-一発で動く) 参照。
+> **補足**: PyPI 上のパッケージ名は `coderouter-cli` ですが、**コマンド名と Python import 名は `coderouter` のまま**です (`from coderouter import ...` / `coderouter serve ...`)。`pip install` 時の名前だけ若干違う、という形。詳しくは [CHANGELOG `[v1.7.0]`](../../CHANGELOG.md#v170--2026-04-25-pypi-公開-uvx-coderouter-cli-一発で動く) 参照。
 >
-> **v1.8.0 から用途別 4 プロファイル**: `coderouter serve --mode coding|general|multi|reasoning` で起動時に切り替え可能 (デフォルトは `multi`)。詳しくは [CHANGELOG `[v1.8.0]`](../CHANGELOG.md) と [`examples/providers.yaml`](../../examples/providers.yaml) のコメントを参照。
+> **v1.8.0 から用途別 4 プロファイル**: `coderouter serve --mode coding|general|multi|reasoning` で起動時に切り替え可能 (デフォルトは `multi`)。詳しくは [CHANGELOG `[v1.8.0]`](../../CHANGELOG.md) と [`examples/providers.yaml`](../../examples/providers.yaml) のコメントを参照。
 
 ### 3. `providers.yaml` を配置
 

--- a/docs/start/when-do-i-need-coderouter.en.md
+++ b/docs/start/when-do-i-need-coderouter.en.md
@@ -123,7 +123,7 @@ filter is what fixes it.
   mid-stream safety guard.** Writing that yourself is subtle
   (see [`docs/articles/zenn-02-coderouter-architecture.md`](../articles/zenn/zenn-02-coderouter-architecture.md)).
 - **`coderouter doctor` for diagnosing a misbehaving setup.**
-  Its six probes cover exactly the failure modes above.
+  Its seven probes cover exactly the failure modes above.
 
 ## 7. When CodeRouter is the wrong choice
 

--- a/docs/start/when-do-i-need-coderouter.md
+++ b/docs/start/when-do-i-need-coderouter.md
@@ -91,7 +91,7 @@ codex "write a function that reverses a string in rust"
 
 - **Claude Code を Anthropic 以外のモデルで動かす。** `/v1/messages` は Ollama には存在しないため、直続きの経路自体がありません
 - **ローカル → 無料クラウド → 有料 の自動フォールバックを、mid-stream ガード付きで** 回したい。自前で書くと地味に難しい（[`docs/articles/zenn-02-coderouter-architecture.md`](../articles/zenn/zenn-02-coderouter-architecture.md) 参照）
-- **`coderouter doctor` で不調を診断したい** — 6 プローブが上記の失敗モードを網羅しています
+- **`coderouter doctor` で不調を診断したい** — 7 プローブが上記の失敗モードを網羅しています
 
 ## 7. CodeRouter では解けない場面
 

--- a/examples/providers.yaml
+++ b/examples/providers.yaml
@@ -129,7 +129,7 @@ providers:
   # `--jinja` で GGUF metadata 埋め込みの chat template を使う (Unsloth GGUF は
   # 通常埋め込み済)。`-ngl 999` で全 layer GPU offload (Metal)。
   #
-  # CodeRouter doctor で 6 probe 全 OK 確認:
+  # CodeRouter doctor (7 probe) で確認:
   #   coderouter doctor --check-model llamacpp-qwen3-6-35b-a3b
   - name: llamacpp-qwen3-6-35b-a3b
     kind: openai_compat


### PR DESCRIPTION
Third-party article fact-check exposed doc/implementation drift; a full audit of the living docs (README JA/EN, docs/start, docs/concepts, docs/guides, docs/backends, examples) followed. Historical records (docs/articles, retrospectives, designs, CHANGELOG) untouched.

Fixes:

- Memory Pressure guard was described as 'switch to a lighter model' (architecture.md L2, README JA/EN guard tables). Actual behaviour
  (guards/memory_pressure.py + fallback.py Pass 3): OOM string match ->
  provider excluded on a cooldown (default 120s) -> falls through to the next chain entry. No dynamic model switching exists.
- Drift detection is 6 signals, not 5 (architecture.md; drift_detection.py incl. goal_progress_stall). drift-detection.md gains the #6 signal, goal_mode clarification (a bool profile flag selecting a stricter threshold preset — not a signal) and per-preset repetition thresholds.
- doctor runs 7 probes, not 6 (doctor.py: auth+basic-chat / num_ctx / tool_calls / thinking / reasoning-leak / streaming / cache). Fixed in README JA/EN, architecture.md (incl. probe-role table which listed a nonexistent 'context-truncation' probe and missed num_ctx/streaming), when-do-i-need JA/EN, usage-guide JA/EN, troubleshooting JA/EN, free-tier-guide, claude-code-llamacpp-vllm, llamacpp/lmstudio-direct JA/EN sample outputs (renumbered [1/7]..[7/7] + cache row), examples/providers.yaml comment.
- quickstart JA/EN: broken relative links to CHANGELOG (../ -> ../../).
- llamacpp-direct.en.md: sync stale huggingface-cli section with the JA version's hf CLI + gguf_dl.py guidance.
- launcher-quickstart.md: one-line pointer to the v2.7.4 provider auto-sync.

Docs-only change; pytest 1569 passed (unaffected).