### PR TITLE
fix(launcher): auto-retry without speculative flags on MTP startup crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ with a silent no-op fallback, no config-schema changes, no new dependencies.
 - **UI**: Web LAUNCH form gets "MTP/draft gguf (空欄で自動検出)" text field
   + "MTP" `auto`/`off` select. Desktop GUI (`launcher_gui.py`) gets the
   matching Entry + a "MTP自動検出" checkbox (default on).
+- **Automatic MTP startup-crash fallback**: when speculative flags were added
+  by AUTO detection (`mtp_mode="auto"`, no explicit `draft_model_path`) and the
+  backend dies during startup (non-zero exit within ~3 min), the launcher
+  relaunches it ONCE without the speculative flags and logs
+  `[launcher] MTP startup failure detected (exit code ...); retrying without
+  speculative decoding` plus the flag-free command. This covers architectures
+  whose `draft-mtp` support in llama.cpp is still immature (detection is right
+  but the MTP context fails to initialize, e.g. `failed to measure MTP context
+  memory`). Explicit `draft_model_path` / operator-supplied `--spec-type` are
+  never auto-retried, and the retry can never loop (single-shot, guarded).
+  Implemented in both the Web launcher (`launcher_routes.py`) and the desktop
+  GUI (`launcher_gui.py`).
 
 ### Docs
 

--- a/coderouter/ingress/launcher_routes.py
+++ b/coderouter/ingress/launcher_routes.py
@@ -30,6 +30,7 @@ import secrets
 import shlex
 import shutil
 import subprocess
+import time
 import uuid
 from collections import deque
 from dataclasses import dataclass, field
@@ -123,6 +124,16 @@ class ManagedProcess:
     pid: int | None = None
     returncode: int | None = None
     log_tail: deque = field(default_factory=lambda: deque(maxlen=200))
+    # MTP auto-fallback state. When the speculative flags were added by AUTO
+    # detection and the child dies during startup, the process is relaunched
+    # ONCE without them (some archs' draft-mtp support in llama.cpp is
+    # immature and crashes the context init). These fields make that possible
+    # and impossible to loop.
+    spec_tokens: list = field(default_factory=list)
+    spec_auto: bool = False
+    mtp_fallback_done: bool = False
+    fallback_cmd: list | None = None
+    started_at: float = 0.0
     # asyncio subprocess handle — not serialised
     _proc: Any = field(default=None, repr=False, compare=False)
 
@@ -509,12 +520,37 @@ def _build_cmd(
 # recover by reading the buffered chunk and continuing so log tailing survives.
 _LOG_STREAM_LIMIT = 256 * 1024  # 256 KB
 
+# Window (seconds) after spawn in which a non-zero exit is treated as a
+# startup crash eligible for the MTP auto-fallback. A backend that ran fine
+# for longer and then died is a normal crash, not a load-time failure, so it
+# is never retried.
+_MTP_FALLBACK_WINDOW_SECS = 180.0
+
+
+def _should_mtp_fallback(proc: ManagedProcess) -> bool:
+    """True when a just-crashed process qualifies for the one-shot MTP retry.
+
+    Only auto-detected speculative launches that die within the startup
+    window are eligible, and only once (guarded by ``mtp_fallback_done``).
+    """
+    p = proc._proc
+    rc = p.returncode if p is not None else proc.returncode
+    return (
+        proc.spec_auto
+        and not proc.mtp_fallback_done
+        and bool(proc.fallback_cmd)
+        and rc not in (0, None)
+        and (time.monotonic() - proc.started_at) <= _MTP_FALLBACK_WINDOW_SECS
+    )
+
 
 async def _tail_logs(proc: ManagedProcess) -> None:
-    """Read stdout+stderr into proc.log_tail until the process exits."""
-    p = proc._proc
-    if p is None:
-        return
+    """Read stdout+stderr into proc.log_tail until the process exits.
+
+    Loops so that a one-shot MTP fallback (relaunch without the auto-detected
+    speculative flags) can be tailed by the same task. The loop exits as soon
+    as no fallback applies.
+    """
 
     async def _drain(stream: asyncio.StreamReader | None) -> None:
         if stream is None:
@@ -540,14 +576,53 @@ async def _tail_logs(proc: ManagedProcess) -> None:
                 break
             proc.log_tail.append(line.decode(errors="replace").rstrip())
 
-    await asyncio.gather(_drain(p.stdout), _drain(p.stderr))
-    await p.wait()
-    proc.returncode = p.returncode
-    proc.pid = None
-    proc.status = "stopped" if (p.returncode or 0) == 0 else "error"
-    proc.log_tail.append(
-        f"[launcher] process exited with code {p.returncode}"
-    )
+    while True:
+        p = proc._proc
+        if p is None:
+            return
+
+        await asyncio.gather(_drain(p.stdout), _drain(p.stderr))
+        await p.wait()
+        proc.returncode = p.returncode
+        proc.pid = None
+        proc.status = "stopped" if (p.returncode or 0) == 0 else "error"
+        proc.log_tail.append(
+            f"[launcher] process exited with code {p.returncode}"
+        )
+
+        if not _should_mtp_fallback(proc):
+            return
+
+        # Auto-detected MTP crashed during startup — retry ONCE without the
+        # speculative flags. The port is unchanged, so the existing provider
+        # registration still stands (do not re-register).
+        rc = proc.returncode
+        proc.mtp_fallback_done = True
+        proc.log_tail.append(
+            f"[launcher] MTP startup failure detected (exit code {rc}); "
+            "retrying without speculative decoding"
+        )
+        proc.log_tail.append(
+            f"[launcher] cmd: {' '.join(proc.fallback_cmd)}"
+        )
+        try:
+            p = await asyncio.create_subprocess_exec(
+                *proc.fallback_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                limit=_LOG_STREAM_LIMIT,
+            )
+        except (FileNotFoundError, OSError) as exc:
+            proc.log_tail.append(f"[launcher] fallback relaunch failed: {exc}")
+            proc.status = "error"
+            return
+        proc._proc = p
+        proc.pid = p.pid
+        proc.status = "running"
+        proc.returncode = None
+        proc.started_at = time.monotonic()
+        proc.log_tail.append(f"[launcher] started PID {p.pid}")
+        # Loop to tail the relaunched process.
 
 
 async def shutdown_launcher(app: Any) -> None:
@@ -769,6 +844,30 @@ async def api_start(req: StartRequest, request: Request) -> dict[str, Any]:
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    # Speculative flags qualify for the one-shot startup-crash fallback only
+    # when they came from AUTO detection (mtp_mode="auto", no explicit draft
+    # model, and detection actually emitted flags). Explicit draft paths and
+    # operator-supplied --spec-type are never auto-retried. The fallback cmd
+    # is rebuilt from scratch with spec_tokens=None (exact — never spliced).
+    spec_auto = (
+        req.mtp_mode == "auto"
+        and req.draft_model_path is None
+        and bool(spec_tokens)
+    )
+    fallback_cmd: list[str] | None = None
+    if spec_auto:
+        try:
+            fallback_cmd = _build_cmd(
+                req.backend, req.model_path, req.port,
+                req.options, req.extra_args,
+                binary=configured_binary,
+                spec_tokens=None,
+            )
+        except ValueError:
+            # A failure to rebuild the non-spec command simply disables the
+            # fallback; it must never block the primary start.
+            fallback_cmd = None
+
     proc_id = uuid.uuid4().hex[:8]
     proc = ManagedProcess(
         id=proc_id,
@@ -781,6 +880,9 @@ async def api_start(req: StartRequest, request: Request) -> dict[str, Any]:
         draft_model_path=req.draft_model_path,
         mtp_mode=req.mtp_mode,
         status="starting",
+        spec_tokens=spec_tokens,
+        spec_auto=spec_auto and fallback_cmd is not None,
+        fallback_cmd=fallback_cmd,
     )
     proc.log_tail.append(f"[launcher] cmd: {' '.join(cmd)}")
     for note in spec_notes:
@@ -806,6 +908,7 @@ async def api_start(req: StartRequest, request: Request) -> dict[str, Any]:
     proc._proc = p
     proc.pid = p.pid
     proc.status = "running"
+    proc.started_at = time.monotonic()
     proc.log_tail.append(f"[launcher] started PID {p.pid}")
 
     _registry(request).add(proc)

--- a/docs/backends/launcher.en.md
+++ b/docs/backends/launcher.en.md
@@ -191,6 +191,10 @@ Just like `-m` / `--model`, the draft model path can only be set via the **MTP/d
 
 Combining a nextn-embedded model / active speculative decoding with `--split-mode tensor` is known to crash llama.cpp ([issue #24309](https://github.com/ggml-org/llama.cpp/issues/24309)). The Launcher detects this combination but does not block the launch — it records a warning in the process log recommending `--split-mode layer` instead.
 
+### Automatic fallback when auto-detected MTP crashes at startup
+
+If the speculative flags were added by **auto-detection** (`mtp_mode: auto`) and the backend **crashes during startup (within ~3 minutes)**, the Launcher **automatically relaunches it once** without the speculative flags. Detection can be correct while some architectures' `draft-mtp` support in llama.cpp is still immature — the arch is detected but the MTP context fails to initialize and the process dies (e.g. `failed to measure MTP context memory` / `requires ctx_other to be set`). The process log records `[launcher] MTP startup failure detected (exit code ...); retrying without speculative decoding` followed by the flag-free relaunch command. The retry happens **at most once**; if it still crashes the process ends in `error`. An **explicit `draft_model_path`** (or an operator-supplied `--spec-type`) is **never** auto-retried — the explicit choice is respected.
+
 ### API
 
 `POST /api/launcher/start` (Web edition) accepts these additional fields (llama.cpp backend only; other backends get a 400):

--- a/docs/backends/launcher.md
+++ b/docs/backends/launcher.md
@@ -191,6 +191,10 @@ llama.cpp の `llama-server` は Multi-Token Prediction (MTP) / speculative deco
 
 nextn 埋め込みモデル / speculative decoding 有効時に `--split-mode tensor` を組み合わせると llama.cpp がクラッシュする既知の問題があります([issue #24309](https://github.com/ggml-org/llama.cpp/issues/24309))。Launcher はこの組み合わせを検出しても起動はブロックせず、プロセスログに `--split-mode layer` を推奨する警告を記録します。
 
+### 自動検出 MTP が起動時にクラッシュした場合の自動フォールバック
+
+**自動検出**(`mtp_mode: auto`)で付与した speculative フラグが原因で backend が**起動直後(約 3 分以内)にクラッシュ**した場合、Launcher は speculative フラグを外して**自動的に 1 回だけ再起動**します。一部のアーキテクチャの `draft-mtp` サポートは llama.cpp 側でまだ成熟しておらず、検出は正しくても MTP コンテキストの初期化に失敗してプロセスが落ちることがあるためです(例: `failed to measure MTP context memory` / `requires ctx_other to be set`)。プロセスログには `[launcher] MTP startup failure detected (exit code ...); retrying without speculative decoding` と、フラグを外した再起動コマンドが記録されます。再起動は**必ず 1 回まで**で、それでも落ちる場合は `error` になります。**明示的な MTP/draft gguf**(`draft_model_path`)を指定した場合や、`--spec-type` を自分で渡した場合は自動再起動の対象外です(ユーザー指定を尊重します)。
+
 ### API
 
 Web版の `POST /api/launcher/start` は以下のフィールドを追加で受け付けます(llama.cpp バックエンドのみ有効。他バックエンドで指定すると 400):

--- a/launcher_gui.py
+++ b/launcher_gui.py
@@ -29,6 +29,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 import tkinter as tk
 import uuid
 from collections import deque
@@ -86,6 +87,11 @@ _CODEROUTER_PORT = 8088
 _MAX_LOG_LINES      = 5000   # mp.log_lines / _cr_log のメモリ上限(行数)
 _MAX_TEXT_LINES     = 2000   # _log_text ウィジェットの表示行上限
 _MAX_LINES_PER_TICK = 1500   # _poll 1回で処理する最大行数(残りは次回へ繰越)
+
+# 自動検出 MTP が起動時にクラッシュした場合、この秒数以内の非ゼロ終了だけを
+# 「起動時失敗」とみなし speculative フラグ無しで 1 回だけ再起動する。これより
+# 長く稼働してから落ちたものは通常のクラッシュ扱いで再起動しない。
+_MTP_FALLBACK_WINDOW_SECS = 180.0
 
 _CONFIG_SEARCH = [
     Path.cwd() / "providers.yaml",
@@ -1237,6 +1243,23 @@ class LauncherApp(tk.Tk):
             self._set_launch_err(str(e))
             return
 
+        # MTP auto-fallback: only auto-detected speculative flags (MTP自動検出
+        # ON, no explicit draft entry, detection emitted flags) qualify for the
+        # one-shot startup-crash retry. Rebuild the command without the spec
+        # tokens (exact — never spliced) so the retry is precise.
+        spec_auto = bool(
+            self._mtp_auto_var.get()
+            and not self._draft_path_var.get().strip()
+            and spec_tokens
+        )
+        fallback_cmd: list[str] | None = None
+        if spec_auto:
+            with contextlib.suppress(ValueError):
+                fallback_cmd = _build_cmd(backend, model_path, port,
+                                          profile_args, extra, binary, None)
+        if fallback_cmd is None:
+            spec_auto = False
+
         proc_id = uuid.uuid4().hex[:8]
         mp = ManagedProcess(
             id=proc_id,
@@ -1263,32 +1286,61 @@ class LauncherApp(tk.Tk):
             mp.log_lines.append(f"[launcher] cmd: {' '.join(cmd)}")
             for note in spec_notes:
                 mp.log_lines.append(f"[launcher] {note}")
-            try:
-                p = subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    bufsize=0,
-                )
-            except Exception as exc:
-                mp.status = "error"
-                self._log_queue.put((proc_id, f"_ERR_:{exc}"))
+            run_cmd = cmd
+            fallback_done = False
+            first = True
+            while True:
+                try:
+                    p = subprocess.Popen(
+                        run_cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        bufsize=0,
+                    )
+                except Exception as exc:
+                    mp.status = "error"
+                    self._log_queue.put((proc_id, f"_ERR_:{exc}"))
+                    return
+
+                started_at = time.monotonic()
+                mp.proc  = p
+                mp.pid   = p.pid
+                mp.status = "running"
+                if first:
+                    self._log_queue.put((proc_id, f"_OK_:{name}:{port}"))
+                    first = False
+
+                assert p.stdout
+                stdout = p.stdout
+                for raw in iter(lambda s=stdout: s.read(4096), b""):
+                    for line in raw.decode("utf-8", errors="replace").splitlines():
+                        self._log_queue.put((proc_id, line))
+                p.wait()
+                mp.returncode = p.returncode
+                mp.status = "stopped" if p.returncode == 0 else "error"
+                self._log_queue.put(
+                    (proc_id, f"[launcher] exited (code {p.returncode})"))
+
+                # MTP startup crash → relaunch ONCE without speculative flags.
+                if (
+                    not fallback_done
+                    and spec_auto
+                    and p.returncode not in (0, None)
+                    and (time.monotonic() - started_at)
+                    <= _MTP_FALLBACK_WINDOW_SECS
+                ):
+                    fallback_done = True
+                    self._log_queue.put((
+                        proc_id,
+                        f"[launcher] MTP startup failure detected "
+                        f"(exit code {p.returncode}); retrying without "
+                        "speculative decoding",
+                    ))
+                    self._log_queue.put(
+                        (proc_id, f"[launcher] cmd: {' '.join(fallback_cmd)}"))
+                    run_cmd = fallback_cmd
+                    continue
                 return
-
-            mp.proc  = p
-            mp.pid   = p.pid
-            mp.status = "running"
-            self._log_queue.put((proc_id, f"_OK_:{name}:{port}"))
-
-            assert p.stdout
-            for raw in iter(lambda: p.stdout.read(4096), b""):
-                for line in raw.decode("utf-8", errors="replace").splitlines():
-                    self._log_queue.put((proc_id, line))
-            p.wait()
-            mp.returncode = p.returncode
-            mp.status = "stopped" if p.returncode == 0 else "error"
-            self._log_queue.put(
-                (proc_id, f"[launcher] exited (code {p.returncode})"))
 
         threading.Thread(target=_run, daemon=True).start()
 

--- a/tests/test_launcher_mtp_fallback.py
+++ b/tests/test_launcher_mtp_fallback.py
@@ -1,0 +1,272 @@
+"""Tests for the one-shot MTP startup-crash auto-fallback in the launcher.
+
+When speculative flags were added by AUTO detection (``mtp_mode="auto"``, no
+explicit ``draft_model_path``, detection actually emitted flags) and the
+backend process dies during startup, the launcher relaunches it ONCE without
+the speculative flags — some architectures' ``draft-mtp`` support in
+llama.cpp is immature and crashes the context init at load. This is never
+done for explicit draft models / operator-supplied ``--spec-type``, and never
+more than once.
+
+Covers:
+
+* the :func:`_should_mtp_fallback` truth table (unit), and
+* the end-to-end retry via ``POST /api/launcher/start`` against a crashing
+  backend stub (integration), including the negative ``mtp_mode="off"`` case.
+"""
+
+from __future__ import annotations
+
+import struct
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from coderouter.config.schemas import (
+    CodeRouterConfig,
+    FallbackChain,
+    LauncherBackendConfig,
+    LauncherConfig,
+    ProviderConfig,
+)
+from coderouter.ingress.app import create_app
+from coderouter.ingress.launcher_routes import (
+    _MTP_FALLBACK_WINDOW_SECS,
+    ManagedProcess,
+    _should_mtp_fallback,
+)
+from coderouter.metrics import uninstall_collector
+
+# ---------------------------------------------------------------------------
+# Synthetic GGUF builder (mirrors tests/test_launcher_mtp.py helpers)
+# ---------------------------------------------------------------------------
+
+_MAGIC = b"GGUF"
+_T_UINT32 = 4
+_T_STRING = 8
+
+
+def _gguf_string(s: str) -> bytes:
+    raw = s.encode("utf-8")
+    return struct.pack("<Q", len(raw)) + raw
+
+
+def _kv_string(key: str, value: str) -> bytes:
+    return _gguf_string(key) + struct.pack("<I", _T_STRING) + _gguf_string(value)
+
+
+def _kv_u32(key: str, value: int) -> bytes:
+    return _gguf_string(key) + struct.pack("<I", _T_UINT32) + struct.pack("<I", value)
+
+
+def _gguf_bytes(arch: str, *, nextn: int | None = None) -> bytes:
+    kvs = [_kv_string("general.architecture", arch)]
+    if nextn is not None:
+        kvs.append(_kv_u32(f"{arch}.nextn_predict_layers", nextn))
+    header = _MAGIC + struct.pack("<I", 3) + struct.pack("<Q", 0)
+    header += struct.pack("<Q", len(kvs))
+    return header + b"".join(kvs)
+
+
+def _make_gguf(
+    path: Path, arch: str, *, nextn: int | None = None, size: int = 0
+) -> Path:
+    data = _gguf_bytes(arch, nextn=nextn)
+    if size > len(data):
+        data = data + b"\x00" * (size - len(data))
+    path.write_bytes(data)
+    return path
+
+
+def _make_crashing_binary(path: Path) -> Path:
+    """Write an executable shell stub that prints to stderr and exits 11."""
+    path.write_text(
+        "#!/bin/sh\n"
+        'echo "llama_init_from_model: failed to initialize the context" 1>&2\n'
+        "exit 11\n"
+    )
+    path.chmod(0o755)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# _should_mtp_fallback — truth table
+# ---------------------------------------------------------------------------
+
+
+def _mp(**overrides: object) -> ManagedProcess:
+    """Build a ManagedProcess primed for the fallback-eligible baseline."""
+    base: dict[str, object] = dict(
+        id="p1",
+        name="x",
+        backend="llama.cpp",
+        model_path="/m.gguf",
+        port=8080,
+        options={},
+        extra_args="",
+        spec_auto=True,
+        mtp_fallback_done=False,
+        fallback_cmd=["llama-server", "-m", "/m.gguf", "--port", "8080"],
+        returncode=11,
+        started_at=time.monotonic(),
+    )
+    base.update(overrides)
+    return ManagedProcess(**base)  # type: ignore[arg-type]
+
+
+def test_should_fallback_auto_nonzero_in_window() -> None:
+    assert _should_mtp_fallback(_mp()) is True
+
+
+def test_should_fallback_explicit_draft_is_false() -> None:
+    # spec_auto False (explicit draft / operator --spec-type) → never retry.
+    assert _should_mtp_fallback(_mp(spec_auto=False)) is False
+
+
+def test_should_fallback_already_retried_is_false() -> None:
+    assert _should_mtp_fallback(_mp(mtp_fallback_done=True)) is False
+
+
+def test_should_fallback_returncode_zero_is_false() -> None:
+    assert _should_mtp_fallback(_mp(returncode=0)) is False
+
+
+def test_should_fallback_returncode_none_is_false() -> None:
+    assert _should_mtp_fallback(_mp(returncode=None)) is False
+
+
+def test_should_fallback_no_fallback_cmd_is_false() -> None:
+    assert _should_mtp_fallback(_mp(fallback_cmd=None)) is False
+
+
+def test_should_fallback_out_of_window_is_false() -> None:
+    old = time.monotonic() - (_MTP_FALLBACK_WINDOW_SECS + 10.0)
+    assert _should_mtp_fallback(_mp(started_at=old)) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration — real subprocess retry via api_start
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> CodeRouterConfig:
+    binary = _make_crashing_binary(tmp_path / "crash-llama-server")
+    return CodeRouterConfig(
+        allow_paid=False,
+        default_profile="default",
+        providers=[
+            ProviderConfig(
+                name="local",
+                base_url="http://localhost:8080/v1",
+                model="qwen-coder",
+                paid=False,
+            ),
+        ],
+        profiles=[FallbackChain(name="default", providers=["local"])],
+        launcher=LauncherConfig(
+            backends={"llama.cpp": LauncherBackendConfig(binary=str(binary))},
+        ),
+    )
+
+
+@pytest.fixture
+def client(
+    config: CodeRouterConfig, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[TestClient]:
+    monkeypatch.setattr(
+        "coderouter.ingress.app.load_config", lambda path=None: config
+    )
+    monkeypatch.delenv("CODEROUTER_LAUNCHER_TOKEN", raising=False)
+    uninstall_collector()
+    app = create_app()
+    try:
+        with TestClient(app) as tc:
+            yield tc
+    finally:
+        uninstall_collector()
+
+
+def _poll_logs(
+    client: TestClient, proc_id: str, needle: str, timeout: float = 5.0
+) -> list[str]:
+    """Poll a process's log until ``needle`` appears or ``timeout`` elapses."""
+    deadline = time.monotonic() + timeout
+    logs: list[str] = []
+    while time.monotonic() < deadline:
+        resp = client.get(f"/api/launcher/logs/{proc_id}?n=200")
+        assert resp.status_code == 200, resp.text
+        logs = resp.json()["logs"]
+        if any(needle in line for line in logs):
+            return logs
+        time.sleep(0.1)
+    return logs
+
+
+def test_auto_mtp_crash_retries_once_without_spec(
+    client: TestClient, tmp_path: Path
+) -> None:
+    # nextn gguf → auto detection emits `--spec-type draft-mtp`.
+    main = _make_gguf(tmp_path / "glm.gguf", "glm4moe", nextn=1, size=4000)
+    resp = client.post(
+        "/api/launcher/start",
+        json={
+            "name": "glm",
+            "backend": "llama.cpp",
+            "model_path": str(main),
+            "port": 8080,
+            "mtp_mode": "auto",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["speculative"] == ["--spec-type", "draft-mtp"]
+    proc_id = body["id"]
+
+    logs = _poll_logs(client, proc_id, "retrying without speculative decoding")
+    joined = "\n".join(logs)
+    assert "retrying without speculative decoding" in joined
+
+    # Exactly two cmd lines: the original (with spec) + one fallback (without).
+    cmd_lines = [ln for ln in logs if ln.startswith("[launcher] cmd:")]
+    assert len(cmd_lines) == 2, joined
+    assert "--spec-type" in cmd_lines[0]
+    assert "--spec-type" not in cmd_lines[1]
+
+    # Exactly one retry — no third cmd line, ends in error after fallback dies.
+    logs = _poll_logs(client, proc_id, "process exited with code")
+    assert "retrying without speculative decoding" in "\n".join(logs)
+    assert (
+        sum(1 for ln in logs if ln.startswith("[launcher] cmd:")) == 2
+    ), "\n".join(logs)
+
+    procs = client.get("/api/launcher/processes").json()["processes"]
+    entry = next(p for p in procs if p["id"] == proc_id)
+    assert entry["status"] == "error"
+
+
+def test_off_mode_never_retries(client: TestClient, tmp_path: Path) -> None:
+    main = _make_gguf(tmp_path / "glm.gguf", "glm4moe", nextn=1, size=4000)
+    resp = client.post(
+        "/api/launcher/start",
+        json={
+            "name": "glm-off",
+            "backend": "llama.cpp",
+            "model_path": str(main),
+            "port": 8081,
+            "mtp_mode": "off",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["speculative"] == []
+    proc_id = body["id"]
+
+    # Wait for the (single) process to exit, then assert no retry ever fired.
+    logs = _poll_logs(client, proc_id, "process exited with code")
+    joined = "\n".join(logs)
+    assert "retrying without speculative decoding" not in joined
+    assert sum(1 for ln in logs if ln.startswith("[launcher] cmd:")) == 1, joined


### PR DESCRIPTION
## Summary

MTP自動検出は正しくても、llama.cpp 側の draft-mtp が arch によっては未成熟でロード時にクラッシュする（実例: Gemma系 nextn=4 モデルで `failed to measure MTP context memory` → SIGSEGV）。

- **自動検出でspecフラグを付けた起動が180秒以内に異常終了した場合、specフラグなしで1回だけ自動再起動**（Web・デスクトップGUI両方）
- 明示的な `draft_model_path` 指定やユーザー自身の `--spec-type` 指定は対象外（自動リトライしない）
- 再試行は `mtp_fallback_done` ガードで構造的に1回限り
- テスト9件追加（発動条件の真偽表＋クラッシュするスタブバイナリでの統合テスト）、計87件通過、ruffクリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169bqKt3eAhtwEe3vd8BP8e