### PR TITLE
feat(launcher): MTP / speculative-decoding support for llama.cpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,63 @@ are kept verbatim where the Japanese text itself is the subject).
 
 ---
 
+## [v2.7.6] — 2026-07-09 (Launcher MTP / speculative-decoding support)
+
+Adds Multi-Token Prediction (MTP) / speculative-decoding support
+to the llama.cpp launcher (both the Web UI and the desktop GUI), closing the
+gap where operators had to hand-assemble `--spec-type` / `--model-draft`
+flags. Fully backward compatible: the new fields default to auto-detection
+with a silent no-op fallback, no config-schema changes, no new dependencies.
+
+### Added
+
+- **`resolve_speculative()` / `find_draft_companion()`**
+  (`coderouter/launcher_speculative.py`) — shared decision logic for both
+  launchers. `mtp_mode="auto"` (default) first checks the selected gguf's
+  own metadata for embedded nextn layers (`{arch}.nextn_predict_layers > 0`)
+  and, if present, emits `--spec-type draft-mtp` with no separate draft
+  model; otherwise it scans the *same folder* as the main gguf for a
+  companion draft/MTP file (name hint or shared prefix, size under 50% of
+  the main model, architecture-matched when readable) and wires up
+  `--spec-type draft-mtp|draft-simple --model-draft <path>`; otherwise it
+  starts normally and logs that no companion was found. An explicit
+  `draft_model_path` skips detection entirely (400 if the path doesn't
+  exist); `mtp_mode="off"` never emits speculative flags. When the operator
+  supplies `--spec-type` in extra args, auto-detection defers to it and
+  adds nothing.
+  Both knobs are llama.cpp-only — vllm/mlx reject them with a 400.
+- **`POST /api/launcher/start`**: new optional `draft_model_path` and
+  `mtp_mode` (`"auto"` / `"off"`) fields; the response now carries the
+  resolved flags as `"speculative"`. `-md` / `--model-draft` /
+  `--spec-draft-model` join the existing `-m`/`--model` denylist for
+  `options`/`extra_args` (llama.cpp) — the draft model can only be set via
+  `draft_model_path`. The remaining spec knobs (`--spec-type`,
+  `--spec-draft-n-max/-n-min/-p-min`, `-ngld`, `-devd`) stay free-form.
+- **GGUF introspection** (`coderouter/gguf_introspect.py`): `GGUFInfo` now
+  reports `n_nextn` and the derived `supports_mtp` property, read from
+  `{arch}.nextn_predict_layers`.
+- **`--split-mode tensor` crash warning**: known llama.cpp issue #24309 —
+  a nextn-embedded model combined with tensor split can crash. The launcher
+  detects the combination and logs a warning recommending `--split-mode
+  layer` without blocking the launch.
+- **UI**: Web LAUNCH form gets "MTP/draft gguf (空欄で自動検出)" text field
+  + "MTP" `auto`/`off` select. Desktop GUI (`launcher_gui.py`) gets the
+  matching Entry + a "MTP自動検出" checkbox (default on).
+
+### Docs
+
+- `docs/backends/launcher.md`/`.en.md`: new "MTP / speculative decoding"
+  section (auto-detection order, companion-file convention, `mtp_mode=off`,
+  extra-args deferral, `-md` denylist, issue #24309 caveat, API fields), plus
+  the LAUNCH form field table and denylist note updated.
+- `docs/backends/llamacpp-direct.md`/`.en.md`: manual `--spec-type
+  draft-mtp` / `--model-draft` / `--spec-draft-n-max` usage example, with a
+  pointer to the launcher's auto-detection.
+- `docs/backends/launcher-quickstart.md`/`.en.md`: one-line pointer to the
+  new MTP section.
+
+---
+
 ## [v2.7.5] — 2026-07-06 (External-bind startup warning + remote-access guide + docs i18n)
 
 Driven by the first field report against the v2.7.0 Host-validation

--- a/coderouter/gguf_introspect.py
+++ b/coderouter/gguf_introspect.py
@@ -136,6 +136,17 @@ class GGUFInfo:
     n_kv_heads: int | None
     file_type: int | None
     file_size_bytes: int
+    n_nextn: int | None = None
+
+    @property
+    def supports_mtp(self) -> bool:
+        """True when the GGUF embeds Multi-Token-Prediction (nextn) layers.
+
+        Derived from ``{arch}.nextn_predict_layers`` — a positive count means
+        the main model carries MTP/nextn tensors and can drive llama.cpp's
+        ``--spec-type draft-mtp`` without a separate draft gguf.
+        """
+        return bool(self.n_nextn and self.n_nextn > 0)
 
     @property
     def quant_name(self) -> str | None:
@@ -224,6 +235,10 @@ _KEY_BLOCK_COUNT = ".block_count"
 _KEY_EMBED_LEN = ".embedding_length"
 _KEY_HEAD_COUNT = ".attention.head_count"
 _KEY_HEAD_COUNT_KV = ".attention.head_count_kv"
+# Number of Multi-Token-Prediction (nextn) layers embedded in the main model
+# (e.g. ``glm4moe.nextn_predict_layers``). A positive value means the GGUF can
+# drive llama.cpp speculative decoding via ``--spec-type draft-mtp`` alone.
+_KEY_NEXTN = ".nextn_predict_layers"
 
 
 def read_gguf_metadata(path: str | Path) -> GGUFInfo:
@@ -245,6 +260,7 @@ def read_gguf_metadata(path: str | Path) -> GGUFInfo:
     n_heads: int | None = None
     n_kv_heads: int | None = None
     file_type: int | None = None
+    n_nextn: int | None = None
 
     with p.open("rb") as fh:
         magic = fh.read(4)
@@ -275,6 +291,8 @@ def read_gguf_metadata(path: str | Path) -> GGUFInfo:
                 n_kv_heads = value
             elif key.endswith(_KEY_HEAD_COUNT) and isinstance(value, int):
                 n_heads = value
+            elif key.endswith(_KEY_NEXTN) and isinstance(value, int):
+                n_nextn = value
 
     return GGUFInfo(
         architecture=arch,
@@ -284,6 +302,7 @@ def read_gguf_metadata(path: str | Path) -> GGUFInfo:
         n_kv_heads=n_kv_heads,
         file_type=file_type,
         file_size_bytes=file_size,
+        n_nextn=n_nextn,
     )
 
 

--- a/coderouter/ingress/launcher_routes.py
+++ b/coderouter/ingress/launcher_routes.py
@@ -40,6 +40,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
+from coderouter.launcher_speculative import resolve_speculative
 from coderouter.logging import get_logger
 
 logger = get_logger(__name__)
@@ -115,6 +116,10 @@ class ManagedProcess:
     options: dict[str, Any]
     extra_args: str
     status: str = "starting"   # "starting" | "running" | "stopped" | "error"
+    # MTP / speculative-decoding controls (defaults keep existing call sites
+    # working). Recorded for introspection; the resolved flags live in the cmd.
+    draft_model_path: str | None = None
+    mtp_mode: str = "auto"
     pid: int | None = None
     returncode: int | None = None
     log_tail: deque = field(default_factory=lambda: deque(maxlen=200))
@@ -208,8 +213,15 @@ _BACKEND_DEFAULTS: dict[str, str] = {
 #   - llama.cpp: ``-m`` / ``--model`` select the GGUF file.
 #   - vllm / mlx: ``--model`` selects the model; ``-m`` selects the python
 #     module that ``_build_cmd`` pins, so it must not be re-specified either.
+#   - llama.cpp: the draft/MTP model is likewise set only via the dedicated
+#     ``draft_model_path`` field, so its aliases (``-md`` / ``--model-draft``
+#     / ``--spec-draft-model``) are rejected in options / extra_args too. The
+#     remaining spec knobs (``--spec-type``, ``--spec-draft-n-max`` …) stay
+#     free-form.
 _MODEL_FLAGS: dict[str, frozenset[str]] = {
-    "llama.cpp": frozenset({"-m", "--model"}),
+    "llama.cpp": frozenset(
+        {"-m", "--model", "-md", "--model-draft", "--spec-draft-model"}
+    ),
     "vllm": frozenset({"-m", "--model"}),
     "mlx": frozenset({"-m", "--model"}),
 }
@@ -407,6 +419,24 @@ def _resolve_within_model_dirs(model_path: str, model_dirs: list[str]) -> Path:
     raise ValueError("model_path is not under any configured model_dirs.")
 
 
+def _option_tokens(options: dict[str, Any]) -> list[str]:
+    """Flatten an ``options`` dict into CLI tokens (``{flag: val}`` semantics).
+
+    Boolean values become a bare flag when true and vanish when false;
+    everything else becomes ``[flag, str(val)]``. Shared by ``_build_cmd`` and
+    ``api_start`` so the tokens fed to ``resolve_speculative`` match exactly
+    what lands on the command line (no double-parsing drift).
+    """
+    tokens: list[str] = []
+    for flag, val in options.items():
+        if isinstance(val, bool):
+            if val:
+                tokens.append(flag)
+        else:
+            tokens.extend([flag, str(val)])
+    return tokens
+
+
 def _build_cmd(
     backend: str,
     model_path: str,
@@ -414,17 +444,27 @@ def _build_cmd(
     options: dict[str, Any],
     extra_args: str,
     binary: str | None = None,
+    spec_tokens: list[str] | None = None,
 ) -> list[str]:
     """Build the CLI command list for the given backend and options.
 
     ``binary`` overrides the default executable (``llama-server`` /
     ``python``).  When None, the default is used and PATH resolution
     is left to the OS.
+
+    ``spec_tokens`` are pre-resolved speculative-decoding / MTP flags
+    (from :func:`coderouter.launcher_speculative.resolve_speculative`).
+    For llama.cpp they are appended right after the port args and BEFORE
+    the profile / extra args. They are trusted (the launcher, not the
+    caller, produced them) so they bypass the model-override guard even
+    though they may contain ``--model-draft``.
     """
     exe = _resolve_binary(backend, binary)
 
     if backend == "llama.cpp":
         cmd: list[str] = [exe, "-m", model_path, "--port", str(port)]
+        if spec_tokens:
+            cmd.extend(spec_tokens)
     elif backend == "vllm":
         cmd = [
             exe, "-m", "vllm.entrypoints.openai.api_server",
@@ -446,12 +486,7 @@ def _build_cmd(
     # H8: reject model-path re-specification via options keys.
     _assert_no_model_override(backend, list(options.keys()))
 
-    for flag, val in options.items():
-        if isinstance(val, bool):
-            if val:
-                cmd.append(flag)
-        else:
-            cmd.extend([flag, str(val)])
+    cmd.extend(_option_tokens(options))
 
     if extra_args.strip():
         extra_tokens = shlex.split(extra_args)
@@ -555,6 +590,11 @@ class StartRequest(BaseModel):
     port: int
     options: dict[str, Any] = {}
     extra_args: str = ""
+    # MTP / speculative-decoding controls (llama.cpp only). ``draft_model_path``
+    # is an explicit companion draft/MTP gguf; ``mtp_mode`` is "auto" (detect)
+    # or "off" (never emit speculative flags).
+    draft_model_path: str | None = None
+    mtp_mode: str = "auto"
 
 
 # ---------------------------------------------------------------------------
@@ -690,11 +730,41 @@ async def api_start(req: StartRequest, request: Request) -> dict[str, Any]:
         if bc and bc.binary:
             configured_binary = bc.binary
 
+    # Validate the MTP mode up front (only "auto" / "off" are accepted).
+    if req.mtp_mode not in ("auto", "off"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"mtp_mode must be 'auto' or 'off', got {req.mtp_mode!r}.",
+        )
+
+    # Build the user token list once (options flags + extra_args) so
+    # resolve_speculative sees exactly what _build_cmd will emit. shlex.split
+    # can raise on unbalanced quotes → surface as 400 like other bad input.
+    try:
+        user_tokens = _option_tokens(req.options)
+        if req.extra_args.strip():
+            user_tokens += shlex.split(req.extra_args)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Resolve MTP / speculative-decoding flags (llama.cpp only; no-op elsewhere).
+    try:
+        spec_tokens, spec_notes = resolve_speculative(
+            req.backend,
+            req.model_path,
+            req.draft_model_path,
+            req.mtp_mode,
+            user_tokens,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     try:
         cmd = _build_cmd(
             req.backend, req.model_path, req.port,
             req.options, req.extra_args,
             binary=configured_binary,
+            spec_tokens=spec_tokens,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -708,9 +778,13 @@ async def api_start(req: StartRequest, request: Request) -> dict[str, Any]:
         port=req.port,
         options=req.options,
         extra_args=req.extra_args,
+        draft_model_path=req.draft_model_path,
+        mtp_mode=req.mtp_mode,
         status="starting",
     )
     proc.log_tail.append(f"[launcher] cmd: {' '.join(cmd)}")
+    for note in spec_notes:
+        proc.log_tail.append(f"[launcher] {note}")
 
     try:
         p = await asyncio.create_subprocess_exec(
@@ -767,6 +841,7 @@ async def api_start(req: StartRequest, request: Request) -> dict[str, Any]:
         "pid": p.pid,
         "command": cmd,
         "provider_sync": provider_sync,
+        "speculative": spec_tokens,
     }
 
 
@@ -969,6 +1044,20 @@ _LAUNCHER_HTML = r"""<!doctype html>
           <option value="">-- なし --</option>
         </select>
         <div id="profile-args" class="mt-1 text-xs font-mono text-slate-400 bg-slate-800/50 rounded p-2 hidden"></div>
+      </div>
+
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <label class="block text-xs text-slate-400 mb-1">MTP/draft gguf (空欄で自動検出)</label>
+          <input id="f-draft" type="text" placeholder="companion .gguf (任意)" />
+        </div>
+        <div>
+          <label class="block text-xs text-slate-400 mb-1">MTP</label>
+          <select id="f-mtp">
+            <option value="auto">auto</option>
+            <option value="off">off</option>
+          </select>
+        </div>
       </div>
 
       <div>
@@ -1292,6 +1381,8 @@ _LAUNCHER_HTML = r"""<!doctype html>
     const backend = document.getElementById("f-backend").value;
     const model = document.getElementById("f-model").value.trim();
     const extra = document.getElementById("f-extra").value.trim();
+    const draft = document.getElementById("f-draft").value.trim();
+    const mtp = document.getElementById("f-mtp").value;
 
     if (!name) { showLaunchErr("名前を入力してください"); return; }
     if (!model) { showLaunchErr("モデルパスを入力してください"); return; }
@@ -1306,7 +1397,8 @@ _LAUNCHER_HTML = r"""<!doctype html>
         method: "POST",
         headers: authHeaders({"Content-Type": "application/json"}),
         body: JSON.stringify({name, backend, model_path: model, port,
-                              options: selectedProfileArgs(), extra_args: extra}),
+                              options: selectedProfileArgs(), extra_args: extra,
+                              draft_model_path: draft || null, mtp_mode: mtp}),
       });
       const d = await res.json();
       if (!res.ok) { showLaunchErr(d.detail || "起動失敗"); return; }

--- a/coderouter/launcher_speculative.py
+++ b/coderouter/launcher_speculative.py
@@ -1,0 +1,333 @@
+"""Speculative-decoding / MTP flag resolution for the llama.cpp launcher.
+
+Why this module exists
+======================
+
+llama.cpp's ``llama-server`` (2026) folds Multi-Token Prediction (MTP) into
+its speculative-decoding framework. Instead of asking the operator to hand-
+assemble the right ``--spec-type`` / ``--model-draft`` incantation, the
+launcher exposes two high-level knobs — ``draft_model_path`` and
+``mtp_mode`` — and derives the concrete CLI tokens here.
+
+Both launchers (the FastAPI web UI in
+:mod:`coderouter.ingress.launcher_routes` and the tkinter desktop app in
+``launcher_gui.py``) call :func:`resolve_speculative` so the decision logic
+lives in exactly one place.
+
+Decision summary (llama.cpp only)
+---------------------------------
+
+* ``mtp_mode="off"`` — never emit speculative flags (reproduces the historical
+  command exactly). Combining it with ``draft_model_path`` is a conflict.
+* Explicit ``draft_model_path`` — validate it, then pick ``draft-mtp`` when the
+  filename looks MTP-ish (``/mtp/i``) or ``draft-simple`` otherwise.
+* ``mtp_mode="auto"`` (the default) — inspect the main GGUF: if it embeds nextn
+  layers (``{arch}.nextn_predict_layers > 0``) use ``--spec-type draft-mtp``
+  with no separate draft model; otherwise scan the *same directory* for a
+  small companion draft/MTP gguf and wire it up if one is found.
+
+The functions here are pure stdlib + :mod:`coderouter.gguf_introspect`; they
+perform filesystem reads but never spawn processes and hold no FastAPI
+dependency, which keeps them trivially unit-testable.
+
+Security
+--------
+
+Every resolved path is placed into an argv list by the caller (never a shell
+string), and ``draft_model_path`` must resolve to an existing regular file —
+so this module adds no new shell-interpolation or path-probing surface beyond
+reading GGUF headers the operator already pointed us at.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from coderouter.gguf_introspect import try_read_gguf_metadata
+
+__all__ = ["find_draft_companion", "resolve_speculative"]
+
+_LLAMA_CPP = "llama.cpp"
+
+# Companion candidates must be meaningfully smaller than the main model — a
+# draft / MTP head is a fraction of the target's weights. Guards against
+# mistaking a second full model in the same folder for a draft.
+_COMPANION_MAX_SIZE_RATIO = 0.5
+
+# Minimum stripped-prefix length before a shared-prefix match is trusted
+# (avoids matching two unrelated models that merely share a short token).
+_MIN_PREFIX_LEN = 3
+
+# Trailing GGUF shard marker, e.g. "-00001-of-00003".
+_SHARD_RE = re.compile(r"[-._]\d{5}-of-\d{5}$", re.IGNORECASE)
+
+# Trailing quantisation token, e.g. "-Q4_K_M", ".IQ3_XXS", "-F16", "-BF16".
+_QUANT_RE = re.compile(
+    r"[-._]?(i?q\d[_a-z0-9]*|bf16|fp?16|fp?32)$",
+    re.IGNORECASE,
+)
+
+# Filename hint that the companion carries MTP tensors (→ draft-mtp).
+_MTP_NAME_RE = re.compile(r"mtp", re.IGNORECASE)
+
+
+def _strip_quant_suffix(stem: str) -> str:
+    """Return ``stem`` with a trailing shard marker and quant token removed.
+
+    Used to derive a model's "family prefix" so a companion sitting next to
+    ``Foo-7B-Q4_K_M.gguf`` (prefix ``Foo-7B``) can be matched even though its
+    own quant/shape suffix differs.
+    """
+    s = _SHARD_RE.sub("", stem)
+    s = _QUANT_RE.sub("", s)
+    return s
+
+
+def _has_spec_type(user_tokens: list[str]) -> bool:
+    """True if the operator already supplied ``--spec-type`` in extra args."""
+    return any(
+        tok == "--spec-type" or tok.startswith("--spec-type=")
+        for tok in user_tokens
+    )
+
+
+def _has_split_mode_tensor(user_tokens: list[str]) -> bool:
+    """True if the tokens request ``--split-mode tensor`` (either form).
+
+    llama.cpp issue #24309: a nextn-embedded model combined with tensor split
+    crashes, so callers warn (but do not block) when this pairs with emitted
+    speculative flags.
+    """
+    for i, tok in enumerate(user_tokens):
+        if tok == "--split-mode=tensor":
+            return True
+        if (
+            tok == "--split-mode"
+            and i + 1 < len(user_tokens)
+            and user_tokens[i + 1] == "tensor"
+        ):
+            return True
+    return False
+
+
+def _spec_type_for_name(path: Path) -> str:
+    """Pick ``draft-mtp`` for MTP-named files, ``draft-simple`` otherwise."""
+    return "draft-mtp" if _MTP_NAME_RE.search(path.name) else "draft-simple"
+
+
+def find_draft_companion(main_path: str | Path) -> Path | None:
+    """Scan the directory of ``main_path`` for a companion draft/MTP gguf.
+
+    A candidate qualifies when it is a ``*.gguf`` other than the main file,
+    is smaller than :data:`_COMPANION_MAX_SIZE_RATIO` of the main file, and
+    either:
+
+    * has an ``mtp`` or ``draft`` hint in its filename, or
+    * shares the main file's family prefix (main filename with its shard /
+      quant suffix stripped).
+
+    If a candidate's GGUF ``architecture`` is readable and differs from the
+    main model's, it is dropped (tokenizer/vocab must match for speculation);
+    unreadable metadata is kept on a best-effort basis.
+
+    Candidates are ranked by name hint (``mtp`` > ``draft`` > none), then by
+    whether they share the prefix, then by smallest size. Returns the best
+    match, or ``None`` when the directory holds no suitable companion.
+    """
+    main = Path(main_path).expanduser()
+    directory = main.parent
+    try:
+        main_size = main.stat().st_size
+    except OSError:
+        return None
+    if main_size <= 0:
+        return None
+
+    main_prefix = _strip_quant_suffix(main.stem)
+    main_meta = try_read_gguf_metadata(main)
+    main_arch = main_meta.architecture if main_meta else None
+
+    try:
+        entries = list(directory.iterdir())
+    except OSError:
+        return None
+
+    # Each ranked candidate: (name_hint, shares_prefix, -size) sorted so that
+    # the strongest hint / prefix / smallest file sorts first.
+    ranked: list[tuple[int, int, int, Path]] = []
+    for cand in entries:
+        if cand == main:
+            continue
+        if cand.suffix.lower() != ".gguf":
+            continue
+        try:
+            if not cand.is_file():
+                continue
+            size = cand.stat().st_size
+        except OSError:
+            continue
+        if size <= 0 or size >= main_size * _COMPANION_MAX_SIZE_RATIO:
+            continue
+
+        name_lower = cand.name.lower()
+        has_mtp = "mtp" in name_lower
+        has_draft = "draft" in name_lower
+        shares_prefix = (
+            len(main_prefix) >= _MIN_PREFIX_LEN
+            and cand.stem.lower().startswith(main_prefix.lower())
+        )
+        if not (has_mtp or has_draft or shares_prefix):
+            continue
+
+        # Reject a candidate whose architecture is readable and mismatches the
+        # main model — a speculator must share the target's vocabulary.
+        cand_meta = try_read_gguf_metadata(cand)
+        if (
+            cand_meta is not None
+            and cand_meta.architecture is not None
+            and main_arch is not None
+            and cand_meta.architecture != main_arch
+        ):
+            continue
+
+        name_hint = 2 if has_mtp else (1 if has_draft else 0)
+        ranked.append((name_hint, int(shares_prefix), size, cand))
+
+    if not ranked:
+        return None
+    # Highest hint, then prefix match, then smallest size.
+    ranked.sort(key=lambda t: (-t[0], -t[1], t[2]))
+    return ranked[0][3]
+
+
+def resolve_speculative(
+    backend: str,
+    model_path: str,
+    draft_model_path: str | None,
+    mtp_mode: str,
+    user_tokens: list[str],
+) -> tuple[list[str], list[str]]:
+    """Resolve speculative-decoding / MTP CLI tokens for a launch.
+
+    Parameters
+    ----------
+    backend:
+        Target backend id. Only ``"llama.cpp"`` supports speculation; other
+        backends must not receive ``draft_model_path`` / ``mtp_mode="off"``.
+    model_path:
+        The vetted main model path (already set via the launcher's dedicated
+        field). Inspected for embedded nextn layers / same-folder companions.
+    draft_model_path:
+        Optional explicit companion draft or MTP gguf. ``None`` means "not
+        supplied".
+    mtp_mode:
+        ``"auto"`` (default behaviour — detect) or ``"off"`` (never emit
+        speculative flags).
+    user_tokens:
+        The flat list of option/extra-args tokens already destined for the
+        command line. Used to defer to an operator-supplied ``--spec-type``
+        and to warn about the tensor-split crash.
+
+    Returns
+    -------
+    ``(spec_tokens, notes)`` where ``spec_tokens`` is the list of CLI tokens to
+    append (empty when none apply) and ``notes`` is a list of human-readable
+    strings describing what was decided (surfaced in the process log).
+
+    Raises
+    ------
+    ValueError
+        On misuse — the web API maps this to HTTP 400:
+
+        * ``draft_model_path`` / ``mtp_mode="off"`` on a non-llama.cpp backend,
+        * ``mtp_mode="off"`` combined with an explicit ``draft_model_path``,
+        * an explicit ``draft_model_path`` that does not resolve to a file.
+    """
+    notes: list[str] = []
+
+    # 1. Non-llama.cpp backends do not support speculation. Reject explicit
+    #    use; otherwise (auto default, no draft) stay a silent no-op.
+    if backend != _LLAMA_CPP:
+        if draft_model_path or mtp_mode == "off":
+            raise ValueError(
+                "draft_model_path / mtp_mode are only supported for llama.cpp"
+            )
+        return [], notes
+
+    # 2. Explicit opt-out. Never emit flags; conflicting draft path is an error.
+    if mtp_mode == "off":
+        if draft_model_path:
+            raise ValueError(
+                "mtp_mode='off' conflicts with an explicit draft_model_path"
+            )
+        return [], notes
+
+    # 3. Operator already drives speculation via extra args → defer entirely.
+    if _has_spec_type(user_tokens):
+        notes.append(
+            "spec flags supplied via extra args; auto MTP detection skipped"
+        )
+        return [], notes
+
+    spec_tokens: list[str] = []
+
+    # 4. Explicit companion draft / MTP gguf.
+    if draft_model_path:
+        draft = Path(draft_model_path).expanduser()
+        if not draft.is_file():
+            raise ValueError(
+                f"draft_model_path does not exist or is not a file: {draft}"
+            )
+        spec_type = _spec_type_for_name(draft)
+        spec_tokens = ["--spec-type", spec_type, "--model-draft", str(draft)]
+        notes.append(
+            f"MTP: explicit draft model {draft.name} → --spec-type {spec_type}"
+        )
+    # 5. Auto detection (only when the main path is an existing .gguf).
+    else:
+        main = Path(model_path).expanduser()
+        if main.suffix.lower() != ".gguf" or not main.is_file():
+            notes.append(
+                "MTP auto: main model is not an existing .gguf; "
+                "skipping speculative detection"
+            )
+        else:
+            info = try_read_gguf_metadata(main)
+            if info is not None and info.n_nextn and info.n_nextn > 0:
+                # 5a. Main gguf embeds nextn/MTP tensors — no draft model needed.
+                spec_tokens = ["--spec-type", "draft-mtp"]
+                notes.append(
+                    f"MTP: nextn layers ({info.n_nextn}) detected in main "
+                    "gguf → --spec-type draft-mtp"
+                )
+            else:
+                # 5b. Look for a companion gguf next to the main model.
+                companion = find_draft_companion(main)
+                if companion is not None:
+                    spec_type = _spec_type_for_name(companion)
+                    spec_tokens = [
+                        "--spec-type",
+                        spec_type,
+                        "--model-draft",
+                        str(companion),
+                    ]
+                    notes.append(
+                        f"MTP: companion gguf {companion.name} found next to "
+                        f"main → --spec-type {spec_type}"
+                    )
+                else:
+                    # 5c. Nothing found — start without speculative decoding.
+                    notes.append(
+                        f"MTP/draft gguf not found next to {main.name}; "
+                        "starting without speculative decoding"
+                    )
+
+    # 6. Warn (do not block) about the nextn + tensor-split crash.
+    if spec_tokens and _has_split_mode_tensor(user_tokens):
+        notes.append(
+            "WARNING: --split-mode tensor with speculative/nextn is known to "
+            "crash llama.cpp (issue #24309); consider --split-mode layer"
+        )
+
+    return spec_tokens, notes

--- a/docs/backends/launcher-quickstart.en.md
+++ b/docs/backends/launcher-quickstart.en.md
@@ -110,6 +110,8 @@ Open `http://localhost:8088/launcher` in a browser, pick a model, and press "▶
 
 A backend started via the Web edition is automatically registered as a provider without editing `providers.yaml` (v2.7.4). Specifying `X-CodeRouter-Profile: launcher` makes it immediately eligible for routing. See the [Launcher Guide](./launcher.en.md) for details.
 
+> **Using llama.cpp with an MTP-capable gguf?** Leave the LAUNCH form's "MTP/draft gguf" field blank and "MTP" set to `auto` to get speculative decoding auto-detected. See [MTP / speculative decoding](./launcher.en.md#mtp--speculative-decoding-llamacpp) for details.
+
 ---
 
 ## 5. Use it from Claude Code

--- a/docs/backends/launcher-quickstart.md
+++ b/docs/backends/launcher-quickstart.md
@@ -109,6 +109,8 @@ coderouter serve --port 8088
 
 Web版で起動した backend は `providers.yaml` を編集しなくても provider として自動登録されます(v2.7.4)。`X-CodeRouter-Profile: launcher` を指定すればすぐにルーティング対象になります。詳細は [Launcher ガイド](./launcher.md)。
 
+> **llama.cpp + MTP対応 gguf を使うなら**: LAUNCH フォームの「MTP/draft gguf」「MTP」欄を空欄・`auto` のままにしておけば speculative decoding を自動検出します。詳細は [MTP / speculative decoding](./launcher.md#mtp--speculative-decoding-llamacpp)。
+
 ---
 
 ## 5. Claude Code から使う

--- a/docs/backends/launcher.en.md
+++ b/docs/backends/launcher.en.md
@@ -108,6 +108,8 @@ The Launcher screen is made up of a "MODELS panel," a "LAUNCH form," a "PROCESSE
 | **Backend** | Choose from `llama.cpp` / `vllm` / `mlx`. The resolved binary path and availability are shown below |
 | **Model path** | Selected from the MODELS panel or entered directly |
 | **Option profile** | Choose a preset defined in `providers.yaml` |
+| **MTP/draft gguf** | Explicit companion draft/MTP gguf path (llama.cpp only). Leave blank for auto-detection → [MTP / speculative decoding](#mtp--speculative-decoding-llamacpp) |
+| **MTP** | `auto` (default, auto-detect) / `off` (disable speculative decoding) |
 | **Extra options** | Enter flags not in the profile on the spot. Parsed with `shlex` and appended to the end of the command |
 
 `▶ Launch` starts the process and it appears in the PROCESSES table. If the binary isn't found, **the launch button is automatically disabled** and the reason is displayed. See [Memory recommendations](#memory-recommendations) for the **⚙ Recommended values** button next to the "Extra options" field.
@@ -151,6 +153,54 @@ Real-time display of the selected process's stdout/stderr. In the Web edition, t
 2. **Start the backend** — choose an option profile and press the launch button. It shows as `running` in PROCESSES
 3. **Start CodeRouter** — "▶ Start CodeRouter" in the top bar
 4. **Connect Claude Code** — copy the connection string and run it in a terminal
+
+---
+
+## MTP / speculative decoding (llama.cpp)
+
+llama.cpp's `llama-server` supports Multi-Token Prediction (MTP) / speculative decoding via `--spec-type`-family flags. The Launcher assembles these flags automatically from the LAUNCH form's **MTP/draft gguf** field and **MTP** field (`auto` / `off`). **llama.cpp only** — specifying `draft_model_path` or `mtp_mode` for vllm/mlx makes the launch request fail with a 400.
+
+### Auto-detection order (`mtp_mode: auto`, the default)
+
+1. **Embedded nextn** — if the selected main gguf's metadata has `{arch}.nextn_predict_layers > 0`, `--spec-type draft-mtp` is added with no separate draft model needed.
+2. **Same-folder companion gguf** — if there's no embedded nextn, the Launcher scans the **same directory** as the main gguf for a companion that satisfies all of:
+   - the filename contains `mtp` or `draft`, or shares the main file's name prefix (with shard/quant suffixes stripped), and
+   - its file size is under 50% of the main gguf, and
+   - if its gguf architecture is readable, it matches the main model's (a mismatch is rejected — to avoid a tokenizer/vocabulary mismatch).
+
+   When a candidate is selected, filenames containing `mtp` get `--spec-type draft-mtp`; otherwise `--spec-type draft-simple` — both paired with `--model-draft <path>`.
+3. **Nothing found** — the process starts normally without speculative decoding. The process log records `[launcher] MTP/draft gguf not found next to <main>.gguf; starting without speculative decoding`.
+
+### Specifying an explicit draft/MTP gguf
+
+You can point the **MTP/draft gguf** field directly at a companion gguf. If the given path doesn't exist, the launch request is rejected with a 400. Filenames containing `mtp` get `--spec-type draft-mtp`; otherwise `--spec-type draft-simple`.
+
+### `mtp_mode: off`
+
+Choosing `off` in the **MTP** field never emits speculative-decoding flags (reproduces the historical launch command exactly). Combining `off` with an explicit **MTP/draft gguf** is a conflict and is rejected with a 400.
+
+### When `--spec-type` is already supplied via extra options
+
+If "Extra options" or the option profile already contains `--spec-type`, the Launcher's auto-detection is skipped entirely (no flags are added) — an explicit operator choice always wins.
+
+### `-md` / `--model-draft` cannot be used in extra options
+
+Just like `-m` / `--model`, the draft model path can only be set via the **MTP/draft gguf** field. Writing `-md` / `--model-draft` / `--spec-draft-model` into "Extra options" or an option profile causes the launch request to be rejected with a 400. The remaining speculative knobs (`--spec-type` / `--spec-draft-n-max` / `--spec-draft-n-min` / `--spec-draft-p-min` / `-ngld` / `-devd`) stay free-form.
+
+### Known issue: `--split-mode tensor` combination (llama.cpp issue #24309)
+
+Combining a nextn-embedded model / active speculative decoding with `--split-mode tensor` is known to crash llama.cpp ([issue #24309](https://github.com/ggml-org/llama.cpp/issues/24309)). The Launcher detects this combination but does not block the launch — it records a warning in the process log recommending `--split-mode layer` instead.
+
+### API
+
+`POST /api/launcher/start` (Web edition) accepts these additional fields (llama.cpp backend only; other backends get a 400):
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `draft_model_path` | `string \| null` | `null` | Explicit companion draft/MTP gguf path |
+| `mtp_mode` | `"auto" \| "off"` | `"auto"` | `auto` = auto-detect, `off` = disable speculative decoding |
+
+On a successful start, the response JSON includes the resolved speculative flags under the `"speculative"` key (a token array, e.g. `["--spec-type", "draft-mtp"]`; an empty array when nothing was added).
 
 ---
 
@@ -250,7 +300,7 @@ The string in the UI's "Extra options" field is parsed with `shlex.split()` and 
 -ngl 40 --rope-scale 2.0 --rope-freq-base 10000
 ```
 
-> **Note**: re-specifying the model via `-m` / `--model` (or the `--model=...` form) is not accepted in either extra options or option profiles — doing so causes the launch request to be rejected with a 400. Specify the model only via the "Model path" field.
+> **Note**: re-specifying the model via `-m` / `--model` (or the `--model=...` form) is not accepted in either extra options or option profiles — doing so causes the launch request to be rejected with a 400. Specify the model only via the "Model path" field. Likewise, re-specifying the draft model via `-md` / `--model-draft` / `--spec-draft-model` (llama.cpp-only flags) is not accepted in extra options or option profiles either. Specify the draft model only via the "MTP/draft gguf" field — see [MTP / speculative decoding](#mtp--speculative-decoding-llamacpp).
 
 ---
 

--- a/docs/backends/launcher.md
+++ b/docs/backends/launcher.md
@@ -108,6 +108,8 @@ Launcher の画面は「MODELS パネル」「LAUNCH フォーム」「PROCESSES
 | **バックエンド** | `llama.cpp` / `vllm` / `mlx` から選択。解決されたバイナリパスと利用可否が下に表示される |
 | **モデルパス** | MODELS パネルから選択するか直接入力 |
 | **オプションプロファイル** | `providers.yaml` で定義したプリセットを選択 |
+| **MTP/draft gguf** | 明示的な companion draft/MTP gguf のパス(llama.cpp のみ)。空欄なら自動検出 → [MTP / speculative decoding](#mtp--speculative-decoding-llamacpp) |
+| **MTP** | `auto`(既定、自動検出)/ `off`(speculative decoding を無効化) |
 | **追加オプション** | プロファイルにないフラグをその場で入力。`shlex` でパースされコマンド末尾に追加される |
 
 `▶ 起動` でプロセスが起動し、PROCESSES テーブルに表示されます。バイナリが見つからない場合は**起動ボタンが自動的に無効化**され、理由が表示されます。「追加オプション」欄の横の **⚙ 推奨値** ボタンについては [メモリ推奨](#メモリ推奨) を参照してください。
@@ -151,6 +153,54 @@ curl http://localhost:8088/v1/chat/completions \
 2. **backend を起動** — オプションプロファイルを選び起動ボタンを押す。PROCESSES に `running` で表示される
 3. **CodeRouter を起動** — 上部バーの「▶ CodeRouter 起動」
 4. **Claude Code を繋ぐ** — 接続文字列をコピーしてターミナルで実行
+
+---
+
+## MTP / speculative decoding (llama.cpp)
+
+llama.cpp の `llama-server` は Multi-Token Prediction (MTP) / speculative decoding を `--spec-type` 系フラグでサポートします。Launcher は LAUNCH フォームの **MTP/draft gguf** 欄と **MTP** 欄(`auto` / `off`)から、これらのフラグを自動的に組み立てます。**llama.cpp バックエンドのみ対応** — vllm / mlx で `draft_model_path` や `mtp_mode` を指定すると起動リクエストは 400 で拒否されます。
+
+### 自動検出の順序(`mtp_mode: auto`、既定)
+
+1. **内蔵 nextn** — 選択したメインの gguf のメタデータに `{arch}.nextn_predict_layers > 0` があれば、追加の draft モデルなしで `--spec-type draft-mtp` を付与します
+2. **同フォルダの companion gguf** — 内蔵 nextn が無ければ、メインの gguf と**同じフォルダ**を走査し、以下をすべて満たす gguf を companion として採用します
+   - ファイル名に `mtp` または `draft` を含む、またはメインファイルの名前プレフィックス(shard / 量子化サフィックスを除いた部分)を共有する
+   - ファイルサイズがメインの gguf の 50% 未満
+   - gguf の architecture が読み取れる場合、メインと一致する(不一致は却下 — トークナイザ/語彙の不一致を避けるため)
+
+   採用されると、ファイル名に `mtp` を含む候補は `--spec-type draft-mtp`、それ以外は `--spec-type draft-simple` として `--model-draft <path>` と共に付与されます。
+3. **見つからない場合** — speculative decoding なしで通常起動します。プロセスログに `[launcher] MTP/draft gguf not found next to <main>.gguf; starting without speculative decoding` と記録されます。
+
+### 明示的な draft/MTP gguf を指定する
+
+**MTP/draft gguf** 欄に companion の gguf を直接指定できます。指定したパスが存在しない場合は起動リクエストが 400 で拒否されます。ファイル名に `mtp` を含む場合は `--spec-type draft-mtp`、それ以外は `--spec-type draft-simple` になります。
+
+### `mtp_mode: off`
+
+**MTP** 欄で `off` を選ぶと speculative decoding のフラグを一切付与しません(従来どおりの起動コマンド)。`off` と **MTP/draft gguf** の同時指定は矛盾するため 400 で拒否されます。
+
+### 追加オプションで `--spec-type` を指定済みの場合
+
+「追加オプション」またはオプションプロファイルに既に `--spec-type` が含まれている場合、Launcher の自動検出は完全にスキップされます(フラグは追加されません)。ユーザー指定が常に優先されます。
+
+### `-md` / `--model-draft` は追加オプションで使えない
+
+`-m` / `--model` と同様、draft モデルのパスは **MTP/draft gguf** 欄でのみ指定できます。`-md` / `--model-draft` / `--spec-draft-model` を「追加オプション」やオプションプロファイルに書くと起動リクエストは 400 で拒否されます。残りの speculative 系フラグ(`--spec-type` / `--spec-draft-n-max` / `--spec-draft-n-min` / `--spec-draft-p-min` / `-ngld` / `-devd`)は引き続き自由入力できます。
+
+### 既知の問題: `--split-mode tensor` との組み合わせ(llama.cpp issue #24309)
+
+nextn 埋め込みモデル / speculative decoding 有効時に `--split-mode tensor` を組み合わせると llama.cpp がクラッシュする既知の問題があります([issue #24309](https://github.com/ggml-org/llama.cpp/issues/24309))。Launcher はこの組み合わせを検出しても起動はブロックせず、プロセスログに `--split-mode layer` を推奨する警告を記録します。
+
+### API
+
+Web版の `POST /api/launcher/start` は以下のフィールドを追加で受け付けます(llama.cpp バックエンドのみ有効。他バックエンドで指定すると 400):
+
+| フィールド | 型 | 既定値 | 説明 |
+|---|---|---|---|
+| `draft_model_path` | `string \| null` | `null` | 明示的な companion draft/MTP gguf のパス |
+| `mtp_mode` | `"auto" \| "off"` | `"auto"` | `auto` = 自動検出、`off` = speculative decoding を無効化 |
+
+起動成功時のレスポンス JSON には、解決された speculative フラグが `"speculative"` キー(トークン配列、例: `["--spec-type", "draft-mtp"]`。何も付与されなければ空配列)として含まれます。
 
 ---
 
@@ -250,7 +300,7 @@ UI の「追加オプション」欄の文字列は `shlex.split()` でパース
 -ngl 40 --rope-scale 2.0 --rope-freq-base 10000
 ```
 
-> **注意**: `-m` / `--model` (および `--model=...` 形式) によるモデルの再指定は、追加オプション・オプションプロファイルのどちらでも受け付けません — 指定すると起動リクエストは 400 で拒否されます。モデルは「モデルパス」欄でのみ指定してください。
+> **注意**: `-m` / `--model` (および `--model=...` 形式) によるモデルの再指定は、追加オプション・オプションプロファイルのどちらでも受け付けません — 指定すると起動リクエストは 400 で拒否されます。モデルは「モデルパス」欄でのみ指定してください。同様に `-md` / `--model-draft` / `--spec-draft-model` による draft モデルの再指定も追加オプション・オプションプロファイルでは受け付けません(llama.cpp のみのフラグ)。draft モデルは「MTP/draft gguf」欄でのみ指定してください — 詳細は [MTP / speculative decoding](#mtp--speculative-decoding-llamacpp)。
 
 ---
 

--- a/docs/backends/llamacpp-direct.en.md
+++ b/docs/backends/llamacpp-direct.en.md
@@ -235,3 +235,29 @@ In the CodeRouter logs you should see `dropped=["reasoning", "reasoning_content"
 - … and so on.
 
 Naming the provider `llamacpp-<model>` keeps things consistent with the conventions in `examples/providers.yaml`.
+
+---
+
+## Using MTP / speculative decoding manually
+
+`llama-server` accepts Multi-Token Prediction (MTP) / speculative-decoding flags directly. If you have a draft/MTP gguf available, enable it by adding the `--spec-type`-family flags:
+
+```bash
+~/llama.cpp/build/bin/llama-server \
+  --model ~/models/qwen3.6-35b-a3b-unsloth/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf \
+  --model-draft ~/models/qwen3.6-35b-a3b-unsloth/Qwen3.6-35B-A3B-mtp.gguf \
+  --spec-type draft-mtp \
+  --spec-draft-n-max 3 \
+  --port 8080 \
+  --ctx-size 32768 \
+  -ngl 999 \
+  --host 127.0.0.1
+```
+
+- `--model-draft <path>`: the companion draft/MTP gguf (must share the main model's tokenizer/vocabulary).
+- `--spec-type draft-mtp`: speculative decoding driven by an MTP head (a nextn-embedded gguf needs only this flag, no `--model-draft`). Use `draft-simple` for a generic draft model instead.
+- `--spec-draft-n-max 3`: cap on how many tokens are speculated ahead per round (tune per model/hardware).
+
+Known issue: combining a nextn-embedded model (or active speculative decoding) with `--split-mode tensor` can crash llama.cpp ([issue #24309](https://github.com/ggml-org/llama.cpp/issues/24309)). Use `--split-mode layer` if this applies to you.
+
+**The [CodeRouter Launcher](./launcher.en.md#mtp--speculative-decoding-llamacpp) automates this whole dance** — if the main gguf embeds nextn, or a companion draft/MTP gguf sits in the same folder, the Launcher auto-detects it and adds `--spec-type` / `--model-draft` to the launch command for you (set the **MTP** field to `off` to disable).

--- a/docs/backends/llamacpp-direct.md
+++ b/docs/backends/llamacpp-direct.md
@@ -288,3 +288,29 @@ llama.cpp の `llama-server` は基本どの GGUF でも上の手順で動きま
 - など
 
 provider name は `llamacpp-<モデル>` の命名で揃えると `examples/providers.yaml` のパターンと整合します。
+
+---
+
+## MTP / speculative decoding を手動で使う
+
+`llama-server` は Multi-Token Prediction (MTP) / speculative decoding フラグを直接受け付けます。draft/MTP 用の gguf を用意できる場合、`--spec-type` 系フラグを追加するだけで有効化できます:
+
+```bash
+~/llama.cpp/build/bin/llama-server \
+  --model ~/models/qwen3.6-35b-a3b-unsloth/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf \
+  --model-draft ~/models/qwen3.6-35b-a3b-unsloth/Qwen3.6-35B-A3B-mtp.gguf \
+  --spec-type draft-mtp \
+  --spec-draft-n-max 3 \
+  --port 8080 \
+  --ctx-size 32768 \
+  -ngl 999 \
+  --host 127.0.0.1
+```
+
+- `--model-draft <path>`: companion の draft/MTP gguf(メインモデルとトークナイザ/語彙が一致している必要あり)
+- `--spec-type draft-mtp`: MTP head を使う speculative decoding(nextn 埋め込み gguf ならこのフラグのみで `--model-draft` 不要)。汎用の draft モデルには `draft-simple` を使う
+- `--spec-draft-n-max 3`: 1 回の speculation で先読みするトークン数の上限(モデル/ハードに応じて調整)
+
+既知の問題として、nextn 埋め込みモデル(または speculative decoding 有効時)と `--split-mode tensor` の組み合わせは llama.cpp がクラッシュすることがあります([issue #24309](https://github.com/ggml-org/llama.cpp/issues/24309))。該当する場合は `--split-mode layer` を使ってください。
+
+**この一連の手組みは [CodeRouter Launcher](./launcher.md#mtp--speculative-decoding-llamacpp) が自動化しています** — メインの gguf に nextn が埋め込まれているか、同じフォルダに companion の draft/MTP gguf があれば、Launcher が `--spec-type` / `--model-draft` を自動検出して起動コマンドに付与します(`MTP` 欄で `off` にすれば無効化も可能)。

--- a/launcher_gui.py
+++ b/launcher_gui.py
@@ -1055,7 +1055,7 @@ class LauncherApp(tk.Tk):
             row=6, column=1, columnspan=3, sticky="ew",
             padx=(0, 10), pady=(0, 2))
 
-        lbl("MTP/draft gguf（空欄で自動検出）", 7, 0)
+        lbl("MTP/draft gguf (空欄で自動検出)", 7, 0)
         self._draft_path_var = tk.StringVar()
         ttk.Entry(card, textvariable=self._draft_path_var).grid(
             row=7, column=1, columnspan=2, sticky="ew",

--- a/launcher_gui.py
+++ b/launcher_gui.py
@@ -54,6 +54,18 @@ except ImportError:
         )
 
 # ---------------------------------------------------------------------------
+# MTP / speculative-decoding resolution (optional — shared with the web UI)
+# ---------------------------------------------------------------------------
+# The GUI can run standalone without the coderouter package on sys.path; when
+# the import fails we degrade gracefully and simply skip the MTP features.
+try:
+    from coderouter.launcher_speculative import resolve_speculative
+    _HAS_SPECULATIVE = True
+except ImportError:
+    resolve_speculative = None  # type: ignore
+    _HAS_SPECULATIVE = False
+
+# ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
 
@@ -179,9 +191,19 @@ def _scan_models(model_dirs: list[str]) -> list[dict[str, Any]]:
 
 def _build_cmd(backend: str, model_path: str, port: int,
                profile_args: dict[str, Any], extra_args: str,
-               binary: str) -> list[str]:
+               binary: str,
+               spec_tokens: list[str] | None = None) -> list[str]:
+    """Assemble the backend launch command.
+
+    ``spec_tokens`` are pre-resolved MTP / speculative-decoding flags (from
+    :func:`coderouter.launcher_speculative.resolve_speculative`). For
+    llama.cpp they are inserted right after the port args, before the profile
+    / extra args.
+    """
     if backend == "llama.cpp":
         cmd = [binary, "-m", model_path, "--port", str(port)]
+        if spec_tokens:
+            cmd.extend(spec_tokens)
     elif backend == "vllm":
         cmd = [binary, "-m", "vllm.entrypoints.openai.api_server",
                "--model", model_path, "--port", str(port)]
@@ -1033,21 +1055,31 @@ class LauncherApp(tk.Tk):
             row=6, column=1, columnspan=3, sticky="ew",
             padx=(0, 10), pady=(0, 2))
 
-        lbl("追加オプション", 7, 0)
+        lbl("MTP/draft gguf（空欄で自動検出）", 7, 0)
+        self._draft_path_var = tk.StringVar()
+        ttk.Entry(card, textvariable=self._draft_path_var).grid(
+            row=7, column=1, columnspan=2, sticky="ew",
+            padx=(0, 6), pady=(6, 0))
+        self._mtp_auto_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(card, text="MTP自動検出",
+                        variable=self._mtp_auto_var).grid(
+            row=7, column=3, sticky="w", padx=(0, 10), pady=(6, 0))
+
+        lbl("追加オプション", 8, 0)
         self._extra_var = tk.StringVar(value="-ngl 99")
         ttk.Entry(card, textvariable=self._extra_var).grid(
-            row=7, column=1, columnspan=2, sticky="ew",
+            row=8, column=1, columnspan=2, sticky="ew",
             padx=(0, 6), pady=(6, 0))
         tk.Button(card, text="⚙ 推奨値", fg=self.FG, bg=self.BG3,
                   activebackground=self.BG2, activeforeground=self.FG,
                   relief="flat", bd=0, padx=6, pady=3, cursor="hand2",
                   font=("sans-serif", 9),
                   command=self._suggest_options).grid(
-            row=7, column=3, sticky="ew", padx=(0, 10), pady=(6, 0))
+            row=8, column=3, sticky="ew", padx=(0, 10), pady=(6, 0))
 
         # 起動ボタン
         _btn_wrap = tk.Frame(card, bg=self.ACCENT, bd=0)
-        _btn_wrap.grid(row=8, column=0, columnspan=4, sticky="ew", padx=10, pady=8)
+        _btn_wrap.grid(row=9, column=0, columnspan=4, sticky="ew", padx=10, pady=8)
         self._launch_btn = tk.Button(
             _btn_wrap, text="▶ llama.cpp / vllm / mlx 起動",
             fg="white", bg=self.ACCENT,
@@ -1065,7 +1097,7 @@ class LauncherApp(tk.Tk):
         tk.Label(card, textvariable=self._launch_err_var,
                  fg=self.RED, bg=self.BG2,
                  font=("sans-serif", 9), anchor="w", justify="left",
-                 wraplength=400).grid(row=9, column=0, columnspan=4,
+                 wraplength=400).grid(row=10, column=0, columnspan=4,
                                       sticky="ew", padx=10, pady=(0, 6))
 
         # アニメーション用(Progressbar 非使用)
@@ -1173,8 +1205,34 @@ class LauncherApp(tk.Tk):
             if matched:
                 profile_args = matched.args
 
+        # MTP / speculative-decoding resolution (llama.cpp only; no-op for
+        # other backends). Skipped entirely if the coderouter package is not
+        # importable (standalone GUI use).
+        spec_tokens: list[str] = []
+        spec_notes: list[str] = []
+        if _HAS_SPECULATIVE and resolve_speculative is not None:
+            draft_path = self._draft_path_var.get().strip() or None
+            mtp_mode = "auto" if self._mtp_auto_var.get() else "off"
+            user_tokens: list[str] = []
+            for flag, val in profile_args.items():
+                if isinstance(val, bool):
+                    if val:
+                        user_tokens.append(str(flag))
+                else:
+                    user_tokens.extend([str(flag), str(val)])
+            if extra.strip():
+                with contextlib.suppress(ValueError):
+                    user_tokens += shlex.split(extra)
+            try:
+                spec_tokens, spec_notes = resolve_speculative(
+                    backend, model_path, draft_path, mtp_mode, user_tokens)
+            except ValueError as e:
+                self._set_launch_err(str(e))
+                return
+
         try:
-            cmd = _build_cmd(backend, model_path, port, profile_args, extra, binary)
+            cmd = _build_cmd(backend, model_path, port, profile_args, extra,
+                             binary, spec_tokens)
         except ValueError as e:
             self._set_launch_err(str(e))
             return
@@ -1203,6 +1261,8 @@ class LauncherApp(tk.Tk):
 
         def _run() -> None:
             mp.log_lines.append(f"[launcher] cmd: {' '.join(cmd)}")
+            for note in spec_notes:
+                mp.log_lines.append(f"[launcher] {note}")
             try:
                 p = subprocess.Popen(
                     cmd,

--- a/tests/test_gguf_introspect.py
+++ b/tests/test_gguf_introspect.py
@@ -137,3 +137,28 @@ def test_missing_file_raises(tmp_path: Path) -> None:
 def test_try_variant_returns_none_on_bad_file(tmp_path: Path) -> None:
     p = _write(tmp_path, b"junk")
     assert try_read_gguf_metadata(p) is None
+
+
+def test_nextn_predict_layers_detected(tmp_path: Path) -> None:
+    """A ``{arch}.nextn_predict_layers`` KV surfaces as n_nextn / supports_mtp."""
+    kvs = [
+        _kv_string("general.architecture", "glm4moe"),
+        _kv_u32("glm4moe.block_count", 40),
+        _kv_u32("glm4moe.nextn_predict_layers", 1),
+    ]
+    p = _write(tmp_path, _build_gguf(kvs))
+    info = read_gguf_metadata(p)
+    assert info.n_nextn == 1
+    assert info.supports_mtp is True
+
+
+def test_nextn_absent_is_none_and_not_mtp(tmp_path: Path) -> None:
+    """Without the nextn KV, n_nextn is None and supports_mtp is False."""
+    kvs = [
+        _kv_string("general.architecture", "llama"),
+        _kv_u32("llama.block_count", 32),
+    ]
+    p = _write(tmp_path, _build_gguf(kvs))
+    info = read_gguf_metadata(p)
+    assert info.n_nextn is None
+    assert info.supports_mtp is False

--- a/tests/test_launcher_mtp.py
+++ b/tests/test_launcher_mtp.py
@@ -1,0 +1,440 @@
+"""Tests for MTP / speculative-decoding support in the llama.cpp launcher.
+
+Covers the shared decision logic in
+:mod:`coderouter.launcher_speculative` (``resolve_speculative`` /
+``find_draft_companion``) plus the launcher-route integration:
+
+* auto detection of nextn-embedded main ggufs → ``--spec-type draft-mtp``,
+* same-folder companion discovery (size ratio, arch-mismatch rejection,
+  mtp- vs draft-named ``--spec-type`` choice),
+* the ``mtp_mode='off'`` / explicit-path / defer / non-llama.cpp guards,
+* the ``--split-mode tensor`` crash warning,
+* ``_MODEL_FLAGS`` rejection of ``-md`` and the end-to-end ``api_start``
+  behaviour (400 on override, ``speculative`` key in the start response).
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from coderouter.config.schemas import CodeRouterConfig, FallbackChain, ProviderConfig
+from coderouter.ingress import launcher_routes
+from coderouter.ingress.app import create_app
+from coderouter.ingress.launcher_routes import _build_cmd
+from coderouter.launcher_speculative import find_draft_companion, resolve_speculative
+from coderouter.metrics import uninstall_collector
+
+# ---------------------------------------------------------------------------
+# Synthetic GGUF builders (mirrors tests/test_gguf_introspect.py helpers)
+# ---------------------------------------------------------------------------
+
+_MAGIC = b"GGUF"
+_T_UINT32 = 4
+_T_STRING = 8
+
+
+def _gguf_string(s: str) -> bytes:
+    raw = s.encode("utf-8")
+    return struct.pack("<Q", len(raw)) + raw
+
+
+def _kv_string(key: str, value: str) -> bytes:
+    return _gguf_string(key) + struct.pack("<I", _T_STRING) + _gguf_string(value)
+
+
+def _kv_u32(key: str, value: int) -> bytes:
+    return _gguf_string(key) + struct.pack("<I", _T_UINT32) + struct.pack("<I", value)
+
+
+def _gguf_bytes(arch: str, *, nextn: int | None = None) -> bytes:
+    kvs = [_kv_string("general.architecture", arch)]
+    if nextn is not None:
+        kvs.append(_kv_u32(f"{arch}.nextn_predict_layers", nextn))
+    header = _MAGIC + struct.pack("<I", 3) + struct.pack("<Q", 0)
+    header += struct.pack("<Q", len(kvs))
+    return header + b"".join(kvs)
+
+
+def _make_gguf(
+    path: Path, arch: str, *, nextn: int | None = None, size: int = 0
+) -> Path:
+    """Write a parseable GGUF header, padded with zero bytes to ``size``.
+
+    Trailing padding is never read by the header parser, so it is a cheap way
+    to give the file a controllable on-disk size for the ratio checks.
+    """
+    data = _gguf_bytes(arch, nextn=nextn)
+    if size > len(data):
+        data = data + b"\x00" * (size - len(data))
+    path.write_bytes(data)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# resolve_speculative — mtp_mode / backend guards
+# ---------------------------------------------------------------------------
+
+
+def test_off_returns_no_flags() -> None:
+    tokens, _notes = resolve_speculative("llama.cpp", "/m.gguf", None, "off", [])
+    assert tokens == []
+
+
+def test_off_with_draft_path_raises() -> None:
+    with pytest.raises(ValueError, match="conflicts"):
+        resolve_speculative("llama.cpp", "/m.gguf", "/d.gguf", "off", [])
+
+
+def test_non_llamacpp_with_draft_raises() -> None:
+    with pytest.raises(ValueError, match=r"only supported for llama\.cpp"):
+        resolve_speculative("vllm", "/m.safetensors", "/d.gguf", "auto", [])
+
+
+def test_non_llamacpp_off_raises() -> None:
+    with pytest.raises(ValueError, match=r"only supported for llama\.cpp"):
+        resolve_speculative("mlx", "/m", None, "off", [])
+
+
+def test_non_llamacpp_auto_is_noop() -> None:
+    tokens, notes = resolve_speculative("vllm", "/m.safetensors", None, "auto", [])
+    assert tokens == [] and notes == []
+
+
+def test_user_spec_type_defers(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "m.gguf", "glm4moe", nextn=1, size=4000)
+    tokens, notes = resolve_speculative(
+        "llama.cpp", str(main), None, "auto", ["--spec-type", "draft-eagle3"]
+    )
+    assert tokens == []
+    assert any("skipped" in n for n in notes)
+
+
+def test_user_spec_type_equals_form_defers(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "m.gguf", "glm4moe", nextn=1, size=4000)
+    tokens, _ = resolve_speculative(
+        "llama.cpp", str(main), None, "auto", ["--spec-type=draft-mtp"]
+    )
+    assert tokens == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_speculative — explicit draft path
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_missing_path_raises() -> None:
+    with pytest.raises(ValueError, match="does not exist"):
+        resolve_speculative(
+            "llama.cpp", "/m.gguf", "/nope/missing.gguf", "auto", []
+        )
+
+
+def test_explicit_draft_simple(tmp_path: Path) -> None:
+    draft = _make_gguf(tmp_path / "small-draft.gguf", "llama", size=1000)
+    tokens, _notes = resolve_speculative(
+        "llama.cpp", "/m.gguf", str(draft), "auto", []
+    )
+    assert tokens == ["--spec-type", "draft-simple", "--model-draft", str(draft)]
+
+
+def test_explicit_draft_mtp_by_name(tmp_path: Path) -> None:
+    draft = _make_gguf(tmp_path / "model-mtp.gguf", "llama", size=1000)
+    tokens, _ = resolve_speculative(
+        "llama.cpp", "/m.gguf", str(draft), "auto", []
+    )
+    assert tokens[:2] == ["--spec-type", "draft-mtp"]
+    assert tokens[2:] == ["--model-draft", str(draft)]
+
+
+# ---------------------------------------------------------------------------
+# resolve_speculative — auto detection
+# ---------------------------------------------------------------------------
+
+
+def test_auto_nextn_main_gguf(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "glm.gguf", "glm4moe", nextn=2, size=4000)
+    tokens, notes = resolve_speculative("llama.cpp", str(main), None, "auto", [])
+    assert tokens == ["--spec-type", "draft-mtp"]
+    assert any("nextn layers (2)" in n for n in notes)
+
+
+def test_auto_no_gguf_skips_silently() -> None:
+    tokens, notes = resolve_speculative(
+        "llama.cpp", "/models/model.safetensors", None, "auto", []
+    )
+    assert tokens == []
+    assert any("not an existing .gguf" in n for n in notes)
+
+
+def test_auto_nothing_found(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "solo.gguf", "llama", size=4000)
+    tokens, notes = resolve_speculative("llama.cpp", str(main), None, "auto", [])
+    assert tokens == []
+    assert any("not found next to" in n for n in notes)
+
+
+def test_auto_companion_mtp_named(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "qwen-7b.gguf", "qwen2", size=8000)
+    _make_gguf(tmp_path / "qwen-7b-mtp.gguf", "qwen2", size=1000)
+    tokens, _notes = resolve_speculative("llama.cpp", str(main), None, "auto", [])
+    assert tokens[:2] == ["--spec-type", "draft-mtp"]
+    assert tokens[2] == "--model-draft"
+    assert tokens[3].endswith("qwen-7b-mtp.gguf")
+
+
+def test_auto_companion_draft_named(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "qwen-7b.gguf", "qwen2", size=8000)
+    _make_gguf(tmp_path / "qwen-7b-draft.gguf", "qwen2", size=1000)
+    tokens, _ = resolve_speculative("llama.cpp", str(main), None, "auto", [])
+    assert tokens[:2] == ["--spec-type", "draft-simple"]
+    assert tokens[3].endswith("qwen-7b-draft.gguf")
+
+
+# ---------------------------------------------------------------------------
+# find_draft_companion — ratio & arch-mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_companion_too_large_is_ignored(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "base.gguf", "llama", size=4000)
+    # 3000 >= 50% of 4000 → not a plausible draft.
+    _make_gguf(tmp_path / "base-draft.gguf", "llama", size=3000)
+    assert find_draft_companion(main) is None
+
+
+def test_companion_arch_mismatch_dropped(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "base.gguf", "llama", size=8000)
+    # draft-named but wrong architecture → vocab mismatch → rejected.
+    _make_gguf(tmp_path / "base-draft.gguf", "qwen2", size=1000)
+    assert find_draft_companion(main) is None
+
+
+def test_companion_arch_match_selected(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "base.gguf", "llama", size=8000)
+    good = _make_gguf(tmp_path / "base-draft.gguf", "llama", size=1000)
+    assert find_draft_companion(main) == good
+
+
+def test_companion_mtp_outranks_draft(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "base.gguf", "llama", size=8000)
+    _make_gguf(tmp_path / "base-draft.gguf", "llama", size=1000)
+    mtp = _make_gguf(tmp_path / "base-mtp.gguf", "llama", size=1200)
+    assert find_draft_companion(main) == mtp
+
+
+# ---------------------------------------------------------------------------
+# split-mode tensor warning
+# ---------------------------------------------------------------------------
+
+
+def test_split_mode_tensor_warns(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "glm.gguf", "glm4moe", nextn=1, size=4000)
+    tokens, notes = resolve_speculative(
+        "llama.cpp", str(main), None, "auto", ["--split-mode", "tensor"]
+    )
+    assert tokens == ["--spec-type", "draft-mtp"]
+    assert any("#24309" in n for n in notes)
+
+
+def test_split_mode_tensor_equals_form_warns(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "glm.gguf", "glm4moe", nextn=1, size=4000)
+    _tokens, notes = resolve_speculative(
+        "llama.cpp", str(main), None, "auto", ["--split-mode=tensor"]
+    )
+    assert any("#24309" in n for n in notes)
+
+
+def test_no_warning_without_spec_flags(tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "solo.gguf", "llama", size=4000)
+    tokens, notes = resolve_speculative(
+        "llama.cpp", str(main), None, "auto", ["--split-mode", "tensor"]
+    )
+    assert tokens == []
+    assert not any("#24309" in n for n in notes)
+
+
+# ---------------------------------------------------------------------------
+# _build_cmd — spec token placement + -md rejection
+# ---------------------------------------------------------------------------
+
+
+def test_build_cmd_places_spec_tokens_after_port() -> None:
+    cmd = _build_cmd(
+        "llama.cpp",
+        "/models/good.gguf",
+        8080,
+        {"--threads": 8},
+        "-ngl 99",
+        spec_tokens=["--spec-type", "draft-mtp"],
+    )
+    port_idx = cmd.index("--port")
+    st_idx = cmd.index("--spec-type")
+    threads_idx = cmd.index("--threads")
+    ngl_idx = cmd.index("-ngl")
+    # spec tokens land right after the port args, before profile/extra args.
+    assert st_idx == port_idx + 2
+    assert st_idx < threads_idx < ngl_idx
+    assert cmd.count("--spec-type") == 1
+
+
+@pytest.mark.parametrize("flag", ["-md", "--model-draft", "--spec-draft-model"])
+def test_build_cmd_rejects_draft_flag_in_extra_args(flag: str) -> None:
+    with pytest.raises(ValueError, match="not allowed"):
+        _build_cmd(
+            "llama.cpp",
+            "/models/good.gguf",
+            8080,
+            {},
+            f"{flag} /models/draft.gguf",
+        )
+
+
+def test_build_cmd_allows_spec_type_in_extra_args() -> None:
+    """The remaining spec knobs stay free-form in extra_args."""
+    cmd = _build_cmd(
+        "llama.cpp",
+        "/models/good.gguf",
+        8080,
+        {},
+        "--spec-type draft-mtp --spec-draft-n-max 3",
+    )
+    assert "--spec-type" in cmd and "--spec-draft-n-max" in cmd
+
+
+# ---------------------------------------------------------------------------
+# api_start integration (TestClient)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config() -> CodeRouterConfig:
+    return CodeRouterConfig(
+        allow_paid=False,
+        default_profile="default",
+        providers=[
+            ProviderConfig(
+                name="local",
+                base_url="http://localhost:8080/v1",
+                model="qwen-coder",
+                paid=False,
+            ),
+        ],
+        profiles=[FallbackChain(name="default", providers=["local"])],
+    )
+
+
+@pytest.fixture
+def client(
+    config: CodeRouterConfig, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[TestClient]:
+    monkeypatch.setattr(
+        "coderouter.ingress.app.load_config", lambda path=None: config
+    )
+    monkeypatch.delenv("CODEROUTER_LAUNCHER_TOKEN", raising=False)
+    uninstall_collector()
+    app = create_app()
+    try:
+        with TestClient(app) as tc:
+            yield tc
+    finally:
+        uninstall_collector()
+
+
+class _FakeProc:
+    """Minimal stand-in for an asyncio subprocess used by _tail_logs."""
+
+    def __init__(self) -> None:
+        self.pid = 4321
+        self.stdout = None
+        self.stderr = None
+        self.returncode = 0
+
+    async def wait(self) -> int:
+        return 0
+
+    def terminate(self) -> None:  # pragma: no cover - not exercised
+        pass
+
+    def kill(self) -> None:  # pragma: no cover - not exercised
+        pass
+
+
+@pytest.fixture
+def _patch_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_exec(*_args: object, **_kwargs: object) -> _FakeProc:
+        return _FakeProc()
+
+    monkeypatch.setattr(
+        launcher_routes.asyncio, "create_subprocess_exec", _fake_exec
+    )
+
+
+def test_api_start_rejects_draft_flag_in_extra_args(client: TestClient) -> None:
+    resp = client.post(
+        "/api/launcher/start",
+        json={
+            "name": "x",
+            "backend": "llama.cpp",
+            "model_path": "/models/good.gguf",
+            "port": 8080,
+            "extra_args": "-md /models/draft.gguf",
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "not allowed" in resp.json()["detail"]
+
+
+def test_api_start_rejects_bad_mtp_mode(client: TestClient) -> None:
+    resp = client.post(
+        "/api/launcher/start",
+        json={
+            "name": "x",
+            "backend": "llama.cpp",
+            "model_path": "/models/good.gguf",
+            "port": 8080,
+            "mtp_mode": "always",
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "mtp_mode" in resp.json()["detail"]
+
+
+def test_api_start_off_with_draft_is_400(client: TestClient) -> None:
+    resp = client.post(
+        "/api/launcher/start",
+        json={
+            "name": "x",
+            "backend": "llama.cpp",
+            "model_path": "/models/good.gguf",
+            "port": 8080,
+            "mtp_mode": "off",
+            "draft_model_path": "/models/draft.gguf",
+        },
+    )
+    assert resp.status_code == 400, resp.text
+
+
+def test_api_start_response_has_speculative(
+    client: TestClient, tmp_path: Path, _patch_subprocess: None
+) -> None:
+    main = _make_gguf(tmp_path / "glm.gguf", "glm4moe", nextn=1, size=4000)
+    resp = client.post(
+        "/api/launcher/start",
+        json={
+            "name": "glm",
+            "backend": "llama.cpp",
+            "model_path": str(main),
+            "port": 8080,
+            "mtp_mode": "auto",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["speculative"] == ["--spec-type", "draft-mtp"]
+    # The resolved flags are present in the command exactly once.
+    assert body["command"].count("--spec-type") == 1


### PR DESCRIPTION
## Summary

Adds MTP (Multi-Token Prediction) / speculative-decoding support to the llama.cpp launcher (Web UI + desktop GUI).

- `mtp_mode="auto"` (default): ① main gguf に `{arch}.nextn_predict_layers > 0` があれば `--spec-type draft-mtp`（別gguf不要） → ② なければ同フォルダの companion draft/MTP gguf を自動検出して `--model-draft` 付与 → ③ なければ通常起動＋ログ
- 明示指定用の `draft_model_path` / 無効化用の `mtp_mode="off"` を `POST /api/launcher/start` に追加、レスポンスに `speculative` キー
- `-md` / `--model-draft` / `--spec-draft-model` を extra_args の denylist に追加（既存 `-m` ガードと同方針）。ユーザーが `--spec-type` を指定した場合は自動検出は譲る
- 共有ロジックは新規 `coderouter/launcher_speculative.py`（両launcherから利用）
- `gguf_introspect`: `n_nextn` / `supports_mtp` 追加
- nextn内蔵モデル＋`--split-mode tensor` の既知クラッシュ (ggml-org/llama.cpp#24309) は警告ログ
- docs (ja/en) 更新、CHANGELOG v2.7.6、テスト41件追加（フルスイート1605件通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169bqKt3eAhtwEe3vd8BP8e