### PR TITLE
chore(release): v2.7.6 (launcher MTP / speculative-decoding support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ are kept verbatim where the Japanese text itself is the subject).
 
 ## [v2.7.6] — 2026-07-09 (Launcher MTP / speculative-decoding support)
 
-Adds Multi-Token Prediction (MTP) / speculative-decoding support
-to the llama.cpp launcher (both the Web UI and the desktop GUI), closing the
+**PR #59 / #60**. Adds Multi-Token Prediction (MTP) / speculative-decoding
+support to the llama.cpp launcher (both the Web UI and the desktop GUI), closing the
 gap where operators had to hand-assemble `--spec-type` / `--model-draft`
 flags. Fully backward compatible: the new fields default to auto-detection
 with a silent no-op fallback, no config-schema changes, no new dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 # in plan.md §11.B; once granted, this name will become an alias and
 # `coderouter` will become the canonical distribution name.
 name = "coderouter-cli"
-version = "2.7.5"
+version = "2.7.6"
 description = "Local-first, free-first, fallback-built-in LLM router. Claude Code / OpenAI compatible."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "coderouter-cli"
-version = "2.7.5"
+version = "2.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
v2.7.6 リリース: version bump + CHANGELOG 最終化 (PR #59 / #60 の Launcher MTP 対応)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169bqKt3eAhtwEe3vd8BP8e