### PR TITLE
docs(guides): replace real LAN IPs and hostname in remote-access examples

### DIFF
--- a/docs/guides/remote-access.en.md
+++ b/docs/guides/remote-access.en.md
@@ -42,15 +42,15 @@ ANTHROPIC_BASE_URL=http://localhost:8088 ANTHROPIC_AUTH_TOKEN=dummy claude
 
 ## ② Tailscale — multiple devices, works from anywhere (recommended)
 
-Install [Tailscale](https://tailscale.com/) (a WireGuard-based mesh VPN) on both machines and **LAN exposure becomes unnecessary**. Each device gets a private `100.x.y.z` address and a MagicDNS name (e.g. `evox2.tailnet-name.ts.net`), reachable only from devices in your tailnet.
+Install [Tailscale](https://tailscale.com/) (a WireGuard-based mesh VPN) on both machines and **LAN exposure becomes unnecessary**. Each device gets a private `100.x.y.z` address and a MagicDNS name (e.g. `my-server.tailnet-name.ts.net`), reachable only from devices in your tailnet.
 
 ```bash
 # server — bind to the Tailscale IP only, allow-list its names
-CODEROUTER_ALLOWED_HOSTS=evox2.tailnet-name.ts.net,100.x.y.z \
+CODEROUTER_ALLOWED_HOSTS=my-server.tailnet-name.ts.net,100.x.y.z \
   coderouter serve --host 100.x.y.z --port 8088
 
 # client (anywhere in the world, as long as it's in the tailnet)
-open http://evox2.tailnet-name.ts.net:8088/dashboard
+open http://my-server.tailnet-name.ts.net:8088/dashboard
 ```
 
 - The point is to **bind to the Tailscale IP**, not `0.0.0.0` — nothing opens on the physical LAN
@@ -85,13 +85,13 @@ CODEROUTER_ALLOWED_HOSTS=coderouter.example.internal coderouter serve --port 808
 On a home LAN with only people you trust, this is fine and simple.
 
 ```bash
-# on the server (e.g. 192.168.4.85) — ALLOWED_HOSTS is the SERVER's address (the one in the URL)
-CODEROUTER_ALLOWED_HOSTS=192.168.4.85 coderouter serve --host 0.0.0.0 --port 8088
+# on the server (e.g. 192.168.1.10) — ALLOWED_HOSTS is the SERVER's address (the one in the URL)
+CODEROUTER_ALLOWED_HOSTS=192.168.1.10 coderouter serve --host 0.0.0.0 --port 8088
 ```
 
 Two chores:
 
-1. **Restrict source IPs with the OS firewall** (optional but recommended): e.g. `sudo ufw allow from 192.168.4.21 to any port 8088`, listing only the devices you allow
+1. **Restrict source IPs with the OS firewall** (optional but recommended): e.g. `sudo ufw allow from 192.168.1.20 to any port 8088`, listing only the devices you allow
 2. **Verify port 8088 is not reachable from the internet** (router port-forwards, UPnP). On networks that assign global IPs internally (universities, legacy corporate ranges), "on the LAN" can silently mean "on the internet"
 
 > ⚠️ On shared-office LANs, campus networks, or anything with a guest Wi-Fi, do not use ④ — use ①–③. Anyone on the LAN could run inference on your models.

--- a/docs/guides/remote-access.md
+++ b/docs/guides/remote-access.md
@@ -42,15 +42,15 @@ ANTHROPIC_BASE_URL=http://localhost:8088 ANTHROPIC_AUTH_TOKEN=dummy claude
 
 ## ② Tailscale — 複数端末・外出先(推奨)
 
-[Tailscale](https://tailscale.com/)(WireGuard ベースのメッシュ VPN)を両方の機体に入れると、**LAN 公開そのものが不要**になります。各端末に `100.x.y.z` の私設 IP と MagicDNS 名(例: `evox2.tailnet-name.ts.net`)が付き、tailnet に参加した端末からしか届きません。
+[Tailscale](https://tailscale.com/)(WireGuard ベースのメッシュ VPN)を両方の機体に入れると、**LAN 公開そのものが不要**になります。各端末に `100.x.y.z` の私設 IP と MagicDNS 名(例: `my-server.tailnet-name.ts.net`)が付き、tailnet に参加した端末からしか届きません。
 
 ```bash
 # サーバー側 — Tailscale IP でだけ待ち受け、その名前を許可
-CODEROUTER_ALLOWED_HOSTS=evox2.tailnet-name.ts.net,100.x.y.z \
+CODEROUTER_ALLOWED_HOSTS=my-server.tailnet-name.ts.net,100.x.y.z \
   coderouter serve --host 100.x.y.z --port 8088
 
 # クライアント側(tailnet 参加済みなら世界中どこからでも)
-open http://evox2.tailnet-name.ts.net:8088/dashboard
+open http://my-server.tailnet-name.ts.net:8088/dashboard
 ```
 
 - `--host 0.0.0.0` ではなく **Tailscale IP にバインド**するのがポイント(物理 LAN 側には一切開かない)
@@ -85,13 +85,13 @@ CODEROUTER_ALLOWED_HOSTS=coderouter.example.internal coderouter serve --port 808
 家族しかいない自宅 LAN のような環境なら、シンプルにこれで動きます。
 
 ```bash
-# サーバー機(例: 192.168.4.85)で — ALLOWED_HOSTS はサーバー自身のIP(URLに打つ方)
-CODEROUTER_ALLOWED_HOSTS=192.168.4.85 coderouter serve --host 0.0.0.0 --port 8088
+# サーバー機(例: 192.168.1.10)で — ALLOWED_HOSTS はサーバー自身のIP(URLに打つ方)
+CODEROUTER_ALLOWED_HOSTS=192.168.1.10 coderouter serve --host 0.0.0.0 --port 8088
 ```
 
 やること 2 つ:
 
-1. **送信元をファイアウォールで絞る**(任意だが推奨): `sudo ufw allow from 192.168.4.21 to any port 8088` のように、許可する端末だけ列挙
+1. **送信元をファイアウォールで絞る**(任意だが推奨): `sudo ufw allow from 192.168.1.20 to any port 8088` のように、許可する端末だけ列挙
 2. **ルーターのポート開放・UPnP で 8088 が外に出ていないか確認**。グローバル IP を構内に振る環境(大学・企業の 133.x 系など)では、「LAN 内」のつもりがインターネット到達可能なことがあります
 
 > ⚠️ 共有オフィス・学内 LAN・ゲスト Wi-Fi が同居するネットワークでは④は使わず、①〜③にしてください。LAN 内の誰でもあなたのモデルで推論できてしまいます。


### PR DESCRIPTION
実環境の値(ホスト名・プライベートIP)を汎用の例示値に差し替え。docsのみ