### PR TITLE
feat(adapters): agent_cli adapter — external coding agents, Phase 1a (claude)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,82 @@ are kept verbatim where the Japanese text itself is the subject).
 
 ---
 
+## [v2.7.7] — 2026-07-09 (External coding agents: agent_cli adapter, Phase 1a claude)
+
+Adds a new adapter kind, `agent_cli`, that lets CodeRouter front an external
+coding-agent CLI (Claude Code / Codex / Gemini / Grok) as a single one-shot
+`prompt in → text out` transformation, keeping the "one request = one
+stateless transformation" ethos intact even though the underlying CLI is a
+stateful, multi-turn, filesystem-editing control loop. Phase 1a implements
+only the `claude` target (Claude Code CLI) — the most stable of the four and
+the only one that emits `total_cost_usd` directly, making it the reference
+implementation for the parser and cost path. `codex` / `gemini` / `grok` are
+declared in the config schema for forward compatibility but rejected with a
+clear error until their phase lands (Phase 1b-1d).
+
+### Added
+
+- **`kind: "agent_cli"` + `AgentCliAdapter`** (`coderouter/adapters/agent_cli.py`,
+  new) — invokes the Claude Code CLI one-shot via
+  `claude -p --output-format json` (prompt fed on stdin, never on argv, so
+  it is never subject to shell interpretation; `shell=True` is never used).
+  Key behaviors:
+  - Subscription-first OAuth: the child process does NOT inherit the parent
+    environment. A minimal env is built explicitly (fixed safe `PATH`,
+    `NO_COLOR=1`, `TERM=dumb`, inherited `HOME` for credential-dir
+    discovery); `ANTHROPIC_API_KEY` is never forwarded unless the operator
+    explicitly lists it in `passthrough_env` (prevents a stray key from
+    silently overriding subscription auth). `--bare` is deliberately never
+    added — it would skip OAuth/keychain reads.
+  - `CODEROUTER_AGENT_DEPTH` recursion guard: the depth is read from the
+    environment, incremented, and propagated into the child; `generate()`
+    refuses with a non-retryable error once the current depth reaches
+    `agent_depth_limit` (default 2).
+  - `exec_timeout_s` is enforced independently of `ProviderConfig.timeout_s`
+    via `asyncio.wait_for`; on expiry the whole child process *group* is
+    `SIGKILL`ed (`start_new_session=True` + `os.killpg`) so the CLI's real
+    LLM-call subprocess is never orphaned.
+  - Default `read_only` sandbox: `allow_file_writes=False` /
+    `sandbox_mode="read_only"` map to claude's `--permission-mode plan`.
+    The permission-mode mapping is clamped to read-only whenever
+    `allow_file_writes` is False, regardless of `sandbox_mode` (defense in
+    depth). `edit` / `full_auto` both map to `acceptEdits`.
+  - Pseudo-streaming: no CLI in Phase 1a exposes a stable token stream, so
+    `stream()` runs `generate()` once and chunks the final answer into
+    content `StreamChunk`s followed by a terminal `finish_reason="stop"`
+    chunk carrying usage.
+  - `total_cost_usd` (claude's JSON output) propagates to the response as
+    the `coderouter_cost_usd` metadata field, feeding the cost dashboard;
+    `session_id` similarly surfaces as `coderouter_session_id`.
+- **`AgentCliConfig` schema** (`coderouter/config/schemas.py`) — new
+  `ProviderConfig.agent_cli` sub-config (`agent`, `command`, `workdir`,
+  `exec_timeout_s`, `allow_file_writes`, `sandbox_mode`, `model`,
+  `max_turns`, `passthrough_env`, `agent_depth_limit`), `extra="forbid"`
+  like the rest of the module. `ProviderConfig.base_url` is relaxed to
+  optional so `agent_cli` providers (which shell out to a local CLI rather
+  than calling a URL) can omit it; a `model_validator` restores the
+  required-ness of `base_url` for `openai_compat` / `anthropic` and
+  requires the `agent_cli` sub-config whenever `kind == "agent_cli"`.
+- **30 new tests** (`tests/test_agent_cli.py`) covering argv construction
+  (model/max-turns/permission-mode mapping and the write-clamp), claude JSON
+  parsing (success / `is_error` / malformed / missing-field paths), a
+  stubbed-subprocess `generate()` path, timeout → process-group kill,
+  child-env isolation (no `ANTHROPIC_API_KEY` leak, `passthrough_env`
+  allowlist, depth increment), the recursion depth limit, and a TestClient
+  end-to-end run through `POST /v1/chat/completions`.
+- New example config: `examples/providers-agent-cli.yaml` — a runnable
+  single-provider `agent_cli` setup for `claude`, plus a commented-out
+  preview of the future `codex` / `gemini` / `grok` provider blocks.
+- Design doc: `docs/designs/external-agents-adapter.md` — the full Phase 1
+  design (architecture, security requirements, per-CLI argv/JSON tables,
+  auth policy, test plan). `codex` / `gemini` / `grok` remain Phase
+  1b-1d — configuring `agent_cli.agent` to any of them is accepted at
+  config-load time but rejected with a clear, non-retryable error
+  (`"agent 'codex' is not implemented in Phase 1a (claude only)"`) when the
+  adapter is constructed.
+
+---
+
 ## [v2.7.6] — 2026-07-09 (Launcher MTP / speculative-decoding support)
 
 **PR #59 / #60**. Adds Multi-Token Prediction (MTP) / speculative-decoding

--- a/coderouter/adapters/agent_cli.py
+++ b/coderouter/adapters/agent_cli.py
@@ -1,0 +1,565 @@
+"""External coding-agent CLI adapter (``kind="agent_cli"``).
+
+This adapter invokes an external coding-agent CLI (Claude Code / Codex /
+Gemini / Grok) as a single one-shot ``exec`` and returns the agent's final
+answer as one ``prompt in → text out`` transformation. It is the in-core
+implementation of the external-agents-adapter design
+(``docs/designs/external-agents-adapter.md``).
+
+Design in one paragraph
+=======================
+
+A coding-agent CLI is normally a stateful, multi-turn, filesystem-editing
+control loop — at odds with CodeRouter's "one request = one stateless
+transformation" ethos. Restricting it to a single non-interactive
+one-shot ``exec`` collapses it back into a single transformation, which
+keeps the ethos intact: orchestration stays on the *client* side, and
+CodeRouter merely performs the one conversion. Following the
+``openai_compat`` precedent, a *single* adapter class fronts *multiple*
+target agents, dispatched on the ``agent`` field.
+
+Phase 1a scope
+==============
+
+Only the ``claude`` (Claude Code CLI) target is implemented here — it is
+the most stable CLI, has the most fine-grained safety controls, and is the
+only one that emits ``total_cost_usd`` directly (making it the reference
+implementation for the parser / cost path). The other agents
+(codex / gemini / grok) are declared in the config schema so providers.yaml
+is forward-compatible, but constructing an adapter for them raises a clear
+``AdapterError`` until their phase lands.
+
+Security (design §6, non-negotiable)
+====================================
+
+* **allowlist argv only** — the child is launched with
+  :func:`asyncio.create_subprocess_exec` and a list argv. ``shell=True`` is
+  never used; the prompt is fed on stdin, so it is never subject to shell
+  interpretation.
+* **default read-only** — ``allow_file_writes=False`` /
+  ``sandbox_mode="read_only"`` are the defaults, mapped to claude's
+  ``--permission-mode plan``. Writes require explicit opt-in and the sandbox
+  mapping is clamped to read-only whenever ``allow_file_writes`` is False.
+* **workdir boundary** — the working directory is expanded, resolved to an
+  absolute path and created; a literal ``..`` escape is rejected.
+* **timeout with process-group kill** — ``exec_timeout_s`` is enforced with
+  :func:`asyncio.wait_for`; on expiry the whole process *group* is
+  ``SIGKILL``ed (the CLI hangs a real LLM call off a child, so killing only
+  the parent would orphan it).
+* **env allowlist** — the child does NOT inherit the parent environment. A
+  minimal env is built explicitly; ``ANTHROPIC_API_KEY`` is never forwarded
+  unless the operator lists it in ``passthrough_env`` (this prevents a
+  stray key from silently overriding subscription OAuth).
+* **recursion cap** — ``CODEROUTER_AGENT_DEPTH`` is propagated (incremented)
+  into the child and refused at or above ``agent_depth_limit``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import shutil
+import signal
+import time
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+from coderouter.adapters.base import (
+    AdapterError,
+    BaseAdapter,
+    ChatRequest,
+    ChatResponse,
+    ProviderCallOverrides,
+    StreamChunk,
+)
+from coderouter.config.schemas import AgentCliConfig, ProviderConfig
+from coderouter.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Fixed, minimal PATH injected into the child (design §5.3.1). The adapter
+# resolves the CLI executable to an absolute path itself (see ``generate``),
+# so this PATH only governs any helper binaries the CLI spawns.
+_SAFE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# Environment variable that carries the recursion depth across nested agent
+# invocations (design §5.5).
+_DEPTH_ENV = "CODEROUTER_AGENT_DEPTH"
+
+# How many trailing stderr bytes to attach to a non-zero-exit error message.
+_MAX_STDERR_TAIL = 2000
+
+# Coarse chunk size (characters) for the pseudo-stream splitter (design §5.1.4).
+_STREAM_CHUNK_CHARS = 512
+
+# sandbox_mode → claude ``--permission-mode`` value (design §5.4). ``edit``
+# and ``full_auto`` both map to ``acceptEdits`` in Phase 1a.
+_CLAUDE_PERMISSION_MODE = {
+    "read_only": "plan",
+    "edit": "acceptEdits",
+    "full_auto": "acceptEdits",
+}
+
+
+def _chunk_text(text: str, size: int = _STREAM_CHUNK_CHARS) -> Iterator[str]:
+    """Split ``text`` into ``size``-char pieces for the pseudo-stream."""
+    for start in range(0, len(text), size):
+        yield text[start : start + size]
+
+
+class AgentCliAdapter(BaseAdapter):
+    """Invoke an external coding-agent CLI one-shot (Phase 1a: claude only).
+
+    The ``agent`` field selects the argv builder / output parser via the
+    dispatch tables built in :meth:`__init__`, mirroring how
+    ``openai_compat`` fronts many HTTP backends from one class.
+    """
+
+    def __init__(self, config: ProviderConfig) -> None:
+        """Bind to a ``ProviderConfig`` and reject unsupported agents.
+
+        Constructing an adapter for an agent other than ``claude`` raises a
+        non-retryable :class:`AdapterError` — the other targets are declared
+        in the schema but not implemented until their phase (design §9).
+        """
+        super().__init__(config)
+        if config.agent_cli is None:  # pragma: no cover - schema enforces this
+            raise AdapterError(
+                "agent_cli provider is missing its agent_cli sub-config",
+                provider=config.name,
+                retryable=False,
+            )
+        self.acfg: AgentCliConfig = config.agent_cli
+        if self.acfg.agent != "claude":
+            raise AdapterError(
+                f"agent {self.acfg.agent!r} is not implemented in Phase 1a "
+                f"(claude only). Configure agent='claude' or wait for the "
+                f"agent's phase.",
+                provider=config.name,
+                retryable=False,
+            )
+        # agent → argv builder / output parser dispatch tables. Phase 1a
+        # registers only claude; later phases add codex / gemini / grok.
+        self._builders = {"claude": self._build_claude_argv}
+        self._parsers = {"claude": self._parse_claude}
+        # claude reads its print-mode prompt from stdin (10MB cap), which
+        # keeps argv free of the (potentially huge) prompt text.
+        self._uses_stdin = True
+
+    # ------------------------------------------------------------------
+    # BaseAdapter contract
+    # ------------------------------------------------------------------
+
+    async def healthcheck(self) -> bool:
+        """Lightweight check: the CLI binary exists on PATH (design §5.1.2)."""
+        return shutil.which(self.acfg.command) is not None
+
+    async def generate(
+        self,
+        request: ChatRequest,
+        *,
+        overrides: ProviderCallOverrides | None = None,
+    ) -> ChatResponse:
+        """Run the CLI once and shape the final answer into a ChatResponse.
+
+        Raises :class:`AdapterError` on every failure path, with
+        ``retryable`` set so the fallback engine can decide whether to try
+        the next provider (transient failures) or stop (config / recursion
+        errors).
+        """
+        # Recursion guard (design §5.5): refuse when we are already nested at
+        # or beyond the configured depth. Non-retryable — retrying the same
+        # chain would recurse again.
+        depth = self._current_depth()
+        if depth >= self.acfg.agent_depth_limit:
+            raise AdapterError(
+                f"agent recursion depth {depth} >= limit "
+                f"{self.acfg.agent_depth_limit}",
+                provider=self.name,
+                retryable=False,
+            )
+
+        # exec_timeout_s is the base; a profile-level override wins when set.
+        # NOTE: the inherited ``effective_timeout`` falls back to
+        # ``ProviderConfig.timeout_s``, which is the wrong knob here, so we
+        # resolve against ``exec_timeout_s`` explicitly (design §5.1.3).
+        timeout = (
+            overrides.timeout_s
+            if overrides is not None and overrides.timeout_s is not None
+            else self.acfg.exec_timeout_s
+        )
+
+        prompt = self._render_prompt(request, overrides)
+        workdir = self._resolve_workdir()
+        argv = self._builders[self.acfg.agent](workdir)
+        # Resolve the executable to an absolute path so argv[0] is a concrete
+        # binary independent of the child's minimal PATH (design §6 allowlist).
+        resolved = shutil.which(argv[0])
+        if resolved is not None:
+            argv = [resolved, *argv[1:]]
+        env = self._build_child_env()
+
+        logger.info(
+            "agent-cli-exec",
+            extra={
+                "provider": self.name,
+                "agent": self.acfg.agent,
+                "argv0": argv[0],
+                "timeout_s": timeout,
+            },
+        )
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=workdir,
+                env=env,
+                # New session/process group so a timeout can SIGKILL the whole
+                # group (the CLI hangs its real LLM call off a child).
+                start_new_session=True,
+            )
+        except (FileNotFoundError, OSError) as exc:
+            raise AdapterError(
+                f"failed to launch {self.acfg.command!r}: {exc}",
+                provider=self.name,
+                retryable=False,
+            ) from exc
+
+        stdin_bytes = prompt.encode("utf-8") if self._uses_stdin else None
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=stdin_bytes), timeout=timeout
+            )
+        except TimeoutError as exc:
+            self._kill_process_group(proc)
+            with contextlib.suppress(Exception):
+                await proc.wait()
+            raise AdapterError(
+                f"{self.acfg.agent} exec timed out after {timeout}s",
+                provider=self.name,
+                retryable=True,
+            ) from exc
+
+        if proc.returncode != 0:
+            tail = (stderr[-_MAX_STDERR_TAIL:].decode("utf-8", "replace") if stderr else "")
+            raise AdapterError(
+                f"{self.acfg.agent} exited {proc.returncode}: {tail!r}",
+                provider=self.name,
+                status_code=None,
+                retryable=self._is_retryable_exit(proc.returncode),
+            )
+
+        final_text, usage, meta = self._parsers[self.acfg.agent](stdout, stderr)
+        return self._to_chat_response(final_text, usage, meta)
+
+    async def stream(
+        self,
+        request: ChatRequest,
+        *,
+        overrides: ProviderCallOverrides | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """Pseudo-stream (design §5.1.4): run once, then chunk the answer.
+
+        No CLI in Phase 1a exposes a stable token stream, so the final text
+        from :meth:`generate` is split into content chunks followed by a
+        terminal ``finish_reason="stop"`` chunk carrying usage.
+        """
+        resp = await self.generate(request, overrides=overrides)
+        try:
+            content = resp.choices[0]["message"]["content"] or ""
+        except (IndexError, KeyError, TypeError):  # pragma: no cover - defensive
+            content = ""
+        for piece in _chunk_text(content):
+            yield StreamChunk(
+                id=resp.id,
+                created=resp.created,
+                model=resp.model,
+                choices=[
+                    {"index": 0, "delta": {"content": piece}, "finish_reason": None}
+                ],
+            )
+        yield StreamChunk(
+            id=resp.id,
+            created=resp.created,
+            model=resp.model,
+            choices=[{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            usage=resp.usage,
+        )
+
+    # ------------------------------------------------------------------
+    # claude argv builder + output parser
+    # ------------------------------------------------------------------
+
+    def _build_claude_argv(self, workdir: str) -> list[str]:
+        """Assemble the ``claude -p`` argv (design §5.1.5 / §5.4).
+
+        Shape::
+
+            claude -p --output-format json --model <m> --max-turns <n>
+                   --permission-mode <plan|acceptEdits> --add-dir <workdir>
+
+        The prompt is fed on stdin (not argv), so it never appears here.
+        ``--bare`` is deliberately NOT added — it would skip OAuth/keychain
+        reads and break subscription auth (design §5.3.4).
+        """
+        model = self.acfg.model or self.config.model
+        argv = [self.acfg.command, "-p", "--output-format", "json", "--model", model]
+        if self.acfg.max_turns is not None:
+            argv += ["--max-turns", str(self.acfg.max_turns)]
+        argv += ["--permission-mode", self._claude_permission_mode()]
+        argv += ["--add-dir", workdir]
+        return argv
+
+    def _claude_permission_mode(self) -> str:
+        """Map ``sandbox_mode`` → claude ``--permission-mode``, clamped.
+
+        When ``allow_file_writes`` is False the effective mode is clamped to
+        ``read_only`` regardless of ``sandbox_mode`` — defense in depth so an
+        ``edit`` / ``full_auto`` request cannot grant writes without the
+        explicit ``allow_file_writes`` opt-in (design §5.4).
+        """
+        mode = self.acfg.sandbox_mode if self.acfg.allow_file_writes else "read_only"
+        return _CLAUDE_PERMISSION_MODE[mode]
+
+    def _parse_claude(
+        self, stdout: bytes, stderr: bytes
+    ) -> tuple[str, dict[str, Any], dict[str, Any]]:
+        """Parse claude ``--output-format json`` output (design §5.1.6).
+
+        Returns ``(final_text, usage, meta)``. Parsing is deliberately
+        defensive: any missing/blank field or a reported ``is_error`` raises a
+        retryable :class:`AdapterError` so the chain can fall through.
+        """
+        text = stdout.decode("utf-8", "replace").strip()
+        if not text:
+            raise AdapterError(
+                "claude produced no stdout to parse",
+                provider=self.name,
+                retryable=True,
+            )
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise AdapterError(
+                f"claude emitted non-JSON output: {exc}",
+                provider=self.name,
+                retryable=True,
+            ) from exc
+        if not isinstance(data, dict):
+            raise AdapterError(
+                "claude JSON output was not an object",
+                provider=self.name,
+                retryable=True,
+            )
+        if data.get("is_error"):
+            raise AdapterError(
+                f"claude reported is_error=true: {str(data.get('result'))[:500]!r}",
+                provider=self.name,
+                retryable=True,
+            )
+        result = data.get("result")
+        if not isinstance(result, str):
+            raise AdapterError(
+                "claude JSON output missing string 'result' field",
+                provider=self.name,
+                retryable=True,
+            )
+
+        usage = self._claude_usage(data)
+        meta: dict[str, Any] = {}
+        cost = data.get("total_cost_usd")
+        if isinstance(cost, (int, float)):
+            # claude is the only CLI that emits a dollar figure directly;
+            # surface it as response metadata for the cost dashboard.
+            meta["coderouter_cost_usd"] = float(cost)
+        session_id = data.get("session_id")
+        if isinstance(session_id, str):
+            meta["coderouter_session_id"] = session_id
+        return result, usage, meta
+
+    def _claude_usage(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Normalize claude token usage into the OpenAI usage shape.
+
+        ``input_tokens`` plus the two cache buckets fold into
+        ``prompt_tokens``; ``cache_read_input_tokens`` is preserved under
+        ``prompt_tokens_details.cached_tokens``. ``num_turns`` / ``duration_ms``
+        ride along as extra keys (design §5.1.6).
+        """
+        raw = data.get("usage")
+        raw = raw if isinstance(raw, dict) else {}
+
+        def _int(key: str) -> int:
+            value = raw.get(key)
+            return int(value) if isinstance(value, (int, float)) else 0
+
+        input_tokens = _int("input_tokens")
+        output_tokens = _int("output_tokens")
+        cache_read = _int("cache_read_input_tokens")
+        cache_creation = _int("cache_creation_input_tokens")
+        prompt_tokens = input_tokens + cache_read + cache_creation
+
+        usage: dict[str, Any] = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": output_tokens,
+            "total_tokens": prompt_tokens + output_tokens,
+        }
+        if cache_read:
+            usage["prompt_tokens_details"] = {"cached_tokens": cache_read}
+        if isinstance(data.get("num_turns"), int):
+            usage["num_turns"] = data["num_turns"]
+        if isinstance(data.get("duration_ms"), (int, float)):
+            usage["duration_ms"] = data["duration_ms"]
+        return usage
+
+    # ------------------------------------------------------------------
+    # helpers: prompt rendering, response shaping, env, workdir, kill
+    # ------------------------------------------------------------------
+
+    def _to_chat_response(
+        self, final_text: str, usage: dict[str, Any], meta: dict[str, Any]
+    ) -> ChatResponse:
+        """Wrap the agent's final text in an OpenAI ChatResponse."""
+        return ChatResponse(
+            id=f"chatcmpl-{uuid.uuid4().hex}",
+            created=int(time.time()),
+            model=self.config.model,
+            choices=[
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": final_text},
+                    "finish_reason": "stop",
+                }
+            ],
+            usage=usage,
+            coderouter_provider=self.name,
+            **meta,
+        )
+
+    def _render_prompt(
+        self, request: ChatRequest, overrides: ProviderCallOverrides | None
+    ) -> str:
+        """Flatten the chat messages into a single role-tagged prompt string.
+
+        The profile-level ``append_system_prompt`` (if any) is prepended as a
+        leading system block, matching the openai_compat directive semantics.
+        """
+        parts: list[str] = []
+        directive = self.effective_append_system_prompt(overrides)
+        if directive:
+            parts.append(f"[system]\n{directive}")
+        for message in request.messages:
+            text = self._message_text(message.content)
+            if text:
+                parts.append(f"[{message.role}]\n{text}")
+        return "\n\n".join(parts).strip()
+
+    @staticmethod
+    def _message_text(content: str | list[dict[str, Any]] | None) -> str:
+        """Extract plain text from a message's ``content`` (str or blocks)."""
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        chunks: list[str] = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("text")
+                if isinstance(text, str):
+                    chunks.append(text)
+        return "\n".join(chunks)
+
+    def _current_depth(self) -> int:
+        """Read the current recursion depth from the environment (0 default)."""
+        raw = os.environ.get(_DEPTH_ENV, "0")
+        try:
+            return int(raw)
+        except ValueError:
+            return 0
+
+    def _build_child_env(self) -> dict[str, str]:
+        """Build the minimal child environment (design §5.3).
+
+        The child does NOT inherit the parent environment. Only a fixed base
+        (PATH / NO_COLOR / TERM), the inherited HOME (for credential-dir
+        discovery), the incremented recursion depth, and the operator's
+        ``passthrough_env`` allowlist are injected. ``ANTHROPIC_API_KEY`` is
+        therefore excluded unless explicitly allowlisted.
+        """
+        parent = os.environ
+        env: dict[str, str] = {
+            "PATH": _SAFE_PATH,
+            "NO_COLOR": "1",
+            "TERM": "dumb",
+            _DEPTH_ENV: str(self._current_depth() + 1),
+        }
+        home = parent.get("HOME")
+        if home:
+            env["HOME"] = home
+        for name in self.acfg.passthrough_env:
+            value = parent.get(name)
+            if value is not None:
+                env[name] = value
+        return env
+
+    def _resolve_workdir(self) -> str:
+        """Resolve + create the working directory, rejecting ``..`` escapes.
+
+        A configured ``workdir`` is ``~`` / env-var expanded and resolved to
+        an absolute path; a literal ``..`` component is rejected as an escape
+        attempt. When unset, a dedicated isolated directory
+        (``~/.coderouter/agents/<name>``) is used (design §6).
+        """
+        raw = self.acfg.workdir
+        if raw:
+            if ".." in Path(raw).parts:
+                raise AdapterError(
+                    f"workdir {raw!r} must not contain '..' (escape attempt)",
+                    provider=self.name,
+                    retryable=False,
+                )
+            expanded = os.path.expanduser(os.path.expandvars(raw))
+            path = Path(expanded).resolve()
+        else:
+            path = (Path.home() / ".coderouter" / "agents" / self.name).resolve()
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise AdapterError(
+                f"failed to prepare workdir {path}: {exc}",
+                provider=self.name,
+                retryable=False,
+            ) from exc
+        return str(path)
+
+    def _kill_process_group(self, proc: asyncio.subprocess.Process) -> None:
+        """SIGKILL the child's whole process group (best effort)."""
+        pid = proc.pid
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            # Group already gone / no permission — fall back to a direct kill.
+            with contextlib.suppress(ProcessLookupError, OSError):
+                proc.kill()
+
+    def _is_retryable_exit(self, returncode: int | None) -> bool:
+        """Whether a non-zero exit should let the chain fall through.
+
+        Phase 1a treats any non-zero exit as transient (rate-limit / OAuth
+        expiry / network), so the fallback engine advances to the next
+        provider rather than surfacing a terminal failure.
+        """
+        return True
+
+    # ``BaseAdapter`` (HTTP-oriented) lazily builds an httpx client; the agent
+    # adapter never touches it, but ``aclose`` on the inherited base is a safe
+    # no-op, so nothing extra is needed here.
+
+
+__all__ = ["AgentCliAdapter"]

--- a/coderouter/adapters/registry.py
+++ b/coderouter/adapters/registry.py
@@ -14,4 +14,10 @@ def build_adapter(provider: ProviderConfig) -> BaseAdapter:
         return OpenAICompatAdapter(provider)
     if provider.kind == "anthropic":
         return AnthropicAdapter(provider)
+    if provider.kind == "agent_cli":
+        # Imported lazily so the external-agent adapter (and its subprocess /
+        # os plumbing) is only pulled in when a config actually uses it.
+        from coderouter.adapters.agent_cli import AgentCliAdapter
+
+        return AgentCliAdapter(provider)
     raise ValueError(f"Unknown adapter kind: {provider.kind!r}")

--- a/coderouter/config/schemas.py
+++ b/coderouter/config/schemas.py
@@ -163,6 +163,125 @@ class CostConfig(BaseModel):
     )
 
 
+class AgentCliConfig(BaseModel):
+    """External coding-agent CLI settings for ``kind="agent_cli"`` providers.
+
+    Introduced by the external-agents-adapter design (Phase 1). One
+    ``agent_cli`` sub-config drives the :class:`AgentCliAdapter`, which
+    invokes an external coding-agent CLI (codex / gemini / grok / claude)
+    in a single one-shot ``exec`` and returns the final answer as one
+    ``prompt in → text out`` transformation. Phase 1a implements the
+    ``claude`` (Claude Code CLI) target only; the other agents are declared
+    at the schema level so configs are forward-compatible, but the adapter
+    rejects them until their phase lands.
+
+    Follows the ``extra="forbid"`` convention used across this module so a
+    typo'd key fails at config-load rather than being silently ignored.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent: Literal["codex", "gemini", "grok", "claude"] = Field(
+        ...,
+        description="External coding-agent CLI to invoke. Phase 1a: 'claude' only.",
+    )
+    command: str | None = Field(
+        default=None,
+        description=(
+            "CLI executable name or absolute path (resolved via PATH). "
+            "When unset, defaults to the ``agent`` name."
+        ),
+    )
+    workdir: str | None = Field(
+        default=None,
+        description=(
+            "Working directory for the one-shot exec. ``~`` / env-var "
+            "expansion is applied. When unset, a dedicated isolated "
+            "directory (``~/.coderouter/agents/<name>``) is used."
+        ),
+    )
+    exec_timeout_s: float = Field(
+        default=600.0,
+        ge=1.0,
+        le=1800.0,
+        description=(
+            "Forced timeout (seconds) for the one-shot exec. Independent "
+            "of ``ProviderConfig.timeout_s`` — the CLI has no built-in "
+            "wall clock so this is enforced with an asyncio watchdog + "
+            "process-group SIGKILL."
+        ),
+    )
+    allow_file_writes: bool = Field(
+        default=False,
+        description=(
+            "Allow the agent to write to the filesystem. Default False "
+            "(read-only). When False the sandbox mapping is clamped to "
+            "read-only regardless of ``sandbox_mode`` (defense in depth)."
+        ),
+    )
+    sandbox_mode: Literal["read_only", "edit", "full_auto"] = Field(
+        default="read_only",
+        description=(
+            "Source mode mapped onto each CLI's sandbox / approval flags. "
+            "Default read_only maps to claude ``--permission-mode plan``."
+        ),
+    )
+    model: str | None = Field(
+        default=None,
+        description=(
+            "Model name passed to the CLI's ``--model``. When unset, "
+            "``ProviderConfig.model`` is used."
+        ),
+    )
+    max_turns: int | None = Field(
+        default=8,
+        ge=1,
+        le=50,
+        description=(
+            "Turn cap. Passed to the CLI's ``--max-turns`` where supported "
+            "(codex ignores it — the CLI has no such flag)."
+        ),
+    )
+    passthrough_env: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Allowlist of environment variable NAMES forwarded from the "
+            "parent process into the child. The child otherwise inherits "
+            "no parent environment (subscription-first auth policy). "
+            "``ANTHROPIC_API_KEY`` is NOT forwarded unless listed here."
+        ),
+    )
+    agent_depth_limit: int = Field(
+        default=2,
+        ge=1,
+        le=4,
+        description=(
+            "Recursion nesting cap. ``CODEROUTER_AGENT_DEPTH`` is "
+            "propagated (incremented) into the child; ``generate()`` "
+            "refuses when the current depth is at or above this limit."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _resolve_and_check(self) -> AgentCliConfig:
+        """Default ``command`` to ``agent`` and reject contradictory sandbox.
+
+        Rule (design §5.2.1 #2): ``allow_file_writes=True`` together with
+        ``sandbox_mode="read_only"`` is contradictory — the operator asked
+        for writes while pinning a read-only sandbox. Fail fast at load,
+        matching the module's other cross-field validators.
+        """
+        if self.command is None:
+            self.command = self.agent
+        if self.allow_file_writes and self.sandbox_mode == "read_only":
+            raise ValueError(
+                "agent_cli: allow_file_writes=True conflicts with "
+                "sandbox_mode='read_only'. Set sandbox_mode to 'edit' or "
+                "'full_auto' to permit writes, or keep allow_file_writes=False."
+            )
+        return self
+
+
 class ProviderConfig(BaseModel):
     """A single provider entry from providers.yaml.
 
@@ -170,20 +289,26 @@ class ProviderConfig(BaseModel):
         - Local llama.cpp server: kind=openai_compat, base_url=http://localhost:8080/v1
         - OpenRouter free: kind=openai_compat, base_url=https://openrouter.ai/api/v1
         - (future) Anthropic: kind=anthropic, base_url=https://api.anthropic.com
+        - External agent CLI: kind=agent_cli, agent_cli={agent: claude, ...}
     """
 
     model_config = ConfigDict(extra="forbid")
 
     name: str = Field(..., description="Unique identifier used in profiles.yaml")
-    kind: Literal["openai_compat", "anthropic"] = Field(
+    kind: Literal["openai_compat", "anthropic", "agent_cli"] = Field(
         default="openai_compat",
         description=(
             "Adapter type. 'openai_compat' covers llama.cpp / Ollama / "
             "OpenRouter / LM Studio / Together / Groq. 'anthropic' is the "
-            "native Anthropic Messages API passthrough (v0.3.x)."
+            "native Anthropic Messages API passthrough (v0.3.x). 'agent_cli' "
+            "invokes an external coding-agent CLI one-shot (see AgentCliConfig)."
         ),
     )
-    base_url: HttpUrl
+    # base_url is required for HTTP-backed adapters (openai_compat / anthropic)
+    # but meaningless for agent_cli (which shells out to a local CLI rather
+    # than calling a URL). It is optional at the field level and enforced per
+    # kind by ``_check_kind_requirements`` below.
+    base_url: HttpUrl | None = None
     model: str = Field(..., description="Upstream model id sent in the request body")
     api_key_env: str | None = Field(
         default=None,
@@ -243,6 +368,14 @@ class ProviderConfig(BaseModel):
 
     capabilities: Capabilities = Field(default_factory=Capabilities)
 
+    # kind="agent_cli": required external coding-agent CLI settings. Opt-in
+    # (default None) exactly like ``restart_command`` — only meaningful when
+    # ``kind == "agent_cli"``, and enforced by ``_check_kind_requirements``.
+    agent_cli: AgentCliConfig | None = Field(
+        default=None,
+        description="Required when kind='agent_cli': external agent CLI settings.",
+    )
+
     cost: CostConfig | None = Field(
         default=None,
         description=(
@@ -296,6 +429,32 @@ class ProviderConfig(BaseModel):
         from coderouter.output_filters import validate_output_filters
 
         validate_output_filters(self.output_filters)
+        return self
+
+    @model_validator(mode="after")
+    def _check_kind_requirements(self) -> ProviderConfig:
+        """Enforce per-``kind`` field requirements (external-agents design §5.2.2).
+
+        - HTTP-backed adapters (``openai_compat`` / ``anthropic``) require a
+          ``base_url`` — they have nowhere to send the request otherwise.
+          ``base_url`` was relaxed to Optional so ``agent_cli`` providers can
+          omit it; this validator restores the required-ness for the HTTP kinds.
+        - ``agent_cli`` requires the ``agent_cli`` sub-config (the adapter has
+          no CLI to invoke without it).
+
+        Same fast-fail philosophy as ``_check_output_filters_known`` — a
+        misconfigured provider surfaces at config-load, not at first request.
+        """
+        if self.kind in ("openai_compat", "anthropic") and self.base_url is None:
+            raise ValueError(
+                f"provider {self.name!r}: base_url is required for "
+                f"kind={self.kind!r}."
+            )
+        if self.kind == "agent_cli" and self.agent_cli is None:
+            raise ValueError(
+                f"provider {self.name!r}: agent_cli sub-config is required "
+                f"for kind='agent_cli'."
+            )
         return self
 
 

--- a/docs/designs/external-agents-adapter.md
+++ b/docs/designs/external-agents-adapter.md
@@ -1,0 +1,606 @@
+# 外部コーディングエージェント統合アダプタ設計書（`kind="agent_cli"`）
+
+> 対象バージョン: CodeRouter v2.x 系 / Phase 1（in-core adapter）
+> 関連: [`docs/future.md`](../future.md) §1.2・§5、[`docs/backends/launcher.md`](../backends/launcher.md)
+> ステータス: 設計確定（実装前）
+
+本設計書は、OpenAI Codex CLI・Google Gemini CLI・xAI Grok・Anthropic Claude Code CLI の4つの外部コーディングエージェントを、CodeRouter の新しいアダプタ種別 `kind="agent_cli"` として本体に組み込む方式を定義するものである。CLI のフラグ・認証仕様はすべて調査レポート（`RESEARCH-cli.md`、2026-07 時点）を、コード上の拡張点はすべてコード解析報告書（`ANALYSIS-code.md`）を典拠とする。ユーザー確定事項（`DECISIONS.md`）は拘束条件であり、本書はそれを厳密に実装する。
+
+---
+
+## 1. 概要と目的
+
+### 1.1 何を作るか
+
+CodeRouter 本体に、外部コーディングエージェント CLI をワンショット（one-shot exec）で呼び出す in-core アダプタ `AgentCliAdapter` を新設する。以下を満たす。
+
+- アダプタ種別は `kind="agent_cli"` の**1アダプタ・複数ターゲット方式**である。`openai_compat` アダプタが多数のバックエンドを1クラスで捌く前例（`ANALYSIS-code.md` §4-1）に倣い、`agent` フィールド（`codex` / `gemini` / `grok` / `claude`）で分岐する。
+- 呼び出しは**ワンショット exec のみ**である（`codex exec` / `gemini -p` / `claude -p` / `grok -p` もしくは Grok は公式 API 直）。セッション継続（resume）・対話モードは扱わない（`DECISIONS.md` #2）。
+- 認証は**サブスクリプション優先**である。子プロセス環境は親環境を継承せず、明示 allowlist で最小注入する（`DECISIONS.md` #4）。
+
+### 1.2 なぜ作るか
+
+Claude Code などのオーケストレータから見たとき、CodeRouter は OpenAI 互換 / Anthropic 互換のエンドポイントを1つ提供する透過プロキシである。本機能により、オーケストレータは他社エージェント（Codex・Gemini・Grok）を**「1つのモデル」**として、`model` 名または `X-CodeRouter-Profile` ヘッダを指定するだけで透過的に利用できる。ユーザーは各社 CLI の起動コマンド・フラグ・認証差を意識せず、`providers.yaml` に1エントリ足すだけで済む。
+
+### 1.3 future.md 思想との整合
+
+`future.md` の核心価値は「透過性」と「1リクエスト=1変換のステートレス性」である（`ANALYSIS-code.md` §2、future.md L647）。コーディングエージェントは本来ステートフル・マルチターン・FS 編集を伴う制御ループであり、この思想と衝突する。しかし**ワンショット exec に限定すれば「プロンプト in → テキスト out」の1変換に落とし込め**、思想と整合する（`ANALYSIS-code.md` §2）。オーケストレーション本体は CodeRouter の「クライアント」＝別プロセス側に置くという future.md §5.2 の結論も維持される。CodeRouter はあくまで1変換を担うだけであり、エージェント間協調は行わない。
+
+---
+
+## 2. スコープ / 非スコープ
+
+### 2.1 スコープ（Phase 1）
+
+| 項目 | 内容 |
+|---|---|
+| 実装形態 | in-core adapter（`kind="agent_cli"`）を CodeRouter 本体へ実装 |
+| 対象エージェント | codex / gemini / grok / claude の4種 |
+| 呼び出し | ワンショット exec（`generate()`）と擬似ストリーム（`stream()`） |
+| 認証 | サブスク優先 + 子プロセス env allowlist |
+| 安全制御 | allowlist argv・既定 read-only・workdir 境界・timeout 強制 kill・再帰上限 |
+
+### 2.2 非スコープ
+
+以下は本フェーズでは扱わない。将来拡張として言及するにとどめる。
+
+| 非スコープ項目 | 理由 / 扱い |
+|---|---|
+| セッション継続（resume） | `DECISIONS.md` #2。ステートフル化は思想と衝突。将来拡張として §10 に記載のみ |
+| 対話モード（TTY） | 非対話面のみを使う。TTY スクレイピングは禁止（`RESEARCH-cli.md` §7） |
+| CodeRouter の MCP サーバー化 | 依存最小主義（Core 5 deps）違反（`ANALYSIS-code.md` §3-D） |
+| マルチターン協調・エージェント間オーケストレーション | future.md §5.2 によりクライアント側の責務 |
+| Plugin SDK 経由の Adapter フック配線 | Adapter Protocol は未配線（`ANALYSIS-code.md` §1）。**Phase 2** として §9 に別掲 |
+
+---
+
+## 3. ユーザーストーリー
+
+運用者は `providers.yaml` に agent_cli プロバイダを記述し、専用プロファイルに割り当てる。Claude Code などのクライアントは `X-CodeRouter-Profile: codex` ヘッダ、または `model_pattern` により `model` 名で当該プロファイルへ到達する。
+
+### 3.1 providers.yaml 記述例（4エージェント分）
+
+```yaml
+allow_paid: true                 # grok API 直や有料サブスク利用時に必要
+
+providers:
+  # ---- Claude Code CLI（Phase 1a・最優先）----
+  - name: agent-claude
+    kind: agent_cli
+    model: opus                  # CLI に渡す --model 値（opus|sonnet|haiku|fable）
+    paid: true
+    capabilities:
+      streaming: false            # 既定 true のため明示上書き必須（§7）
+    agent_cli:
+      agent: claude
+      command: claude            # PATH 解決。絶対パスも可
+      workdir: ~/.coderouter/agents/claude
+      exec_timeout_s: 600
+      allow_file_writes: false   # 既定 read-only
+      max_turns: 8
+      sandbox_mode: read_only
+      passthrough_env: [CLAUDE_CODE_OAUTH_TOKEN]   # setup-token（任意）
+
+  # ---- OpenAI Codex CLI（Phase 1b）----
+  - name: agent-codex
+    kind: agent_cli
+    model: gpt-5.5
+    paid: true
+    capabilities:
+      streaming: false
+    agent_cli:
+      agent: codex
+      command: codex
+      workdir: ~/.coderouter/agents/codex
+      exec_timeout_s: 600
+      allow_file_writes: false
+      sandbox_mode: read_only
+      passthrough_env: []        # サブスク OAuth は ~/.codex から読む
+
+  # ---- Google Gemini CLI（Phase 1c）----
+  - name: agent-gemini
+    kind: agent_cli
+    model: gemini-2.5-pro
+    paid: true
+    capabilities:
+      streaming: false
+    agent_cli:
+      agent: gemini
+      command: gemini
+      workdir: ~/.coderouter/agents/gemini
+      exec_timeout_s: 600
+      allow_file_writes: false
+      max_turns: 8               # settings.json の maxSessionTurns 相当
+      sandbox_mode: read_only
+      passthrough_env: [GEMINI_API_KEY]   # OAuth キャッシュが無い場合の保険
+
+  # ---- xAI Grok（Phase 1d・CLI 経路）----
+  - name: agent-grok
+    kind: agent_cli
+    model: grok-code-fast-1
+    paid: true
+    capabilities:
+      streaming: false
+    agent_cli:
+      agent: grok
+      command: grok
+      workdir: ~/.coderouter/agents/grok
+      exec_timeout_s: 600
+      allow_file_writes: false
+      max_turns: 8
+      sandbox_mode: read_only
+      passthrough_env: [XAI_API_KEY]      # grok は API 課金必須（サブスク非対応）
+
+profiles:
+  - name: codex
+    providers: [agent-codex]
+  - name: gemini
+    providers: [agent-gemini]
+  - name: grok
+    providers: [agent-grok]
+  - name: claude-agent
+    providers: [agent-claude]
+
+# model 名でも到達可能にする（任意）
+auto_router:
+  rules:
+    - id: user:route-codex
+      profile: codex
+      match: { model_pattern: "codex.*" }
+```
+
+> 補足: Grok は公式 API が OpenAI 互換（`https://api.x.ai/v1`）であるため、CLI を使わず既存 `kind="openai_compat"` プロバイダとして `grok-code-fast-1` を直接叩く方が安定である（`RESEARCH-cli.md` §3、`DECISIONS.md` #5）。上記 agent_cli 版は CLI 統一運用を望む場合の代替経路である（§9 Phase 1d 参照）。
+
+### 3.2 呼び出しの流れ
+
+Claude Code 側の接続例。
+
+```bash
+# プロファイルヘッダで codex エージェントに到達
+ANTHROPIC_BASE_URL=http://localhost:8088 \
+ANTHROPIC_AUTH_TOKEN=dummy \
+  claude
+# → リクエストヘッダ X-CodeRouter-Profile: codex を付与すると
+#   CodeRouter が codex exec を1回起動し、最終回答テキストを1変換で返す
+```
+
+クライアントから見えるのは通常の OpenAI/Anthropic 応答であり、背後で外部 CLI が動いていることは透過である。
+
+---
+
+## 4. アーキテクチャ
+
+### 4.1 構成図
+
+```
+ ┌────────────────┐   OpenAI/Anthropic 互換    ┌──────────────────────────────┐
+ │ Claude Code /  │ ────── HTTP ────────────►  │ CodeRouter ingress            │
+ │ Cursor 等      │   X-CodeRouter-Profile     │  openai_routes / anthropic    │
+ └────────────────┘                            └──────────────┬───────────────┘
+                                                              │ ChatRequest
+                                                              ▼
+                                              ┌──────────────────────────────┐
+                                              │ routing/fallback.py           │
+                                              │  register_provider / _adapters│
+                                              │  guards（tool_loop /          │
+                                              │  context_budget / memory）    │
+                                              └──────────────┬───────────────┘
+                                                              │ build_adapter(provider)
+                                                              ▼
+                                              ┌──────────────────────────────┐
+                                              │ AgentCliAdapter(BaseAdapter)  │
+                                              │  agent=codex|gemini|grok|claude│
+                                              │  generate() / stream() /      │
+                                              │  healthcheck()                │
+                                              └──────────────┬───────────────┘
+                                                              │ create_subprocess_exec
+                                                              │ （allowlist argv・env allowlist・PGID）
+                                                              ▼
+                        ┌──────────┬──────────┬──────────┬──────────────┐
+                        │ codex    │ gemini   │ grok     │ claude        │
+                        │ exec     │ -p       │ -p / API │ -p            │
+                        │ --json   │ --output │ --output │ --output      │
+                        │          │ -format  │ -format  │ -format json  │
+                        └──────────┴──────────┴──────────┴──────────────┘
+                              ▲ 認証は各 CLI の資格情報ディレクトリ
+                              │ ~/.codex ~/.gemini ~/.claude（OAuth）
+```
+
+### 4.2 AgentCliAdapter の位置づけ
+
+`AgentCliAdapter` は `coderouter/adapters/base.py` の `BaseAdapter`（L162）を継承する。既存の fallback / profile / guards / cost / `register_provider` の資産を無改造で継承できる（`ANALYSIS-code.md` §3-A・§4-4）。`build_adapter`（`adapters/registry.py` L11）に1分岐を足すだけで配線される。
+
+### 4.3 リクエストフロー
+
+1. ingress が `ChatRequest`（`base.py` L43）を構築。
+2. `routing/fallback.py` がプロファイルの chain を解決し、既存 guards を wire 層で適用（`ANALYSIS-code.md` §5）。
+3. `register_provider`（fallback.py L1176）が `_adapters` キャッシュ（L1106-1108）から `AgentCliAdapter` を取得。
+4. `generate()` が `ChatRequest.messages` からプロンプト文字列を組み立て、CLI を1回 exec、最終回答を `ChatResponse`（L70）へ整形して返す。
+5. 失敗は `AdapterError`（L104、`retryable` フラグ付き）で送出し、fallback エンジンが次プロバイダへ降格する。
+
+---
+
+## 5. 詳細設計
+
+### 5.1 `coderouter/adapters/agent_cli.py`（新規）
+
+#### 5.1.1 クラス設計
+
+```python
+class AgentCliAdapter(BaseAdapter):
+    """外部コーディングエージェント CLI を one-shot exec で呼ぶアダプタ。
+
+    agent フィールドで codex / gemini / grok / claude を分岐する
+    1アダプタ・複数ターゲット方式（openai_compat.py の前例に倣う）。
+    """
+
+    def __init__(self, config: ProviderConfig) -> None:
+        super().__init__(config)
+        self.acfg: AgentCliConfig = config.agent_cli  # 必須（検証済み）
+        # agent → argv ビルダ / パーサのディスパッチ表
+        self._builders = {
+            "codex": self._build_codex_argv,
+            "gemini": self._build_gemini_argv,
+            "grok": self._build_grok_argv,
+            "claude": self._build_claude_argv,
+        }
+        self._parsers = {
+            "codex": self._parse_codex,
+            "gemini": self._parse_gemini,
+            "grok": self._parse_grok,
+            "claude": self._parse_claude,
+        }
+```
+
+#### 5.1.2 `healthcheck()` 擬似コード
+
+CLI バイナリの存在確認のみを行う（`ANALYSIS-code.md` §4-1、`base.py` L239）。実 API を叩かない軽量チェックである。
+
+```python
+async def healthcheck(self) -> bool:
+    import shutil
+    return shutil.which(self.acfg.command) is not None
+```
+
+#### 5.1.3 `generate()` 擬似コード
+
+```python
+async def generate(self, request, *, overrides=None) -> ChatResponse:
+    # 注意: 継承元の effective_timeout()（base.py L222）はオーバーライド未設定時に
+    # self.config.timeout_s（ProviderConfig.timeout_s）へフォールバックするため、
+    # そのまま呼ぶと exec_timeout_s が無視される。agent_cli は独自に解決する。
+    timeout = (
+        overrides.timeout_s
+        if overrides is not None and overrides.timeout_s is not None
+        else self.acfg.exec_timeout_s
+    )
+    prompt = self._render_prompt(request, overrides)     # messages → 1本の文字列
+    argv = self._builders[self.acfg.agent](prompt)       # allowlist argv
+    env = self._build_child_env()                         # env allowlist 注入（§5.3）
+    cwd = self._resolve_workdir()                         # workdir 境界検証（§6）
+
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdin=PIPE, stdout=PIPE, stderr=PIPE,
+        cwd=cwd, env=env,
+        start_new_session=True,     # 新プロセスグループ（PGID kill 用）
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(input=prompt.encode() if self._uses_stdin else None),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        self._kill_process_group(proc)   # os.killpg(os.getpgid(pid), SIGKILL)
+        raise AdapterError(f"{self.acfg.agent} exec timed out after {timeout}s",
+                           provider=self.name, retryable=True)
+
+    if proc.returncode != 0:
+        raise AdapterError(f"{self.acfg.agent} exit={proc.returncode}: {stderr[-2000:]!r}",
+                           provider=self.name,
+                           status_code=None,
+                           retryable=self._is_retryable(proc.returncode))
+
+    final_text, usage, cost = self._parsers[self.acfg.agent](stdout, stderr)
+    return self._to_chat_response(request, final_text, usage, cost)
+```
+
+#### 5.1.4 `stream()` 擬似コード（擬似ストリーム）
+
+CLI によっては安定した `stream-json` 面が無い（Codex は JSONL だが最終メッセージ抽出前提、Gemini の stream-json は pre-1.0）。本フェーズは**擬似ストリーム**方針を採る。`generate()` の最終テキストを1つ以上の `StreamChunk`（`base.py` L86）に分割して yield する。`capabilities.streaming=false` を既定とし（§7）、クライアントが SSE を要求した場合のみ擬似的に応答する。
+
+```python
+async def stream(self, request, *, overrides=None) -> AsyncIterator[StreamChunk]:
+    resp = await self.generate(request, overrides=overrides)
+    text = resp.choices[0]["message"]["content"]
+    for piece in _chunk_text(text):      # 適当な粒度で分割
+        yield StreamChunk(id=resp.id, created=resp.created, model=resp.model,
+                          choices=[{"index": 0, "delta": {"content": piece},
+                                    "finish_reason": None}])
+    yield StreamChunk(id=resp.id, created=resp.created, model=resp.model,
+                      choices=[{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                      usage=resp.usage)
+```
+
+#### 5.1.5 各エージェントの argv 構築表
+
+すべてのフラグは `RESEARCH-cli.md` を典拠とする。`sandbox_mode=read_only`（既定）の場合を示す。`shell=True` は禁止し、必ずリスト形式の argv を `create_subprocess_exec` へ渡す。
+
+| agent | 基本 argv | JSON 出力 | モデル指定 | 作業dir | サンドボックス/承認 | ターン上限 | プロンプト投入 |
+|---|---|---|---|---|---|---|---|
+| **codex** | `codex exec` | `--json` | `-m <model>` | `--cd <workdir>` | `-s read-only` | （フラグ無し→外部 timeout で囲む） | 引数末尾 or `-`（stdin） |
+| **gemini** | `gemini` | `--output-format json` | `-m <model>` | `--include-directories <workdir>` | `--approval-mode default` | settings.json `maxSessionTurns`（CLI フラグ無し） | `-p "<prompt>"` |
+| **grok**(CLI) | `grok` | `--output-format json` | `-m <model>` | `--cwd <workdir>` | `--sandbox`（書込拒否） | `--max-turns <N>` | `-p "<prompt>"` |
+| **claude** | `claude -p` | `--output-format json` | `--model <model>` | `--add-dir <workdir>` | `--permission-mode plan` | `--max-turns <N>` | 引数 or stdin（10MB上限） |
+
+補足事項（`RESEARCH-cli.md` 由来）:
+
+- **codex**: `--timeout` / `--max-turns` は**存在しない**。時間上限は本アダプタの `asyncio.wait_for` + PGID kill で強制する。git 外ディレクトリで動かす場合は `--skip-git-repo-check` を付与。`--ephemeral` でセッション不保存。`--full-auto` は非推奨のため使わない。
+- **gemini**: 全体 `--timeout` フラグは無い。`maxSessionTurns` 超過は終了コード **53**。非 TTY で自動ヘッドレス化するが、確実性のため `-p` を明示する。
+- **grok(CLI)**: `--always-approve`（別名 `--yolo`）は full_auto 時のみ。read_only では付与しない。
+- **claude**: `--bare` は付与**しない**（理由は §5.3.4）。`--max-turns` は print mode（`-p`）でのみ有効。
+
+#### 5.1.6 JSON 出力のパース仕様
+
+| agent | 出力形式 | 最終回答の抽出 | usage 正規化 | コスト |
+|---|---|---|---|---|
+| **codex** | JSONL（1行1イベント） | 最後の `item.completed` かつ `item.type=="agent_message"` の `item.text` | `turn.completed.usage` の `input_tokens` / `cached_input_tokens` / `output_tokens` | ドル額出力なし → `cost` から算出（§5.2） |
+| **gemini** | 単一 JSON オブジェクト | `.response` | `.stats.models.<name>.tokens` | ドル額なし → 算出 |
+| **grok**(CLI) | 単一 JSON（`--output-format json`） | 応答本文フィールド | トークンフィールド | ドル額なし → 算出 |
+| **claude** | 単一 JSON オブジェクト | `.result`（`type=="result"`, `subtype=="success"`, `is_error==false`） | `num_turns` / `duration_ms` 併記 | **`total_cost_usd` を直接出力**（唯一） |
+
+- usage は OpenAI 形式 `{"prompt_tokens", "completion_tokens", "total_tokens"}` に正規化して `ChatResponse.usage`（`base.py` L80）へ格納する。codex の `cached_input_tokens` は `prompt_tokens_details.cached_tokens` として保持する。
+- **total_cost_usd**: claude は JSON の `total_cost_usd` をそのまま `coderouter_provider` 相当のメタとして cost dashboard に流す。他エージェントは `ProviderConfig.cost`（`schemas.py` L246、`CostConfig`）に単価を設定した場合のみトークン数から算出する。未設定ならコスト0（トークン数のみ集計）。
+- JSON は**防御的にパース**する（`RESEARCH-cli.md` §7）。想定フィールド欠落時は `AdapterError(retryable=True)` を送出する。
+
+#### 5.1.7 stdout/stderr の drain
+
+Codex は**進捗を stderr・最終メッセージを stdout** に分離出力する（`RESEARCH-cli.md` §1）。`communicate()` は両ストリームを並行に読み切るため、パイプバッファ満杯によるデッドロックを避けられる。`launcher_routes.py` の `_drain`（L555-577、`_LOG_STREAM_LIMIT`・`LimitOverrunError` 対策）が下敷きになる（`ANALYSIS-code.md` §4-5）。ただしワンショットのため常駐レジストリ（`ManagedProcess` L109）は不要で、`create_subprocess_exec` + `communicate()` の1ショットで足りる。
+
+#### 5.1.8 タイムアウトとプロセスグループ kill
+
+- `exec_timeout_s`（プロファイル override（`ProviderCallOverrides.timeout_s`）があればそちらが優先）を `asyncio.wait_for` で強制する。継承元 `effective_timeout()`（`base.py` L222）は `ProviderConfig.timeout_s` にフォールバックする実装のためそのままは使わず、§5.1.3 の通り `AgentCliConfig.exec_timeout_s` を基準に解決する。Codex/Gemini は CLI 側 timeout を持たないため Python 側の強制 kill が必須である（`RESEARCH-cli.md` §7）。
+- 子プロセスは `start_new_session=True` で新プロセスグループとして起動し、タイムアウト時は `os.killpg(os.getpgid(pid), SIGKILL)` でグループごと確実に停止する（CLI が子プロセス＝実 LLM 呼び出しをぶら下げるため、親のみ kill では孤児が残る）。
+
+#### 5.1.9 ANSI / TTY 対策
+
+必ず非対話面（`exec` / `-p`）と JSON 出力を使う（`RESEARCH-cli.md` §7）。加えて子プロセス env に `NO_COLOR=1` / `TERM=dumb` を注入し、ANSI エスケープの混入を防ぐ。stdin/stdout はパイプ接続であり TTY を割り当てない。
+
+### 5.2 config schema
+
+#### 5.2.1 `AgentCliConfig`（新規サブスキーマ）
+
+`schemas.py` に以下を追加する。`extra="forbid"` を踏襲する（`schemas.py` L175 の方針）。
+
+| フィールド | 型 | 既定 | 説明 |
+|---|---|---|---|
+| `agent` | `Literal["codex","gemini","grok","claude"]` | 必須 | 呼び出す外部エージェント種別 |
+| `command` | `str` | `agent` 名と同じ | CLI 実行ファイル名または絶対パス（PATH 解決） |
+| `workdir` | `str \| None` | `None` | 作業ディレクトリ。`~` / 環境変数展開。未設定時は専用隔離 dir を自動生成 |
+| `exec_timeout_s` | `float`（`ge=1.0, le=1800.0`） | `600.0` | ワンショット exec の強制タイムアウト |
+| `allow_file_writes` | `bool` | `False` | FS 書き込み許可。既定は read-only（§6） |
+| `sandbox_mode` | `Literal["read_only","edit","full_auto"]` | `"read_only"` | 各 CLI のサンドボックス/承認へのマッピング元（§5.4） |
+| `model` | `str \| None` | `None` | CLI へ渡すモデル名の上書き。未設定なら `ProviderConfig.model` を使用 |
+| `max_turns` | `int \| None`（`ge=1, le=50`） | `8` | ターン上限。codex は無視（CLI 未対応）、他は該当フラグへ |
+| `passthrough_env` | `list[str]` | `[]` | 子プロセスへ転送する env 変数名の allowlist（§5.3） |
+| `agent_depth_limit` | `int`（`ge=1, le=4`） | `2` | 再帰ネスト上限（§5.5） |
+
+検証ルール（`model_validator(mode="after")`、`schemas.py` の既存 fast-fail パターンに倣う）:
+
+1. `agent=="grok"` かつ `passthrough_env` に `XAI_API_KEY` が無い場合は警告レベルで注記（Grok はサブスク非対応で API キー必須。`RESEARCH-cli.md` §3）。
+2. `allow_file_writes=True` かつ `sandbox_mode=="read_only"` は矛盾のため `ValueError`。
+3. `exec_timeout_s` は `ProviderConfig.timeout_s`（`schemas.py` L198）とは独立。exec 用の別枠として扱う。
+
+#### 5.2.2 `ProviderConfig` への追加
+
+`schemas.py` L178 の `kind` の `Literal` に `"agent_cli"` を追加し、`agent_cli` フィールドを任意で足す（`restart_command` L274 のように opt-in・既定 None のパターンを踏襲）。
+
+```python
+kind: Literal["openai_compat", "anthropic", "agent_cli"] = "openai_compat"
+agent_cli: AgentCliConfig | None = Field(default=None,
+    description="kind='agent_cli' 時に必須の外部エージェント設定。")
+```
+
+追加検証（`ProviderConfig` の `model_validator`）:
+
+- `kind=="agent_cli"` のとき `agent_cli` は必須。欠落は `ValueError`。
+- `kind=="agent_cli"` のとき `base_url` は不要。**設計判断**: 現行 `base_url: HttpUrl`（L186）は必須のため、`base_url: HttpUrl | None = None` に緩和し、「`kind` が `openai_compat`/`anthropic` のときのみ必須」を `model_validator` で強制する。これにより agent_cli は URL を持たずに済む。
+- `model` は必須のまま流用する。capability registry・ログ・cost 集計のキーとして機能し、`AgentCliConfig.model` が未設定なら CLI の `--model` 値にもなる。
+
+#### 5.2.3 `build_adapter` への配線
+
+`adapters/registry.py` L11-17 に1分岐を追加する（`ANALYSIS-code.md` §4-2）。
+
+```python
+if provider.kind == "agent_cli":
+    from coderouter.adapters.agent_cli import AgentCliAdapter
+    return AgentCliAdapter(provider)
+```
+
+`routing/fallback.py` は改修不要（`register_provider` L1176・`_adapters` キャッシュ L1106-1108 が新 kind を自動で扱う。`ANALYSIS-code.md` §4-4）。
+
+### 5.3 認証設計（`DECISIONS.md` #4 準拠）
+
+#### 5.3.1 基本方針: サブスク優先 + 子プロセス env allowlist
+
+子プロセスは**親環境を継承しない**。`env=` を明示構築し、allowlist に列挙された変数のみを注入する。これは残存 `ANTHROPIC_API_KEY` がサブスク OAuth を上書きする事故（`RESEARCH-cli.md` §4 の落とし穴）を根本から断つためである。
+
+`_build_child_env()` は以下だけを含む最小環境を返す。
+
+| キー | 出所 | 目的 |
+|---|---|---|
+| `HOME` | 親の `HOME`（後述ポリシー） | 資格情報ディレクトリ探索 |
+| `PATH` | 固定の安全な PATH | CLI バイナリ解決 |
+| `NO_COLOR` / `TERM=dumb` | 固定注入 | ANSI 抑止 |
+| `CODEROUTER_AGENT_DEPTH` | 現在値+1 | 再帰防止（§5.5） |
+| `passthrough_env` 列挙分 | 親環境から該当名のみ | エージェント別の必須キー（下表） |
+
+`ANTHROPIC_API_KEY` は allowlist に**既定で含めない**。含めたい場合は運用者が明示的に `passthrough_env` へ書く必要がある（`ANALYSIS-code.md` §5、`config/loader.py` の `resolve_api_key` L95 とは別系統の転送）。
+
+#### 5.3.2 HOME / 資格情報ディレクトリ継承ポリシー
+
+サブスク OAuth トークンはファイルで保管される（`~/.codex/auth.json`・`~/.gemini/`・`~/.claude/.credentials.json`）。子プロセスがこれらを読めるよう `HOME` を継承させる。ただし **`HOME` 継承はするが env allowlist は最小のまま**という分離を守る（`ANALYSIS-code.md` §5 が「(a) env allowlist と (b) HOME/設定ディレクトリ継承ポリシーを分けて定義せよ」と要求）。運用者が資格情報を隔離したい場合は、CLI 別の `CODEX_HOME` 等を `passthrough_env` で指す運用も可能とする。
+
+#### 5.3.3 エージェント別の認証要件
+
+| agent | 優先経路（サブスク） | 代替 | passthrough_env の推奨 |
+|---|---|---|---|
+| **claude** | Pro/Max OAuth（`~/.claude/.credentials.json`）。`claude setup-token` の1年トークン `CLAUDE_CODE_OAUTH_TOKEN` も可 | `ANTHROPIC_API_KEY`（**非推奨**・既定注入せず） | `[CLAUDE_CODE_OAUTH_TOKEN]`（任意） |
+| **codex** | ChatGPT プラン OAuth（`~/.codex/auth.json`）。**約8日で失効**に注意 | `CODEX_API_KEY` | `[]`（サブスク時は空） |
+| **gemini** | Google OAuth キャッシュ（`~/.gemini/`）。**キャッシュ済みなら**動作 | `GEMINI_API_KEY` | `[GEMINI_API_KEY]`（保険） |
+| **grok** | **サブスク非対応**（SuperGrok / X Premium+ は API をカバーしない） | `XAI_API_KEY` **必須** | `[XAI_API_KEY]`（必須） |
+
+#### 5.3.4 `--bare` を使わない理由（claude）
+
+`claude --bare` は hooks/skills/plugins/MCP/CLAUDE.md の自動探索をスキップし CI 向きだが、**OAuth / keychain を読まない**（`RESEARCH-cli.md` §4）。本機能はサブスク OAuth を第一経路とするため、`--bare` を付けるとサブスク認証が効かなくなる。したがって `--bare` は**付与しない**。将来 `--bare` が `-p` の既定になる予定がある点は §10 のリスクに記載する。
+
+### 5.4 mode → 各 CLI サンドボックス/承認フラグのマッピング
+
+`sandbox_mode` を各 CLI の実フラグへ写像する（`RESEARCH-cli.md` §synthesis 由来）。既定は `read_only`。
+
+| sandbox_mode | codex | gemini | grok(CLI) | claude |
+|---|---|---|---|---|
+| **read_only**（既定） | `-s read-only` | `--approval-mode default`（書込なし） | `--sandbox`（書込拒否） | `--permission-mode plan` |
+| **edit** | `-s workspace-write -a on-request` | `--approval-mode auto_edit` | `--allow`（値未確定・要検証） | `--permission-mode acceptEdits` |
+| **full_auto** | `-s workspace-write -a never` | `--yolo`（+ Docker サンドボックス推奨） | `--always-approve` | `--permission-mode acceptEdits`（CI ロックダウンは `dontAsk`） |
+
+- `allow_file_writes=False`（既定）は `read_only` 相当にクランプし、`edit`/`full_auto` を要求されても書き込みフラグを外す（多重防御）。
+- codex の `workspace-write` は既定でネットワーク無効・`.git` 読取専用（`RESEARCH-cli.md` §1-4）であり、そのまま利用する。
+- grok(CLI) の `--allow` は `RESEARCH-cli.md` にフラグの存在のみ記載されており、値（サブコマンド/引数形式）は未確認である。Phase 1d 着手時に実 CLI で検証すること（`--deny` も同様）。
+
+### 5.5 再帰防止
+
+外部エージェントがさらに CodeRouter を呼び返すネスト再帰を防ぐ（`RESEARCH-cli.md` §7）。
+
+- `CODEROUTER_AGENT_DEPTH` 環境変数を子プロセスへ伝播する。`_build_child_env()` は現在値（未設定なら 0）に +1 した値を注入する。
+- `generate()` 冒頭で現在の depth を読み、`AgentCliConfig.agent_depth_limit`（既定 2）以上なら `AdapterError(retryable=False)` で即時停止する。
+- 併せて `max_turns`（既定 8）で各エージェントの内部ループを有界化する（codex はフラグ非対応のため timeout で代替）。
+
+---
+
+## 6. セキュリティ要件
+
+subprocess は任意コード実行の攻撃面である（`ANALYSIS-code.md` §5）。以下を要件化する。
+
+| 要件 | 実装 |
+|---|---|
+| **allowlist argv のみ** | `create_subprocess_exec` にリスト argv を渡す。`shell=True` は**禁止**。プロンプトは引数値または stdin で渡し、シェル解釈を経由させない |
+| **既定 read-only** | `allow_file_writes=False` / `sandbox_mode="read_only"` が既定。書き込みは明示 opt-in（`restart_command` の「opt-in・既定オフ」先例に倣う） |
+| **workdir 境界** | `workdir` を絶対パスへ正規化し、専用隔離ディレクトリ配下に限定。`..` によるエスケープを拒否。未設定時は `~/.coderouter/agents/<name>` を自動生成 |
+| **timeout 強制 kill** | `exec_timeout_s` を `asyncio.wait_for` で強制、超過時は PGID ごと SIGKILL（§5.1.8） |
+| **env allowlist** | 親環境を継承せず最小注入。`ANTHROPIC_API_KEY` は既定で渡さない（§5.3） |
+| **ネスト上限** | `CODEROUTER_AGENT_DEPTH` + `agent_depth_limit`（§5.5） |
+
+加えて、既存 guards（`tool_loop.py` L290 / `context_budget.py` L109,L153 / `memory_budget.py` L150）は**wire 層検査**であり、新アダプタにも**自動適用**される（`ANALYSIS-code.md` §5）。すなわちツールループ検出・コンテキスト予算・メモリ予算の各保護は agent_cli プロバイダでも追加実装なしで効く。
+
+---
+
+## 7. capability gate との整合
+
+agent_cli プロバイダは「プロンプト in → テキスト out」の不透明なテキストバックエンドである。native なツール呼び出しの往復をクライアントへ中継しない（内部で完結する）。したがって capability の分類方針を以下に定める。
+
+- **`capabilities.tools=false`**（`schemas.py` L29 既定）。エージェントはツールを内部使用するが、CodeRouter のワイヤ上は往復しないため、gate 上は「ツール非対応」とする。
+- **`capabilities.streaming=false`**。§5.1.4 の擬似ストリームであり native SSE ではないため false を既定とする。
+- **`capabilities.reasoning_control="none"` / `mcp="none"`**。CLI が内部で完結するため CodeRouter は関与しない。
+
+配置方針: agent_cli プロバイダは**専用プロファイル**（例: `codex` / `gemini`）に単独で置くか、**fallback chain の終端**に置く。理由は、ツール往復を期待するクライアント要求（`has_tools` 経路）を中間に挟むと、ツール応答をワイヤに返せず不整合になるためである。`auto_router` の `model_pattern` で専用プロファイルへ振り分けるのが推奨形（§3.1）。capability_registry への新規エントリ追加は必須ではなく、`ProviderConfig.capabilities` の明示宣言で足りる。
+
+---
+
+## 8. テスト計画
+
+`ANALYSIS-code.md` §6 を具体化する。雛形は `tests/test_launcher_mtp.py`（L340・L368）である。
+
+| # | テスト | 手法 |
+|---|---|---|
+| T1 | argv 構築の正しさ | 4エージェント × 3 sandbox_mode の argv を snapshot 検証（フラグが `RESEARCH-cli.md` と一致すること） |
+| T2 | JSON パース | 各 CLI の実サンプル JSON/JSONL を固定文字列で与え、最終回答・usage・cost の抽出を検証。欠落フィールドで `AdapterError(retryable=True)` |
+| T3 | スタブ subprocess | `monkeypatch` で `asyncio.create_subprocess_exec` を `_FakeProc` に差し替え（`test_launcher_mtp.py` L368-374 の手法）。stdout/stderr/returncode を注入 |
+| T4 | TestClient E2E | `TestClient(create_app())`（L340）で agent_cli provider + profile を config に書き、`POST /v1/chat/completions` / `/v1/messages` を検証。`X-CodeRouter-Profile` ヘッダ（`openai_routes` L180・L202） |
+| T5 | fallback 降格 | `AdapterError(retryable=True)` を注入し、次プロバイダへ降格することを検証 |
+| T6 | タイムアウト kill | `_FakeProc` を無限ハングさせ、`exec_timeout_s` 超過で PGID kill + `AdapterError` を確認 |
+| T7 | 認証 env 分離 | `_build_child_env()` を単体検証。`ANTHROPIC_API_KEY` が親環境にあっても子 env に**含まれない**こと、`passthrough_env` 列挙分のみ通ること、`CODEROUTER_AGENT_DEPTH` が +1 されること |
+| T8 | 再帰上限 | `CODEROUTER_AGENT_DEPTH` を上限値に設定した状態で `generate()` が `AdapterError(retryable=False)` を出すこと |
+| T9 | 実 CLI smoke | opt-in の手動テスト（CI 非搭載）。各 CLI が実在する環境でのみ実行 |
+
+---
+
+## 9. 実装フェーズ
+
+| Phase | 対象 | 主な変更ファイル | 概算規模 |
+|---|---|---|---|
+| **1a** | claude のみ（最安定・`total_cost_usd` 出力あり・安全制御最細） | `adapters/agent_cli.py`（新規）/ `adapters/registry.py` / `config/schemas.py` / `tests/test_agent_cli.py`（新規） | 新規 ~400 行 + 既存 ~15 行 |
+| **1b** | codex 追加（JSONL パーサ・stderr/stdout 分離） | `adapters/agent_cli.py`（builder/parser 追加） | +~120 行 |
+| **1c** | gemini 追加（単一 JSON・exit 53 ハンドリング） | `adapters/agent_cli.py` | +~90 行 |
+| **1d** | grok 追加（CLI 経路） | `adapters/agent_cli.py` | +~90 行 |
+| **2** | Adapter Protocol の engine 配線 + `coderouter-plugin-agents` への切り出し | `plugins/base.py`（Adapter Protocol 実体化）/ `plugins/loader.py` / 新規パッケージ | 別リポ・core 改修 |
+
+### 9.1 Phase 1a（claude 最優先）
+
+`DECISIONS.md` #5・`RESEARCH-cli.md` §synthesis の推奨に従い claude を最初に実装する。`total_cost_usd` を直接出力する唯一の CLI であり、`--output-format json` スキーマが最も安定（後方互換・追加のみ）であるため、パーサ・cost 経路の基準実装になる。
+
+### 9.2 Phase 1d（grok）の判断基準
+
+Grok の公式 API は OpenAI 互換であり、**既存 `kind="openai_compat"` プロバイダで既に代替可能**である（`base_url: https://api.x.ai/v1`・`api_key_env: XAI_API_KEY`・`model: grok-code-fast-1`）。したがって agent_cli の grok CLI 対応は次を満たす場合のみ実装する。
+
+- 公式 CLI「Grok Build」が beta を脱し JSON スキーマが安定したこと。
+- CLI 固有機能（ローカル FS 編集・サンドボックス）を CodeRouter 経由で使う運用需要が実在すること。
+
+それ以外は API 直（openai_compat）を推奨経路とする。
+
+### 9.3 Phase 2（plugin 化）の移行パス
+
+現状 Adapter Protocol は実体が空（`name: str` のみ、`plugins/base.py` L168-169、`ANALYSIS-code.md` §1）でデッドエンドである。将来 core が Adapter hook を配線したら、in-core の `AgentCliAdapter` を**ほぼそのまま** `coderouter-plugin-agents` へ移設できる（前方互換、`ANALYSIS-code.md` §3）。ロードは entry-point 方式（`group="coderouter.adapters"` 等）+ `plugins.enabled` の二段ゲート（`PluginsConfig`、`schemas.py` L1247）を経る。
+
+---
+
+## 10. リスクと未解決事項
+
+| リスク / 事項 | 内容 | 対応方針 |
+|---|---|---|
+| **CLI バージョン churn** | codex/gemini はほぼ毎日リリース、pre-1.0 の破壊的変更あり（`RESEARCH-cli.md` §1-6・§2-6） | バージョン **pin** を運用手順に明記。JSON は防御的パース（欠落で retryable エラー）。`command` に固定版バイナリを指定可能に |
+| **サブスク規約** | Consumer Terms は常時稼働サービスへの転用を禁止。claude/codex のサブスク OAuth はマルチテナント常時サービスに使うべきでない（`RESEARCH-cli.md` §synthesis の「避けること」） | 個人 CI/スクリプト用途に限定と明記。常時 backend は API キー（Commercial Terms）を運用者判断で選択 |
+| **OAuth 失効** | codex OAuth は**約8日**で失効（`RESEARCH-cli.md` §1-2） | healthcheck では検知不可（バイナリ存在のみ）。exec 失敗を `AdapterError` で fallback。運用手順に再ログイン注記 |
+| **レート制限（5時間窓）** | claude/codex は5時間ローリング窓 + 週次上限（`RESEARCH-cli.md` §1-5・§4-5） | 上限到達時の exec 失敗を retryable エラーで扱い、chain の次プロバイダへ降格 |
+| **ストリーミング制約** | 安定した stream-json 面が CLI により無い | 擬似ストリーム方針（§5.1.4）。`capabilities.streaming=false` を既定に |
+| **gemini OAuth キャッシュ依存** | クリーン CI では OAuth 未サインインで動かない（`RESEARCH-cli.md` §2-2） | `GEMINI_API_KEY` を `passthrough_env` の保険に |
+| **claude `--bare` 既定化予定** | 将来 `--bare` が `-p` の既定になる可能性（`RESEARCH-cli.md` §4-6）。その場合 OAuth を読まなくなる | バージョン pin + 移行時に明示的に `--bare` を無効化するフラグ調査 |
+| **gemini maxSessionTurns 未遵守バグ** | 既知の変動（`RESEARCH-cli.md` §2-6） | timeout を最終防波堤とする |
+
+---
+
+## 11. 付録
+
+### 11.1 調査サマリ比較表（`RESEARCH-cli.md` §5 要約）
+
+| 項目 | Codex CLI | Gemini CLI | Grok（API / CLI） | Claude Code CLI |
+|---|---|---|---|---|
+| 認証 | ChatGPT OAuth or API key | Google OAuth / API key | API key（推奨）/ CLI は OIDC | Pro/Max OAuth or API key |
+| ヘッドレス | `codex exec "..."` | `gemini -p "..."` | API 直 / `grok -p "..."` | `claude -p "..."` |
+| JSON 出力 | `--json`（JSONL） | `--output-format json` | API ネイティブ | `--output-format json` |
+| サンドボックス | Seatbelt/Landlock, net 既定無効 | Docker/Podman/Seatbelt | API=なし / CLI=`--sandbox` | Seatbelt/bubblewrap |
+| サブスクで使えるか | ○（8日失効・CI は key 推奨） | △（要キャッシュ） | **×**（API 別課金） | ○（setup-token 1年・個人 CI 公認） |
+| コスト出力 | トークンのみ | トークンのみ | トークンのみ | **`total_cost_usd` あり** |
+| max-turns/timeout | なし（外部で囲む） | maxSessionTurns（bug あり） | `--max-turns`（CLI） | `--max-turns`（print） |
+| 成熟度 | 高（要 pin） | 中（pre-1.0） | API=高 / CLI=beta | **最高** |
+
+### 11.2 シンボル早見表（`ANALYSIS-code.md` 付録より関連分）
+
+| 対象 | ファイル:行 |
+|---|---|
+| `BaseAdapter` generate/stream/healthcheck | `adapters/base.py` L162, L243, L256, L239 |
+| `ChatRequest` / `ChatResponse` / `StreamChunk` | `adapters/base.py` L43 / L70 / L86 |
+| `AdapterError`（retryable フラグ） | `adapters/base.py` L104 |
+| `effective_timeout` | `adapters/base.py` L222 |
+| `build_adapter` | `adapters/registry.py` L11 |
+| `register_provider` / `_adapters` キャッシュ | `routing/fallback.py` L1176 / L1106 |
+| `ProviderConfig.kind` / `restart_command` / `api_key_env` | `config/schemas.py` L178 / L274 / L188 |
+| `CostConfig` | `config/schemas.py` L64 |
+| `PluginsConfig` / Adapter Protocol（空） | `config/schemas.py` L1247 / `plugins/base.py` L156, L168 |
+| `ManagedProcess` / `_drain`（drain 手法） | `ingress/launcher_routes.py` L109 / L555-577 |
+| guards（自動適用） | `tool_loop.py` L290 / `context_budget.py` L109 / `memory_budget.py` L150 |
+| 資格情報解決 | `config/loader.py` L95 |
+| テスト雛形 | `tests/test_launcher_mtp.py` L340, L368 |
+| 設計思想（透過性・ステートレス） | `docs/future.md` §1.2 L164, §5 L636-815（特に L647, L677） |
+</content>
+</invoke>

--- a/examples/providers-agent-cli.yaml
+++ b/examples/providers-agent-cli.yaml
@@ -1,0 +1,166 @@
+# ============================================================
+# CodeRouter providers.yaml — 外部コーディングエージェント CLI (agent_cli)
+# 【カテゴリ】 kind="agent_cli" アダプタ / Phase 1a (claude のみ実装)
+#
+# 出典: docs/designs/external-agents-adapter.md
+# 目的: Claude Code CLI (`claude -p --output-format json`) を CodeRouter の
+#       1プロバイダとして登録し、他のオーケストレータ (別の Claude Code /
+#       Cursor 等) から「1つのモデル」として透過的に呼び出せるようにする。
+#       CodeRouter はワンショット exec (プロンプト in → テキスト out) の
+#       1変換だけを担い、エージェントのマルチターン制御ループそのものは
+#       中で完結させる (future.md の「1リクエスト=1変換」思想を維持)。
+#
+# Phase 1a スコープ:
+#   - agent: claude のみ実装済み。サブスクリプション OAuth
+#     (`~/.claude/.credentials.json` または `claude setup-token`) を優先し、
+#     子プロセスには ANTHROPIC_API_KEY を含む親環境を継承させない
+#     (env allowlist、下記 passthrough_env 参照)。
+#   - agent: codex / gemini / grok は config スキーマ上は宣言できるが、
+#     アダプタ構築時に AdapterError("not implemented in Phase 1a") で
+#     拒否される。末尾にコメントアウトした Phase 1b-1d のプレビュー
+#     ブロック (未実装) を参照。
+#   - 既定は read_only (書き込み不可)。書き込みを許可するには
+#     allow_file_writes: true と sandbox_mode: edit|full_auto を両方
+#     明示する必要がある (片方だけだと config load 時に ValueError)。
+#   - streaming は native ではなく擬似ストリーム (最終回答を分割して
+#     yield するだけ) なので capabilities.streaming: false を明示する
+#     (既定 true のため上書き必須)。
+#
+# 使い方:
+#   1. claude CLI がインストール済み・`claude` が PATH 上にあること
+#      (`claude --version` で確認)。
+#   2. サブスクリプション認証を済ませておく (`claude` を対話起動して
+#      ログイン、または `claude setup-token` で1年トークンを発行し
+#      CLAUDE_CODE_OAUTH_TOKEN として環境変数に設定)。
+#   3. cp examples/providers-agent-cli.yaml ~/.coderouter/providers.yaml
+#   4. coderouter serve --port 8088
+#   5. 動作確認:
+#        curl http://localhost:8088/v1/chat/completions \
+#          -H 'Content-Type: application/json' \
+#          -H 'X-CodeRouter-Profile: claude-agent' \
+#          -d '{"model":"opus","messages":[{"role":"user","content":"1行でこんにちはと言って"}]}'
+#
+# 注意: agent_cli は課金対象の外部 CLI 呼び出しになり得るため
+#   (claude はサブスクリプション消費、codex/gemini/grok も同様)、
+#   providers[].paid: true としており、これを有効にするには
+#   allow_paid: true が必要 (plan.md §2.3)。
+# ============================================================
+
+allow_paid: true                 # agent_cli (paid: true) を使うために必要
+default_profile: claude-agent
+
+providers:
+  # ---- Claude Code CLI (Phase 1a・実装済み) ----
+  - name: agent-claude
+    kind: agent_cli
+    model: opus                  # CLI へ渡す --model 値 (opus|sonnet|haiku|fable)
+    paid: true
+    timeout_s: 30                # HTTP 層の既定値。agent_cli では使われない
+                                  # (exec の強制タイムアウトは exec_timeout_s の方)
+    capabilities:
+      streaming: false            # 既定 true のため明示上書き必須 (擬似ストリームのみ)
+      tools: false                 # エージェント内部でツールを使うが CodeRouter の
+                                    # ワイヤ上は往復しない (§7)
+    agent_cli:
+      agent: claude
+      command: claude            # PATH 解決。絶対パスも可
+      workdir: ~/.coderouter/agents/claude
+      exec_timeout_s: 600         # ワンショット exec の強制タイムアウト (秒)
+      allow_file_writes: false    # 既定 read-only (書き込みには明示 opt-in が必要)
+      sandbox_mode: read_only     # --permission-mode plan にマップされる
+      max_turns: 8                # CLI 内部のターン上限 (--max-turns)
+      passthrough_env: [CLAUDE_CODE_OAUTH_TOKEN]   # setup-token を使う場合のみ (任意)
+      agent_depth_limit: 2         # ネスト再帰 (CODEROUTER_AGENT_DEPTH) の上限
+
+profiles:
+  # claude-agent — Claude Code CLI 専用プロファイル。単独 (fallback なし)。
+  # agent_cli は「プロンプト in → テキスト out」の不透明なテキスト
+  # バックエンドなので、ツール往復を期待する chain の途中には挟まない
+  # (§7 配置方針)。
+  - name: claude-agent
+    providers:
+      - agent-claude
+
+# model 名でも到達可能にしたい場合の例 (任意):
+# auto_router:
+#   rules:
+#     - id: user:route-claude-agent
+#       profile: claude-agent
+#       match: { model_pattern: "claude-agent.*" }
+
+# ============================================================
+# 以下はプレビュー (Phase 1b-1d・未実装) — コメントアウト
+#
+# 下記の agent: codex / gemini / grok は config スキーマとしては
+# 有効 (providers.yaml として読み込める) だが、AgentCliAdapter の
+# __init__ が Phase 1a では claude 以外を拒否するため、実際に
+# リクエストを投げると起動時に
+#   AdapterError: agent 'codex' is not implemented in Phase 1a
+#   (claude only). Configure agent='claude' or wait for the agent's
+#   phase.
+# で失敗する (retryable=False)。将来のフェーズが実装されるまでの
+# forward-compatible なプレースホルダとして参照用に残してある。
+# 詳細: docs/designs/external-agents-adapter.md §3, §9
+# ============================================================
+
+# providers:
+#   # ---- OpenAI Codex CLI (Phase 1b・未実装) ----
+#   - name: agent-codex
+#     kind: agent_cli
+#     model: gpt-5.5
+#     paid: true
+#     capabilities:
+#       streaming: false
+#     agent_cli:
+#       agent: codex
+#       command: codex
+#       workdir: ~/.coderouter/agents/codex
+#       exec_timeout_s: 600
+#       allow_file_writes: false
+#       sandbox_mode: read_only
+#       passthrough_env: []        # サブスク OAuth は ~/.codex から読む
+#
+#   # ---- Google Gemini CLI (Phase 1c・未実装) ----
+#   - name: agent-gemini
+#     kind: agent_cli
+#     model: gemini-2.5-pro
+#     paid: true
+#     capabilities:
+#       streaming: false
+#     agent_cli:
+#       agent: gemini
+#       command: gemini
+#       workdir: ~/.coderouter/agents/gemini
+#       exec_timeout_s: 600
+#       allow_file_writes: false
+#       max_turns: 8               # settings.json の maxSessionTurns 相当
+#       sandbox_mode: read_only
+#       passthrough_env: [GEMINI_API_KEY]   # OAuth キャッシュが無い場合の保険
+#
+#   # ---- xAI Grok (Phase 1d・未実装・CLI 経路) ----
+#   # 補足: Grok の公式 API は OpenAI 互換なので、CLI 経路より
+#   #   kind: openai_compat + base_url: https://api.x.ai/v1 の方が
+#   #   現状は安定 (§9.2)。以下は CLI 統一運用を望む場合の代替経路。
+#   - name: agent-grok
+#     kind: agent_cli
+#     model: grok-code-fast-1
+#     paid: true
+#     capabilities:
+#       streaming: false
+#     agent_cli:
+#       agent: grok
+#       command: grok
+#       workdir: ~/.coderouter/agents/grok
+#       exec_timeout_s: 600
+#       allow_file_writes: false
+#       max_turns: 8
+#       sandbox_mode: read_only
+#       passthrough_env: [XAI_API_KEY]      # grok は API 課金必須 (サブスク非対応)
+#
+# profiles:
+#   - name: codex
+#     providers: [agent-codex]
+#   - name: gemini
+#     providers: [agent-gemini]
+#   - name: grok
+#     providers: [agent-grok]

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,0 +1,499 @@
+"""Tests for the agent_cli adapter (Phase 1a — claude only).
+
+Implements the design's §8 test plan for the Phase 1a scope:
+
+* T1  argv construction (model / max-turns / permission-mode mapping,
+      allow_file_writes clamp).
+* T2  claude JSON parsing (success / is_error / malformed / missing fields).
+* T3  stubbed subprocess via ``asyncio.create_subprocess_exec`` monkeypatch.
+* T4  TestClient E2E through ``POST /v1/chat/completions``.
+* T6  timeout → process-group kill + retryable AdapterError.
+* T7  child-env isolation (no ANTHROPIC_API_KEY leak, NO_COLOR present,
+      passthrough allowlist, depth +1).
+* T8  recursion depth limit → non-retryable AdapterError.
+
+Plus config-schema validation (agent_cli required, base_url optionality,
+sandbox / allow_file_writes conflict) and healthcheck / retryable semantics.
+
+Subprocess stubbing follows the ``_FakeProc`` shape used in
+``tests/test_launcher_mtp.py``; the TestClient scaffolding mirrors
+``tests/test_fix_h8_launcher_auth.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from coderouter.adapters.agent_cli import AgentCliAdapter
+from coderouter.adapters.base import AdapterError, ChatRequest, Message
+from coderouter.config.schemas import (
+    AgentCliConfig,
+    Capabilities,
+    CodeRouterConfig,
+    FallbackChain,
+    ProviderConfig,
+)
+from coderouter.ingress.app import create_app
+from coderouter.metrics import uninstall_collector
+
+# ---------------------------------------------------------------------------
+# Canned claude `--output-format json` result (design §5.1.6 shape)
+# ---------------------------------------------------------------------------
+
+CLAUDE_RESULT = {
+    "type": "result",
+    "subtype": "success",
+    "is_error": False,
+    "duration_ms": 1234,
+    "num_turns": 3,
+    "result": "Hello from claude",
+    "session_id": "sess-abc123",
+    "total_cost_usd": 0.0123,
+    "usage": {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_read_input_tokens": 10,
+        "cache_creation_input_tokens": 5,
+    },
+}
+CLAUDE_JSON = json.dumps(CLAUDE_RESULT).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(**agent_cli_overrides: object) -> AgentCliAdapter:
+    """Build an AgentCliAdapter with a claude sub-config + overrides."""
+    acfg: dict[str, object] = {"agent": "claude"}
+    acfg.update(agent_cli_overrides)
+    provider = ProviderConfig(
+        name="agent-claude",
+        kind="agent_cli",
+        model="opus",
+        paid=True,
+        capabilities=Capabilities(streaming=False),
+        agent_cli=AgentCliConfig(**acfg),  # type: ignore[arg-type]
+    )
+    return AgentCliAdapter(provider)
+
+
+def _request() -> ChatRequest:
+    return ChatRequest(messages=[Message(role="user", content="hi there")])
+
+
+class _FakeProc:
+    """Minimal stand-in for an asyncio subprocess (mirrors test_launcher_mtp)."""
+
+    def __init__(
+        self,
+        *,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        returncode: int = 0,
+        hang: bool = False,
+    ) -> None:
+        # A pid that cannot exist, so the timeout kill path's os.getpgid()
+        # raises ProcessLookupError instead of signalling a real process.
+        self.pid = 2_147_483_647
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self._hang = hang
+        self.killed = False
+        self.stdin_received: bytes | None = None
+
+    async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
+        self.stdin_received = input
+        if self._hang:
+            await asyncio.sleep(3600)
+        return self._stdout, self._stderr
+
+    async def wait(self) -> int:
+        return self.returncode
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+def _patch_exec(monkeypatch: pytest.MonkeyPatch, proc: _FakeProc) -> list[list[str]]:
+    """Patch asyncio.create_subprocess_exec to return ``proc``; capture argv."""
+    captured: list[list[str]] = []
+
+    async def fake_exec(*argv: str, **kwargs: object) -> _FakeProc:
+        captured.append(list(argv))
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# T1 — argv construction
+# ---------------------------------------------------------------------------
+
+
+def test_argv_read_only_default() -> None:
+    adapter = _make_adapter(workdir="/tmp/wd")
+    argv = adapter._build_claude_argv("/tmp/wd")
+    assert argv == [
+        "claude",
+        "-p",
+        "--output-format",
+        "json",
+        "--model",
+        "opus",
+        "--max-turns",
+        "8",
+        "--permission-mode",
+        "plan",
+        "--add-dir",
+        "/tmp/wd",
+    ]
+
+
+def test_argv_model_override_and_max_turns() -> None:
+    adapter = _make_adapter(model="sonnet", max_turns=3)
+    argv = adapter._build_claude_argv("/w")
+    assert argv[argv.index("--model") + 1] == "sonnet"
+    assert argv[argv.index("--max-turns") + 1] == "3"
+
+
+def test_argv_omits_max_turns_when_none() -> None:
+    adapter = _make_adapter(max_turns=None)
+    argv = adapter._build_claude_argv("/w")
+    assert "--max-turns" not in argv
+
+
+def test_argv_permission_mode_edit_maps_accept_edits() -> None:
+    adapter = _make_adapter(sandbox_mode="edit", allow_file_writes=True)
+    argv = adapter._build_claude_argv("/w")
+    assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
+
+
+def test_argv_permission_mode_full_auto_maps_accept_edits() -> None:
+    adapter = _make_adapter(sandbox_mode="full_auto", allow_file_writes=True)
+    argv = adapter._build_claude_argv("/w")
+    assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
+
+
+def test_argv_read_only_clamp_when_writes_disabled() -> None:
+    # sandbox_mode=edit but allow_file_writes=False → clamp to read-only (plan).
+    adapter = _make_adapter(sandbox_mode="edit", allow_file_writes=False)
+    argv = adapter._build_claude_argv("/w")
+    assert argv[argv.index("--permission-mode") + 1] == "plan"
+
+
+def test_argv_never_includes_bare_flag() -> None:
+    adapter = _make_adapter()
+    assert "--bare" not in adapter._build_claude_argv("/w")
+
+
+# ---------------------------------------------------------------------------
+# T7 — child-env isolation
+# ---------------------------------------------------------------------------
+
+
+def test_env_excludes_anthropic_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-not-leak")
+    adapter = _make_adapter()
+    env = adapter._build_child_env()
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_env_has_no_color_and_dumb_term() -> None:
+    adapter = _make_adapter()
+    env = adapter._build_child_env()
+    assert env["NO_COLOR"] == "1"
+    assert env["TERM"] == "dumb"
+
+
+def test_env_passthrough_allowlist_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "tok-123")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-nope")
+    adapter = _make_adapter(passthrough_env=["CLAUDE_CODE_OAUTH_TOKEN"])
+    env = adapter._build_child_env()
+    assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "tok-123"
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_env_depth_incremented(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CODEROUTER_AGENT_DEPTH", "1")
+    adapter = _make_adapter()
+    env = adapter._build_child_env()
+    assert env["CODEROUTER_AGENT_DEPTH"] == "2"
+
+
+def test_env_depth_defaults_to_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CODEROUTER_AGENT_DEPTH", raising=False)
+    adapter = _make_adapter()
+    env = adapter._build_child_env()
+    assert env["CODEROUTER_AGENT_DEPTH"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# T2 — claude JSON parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_success() -> None:
+    adapter = _make_adapter()
+    text, usage, meta = adapter._parse_claude(CLAUDE_JSON, b"")
+    assert text == "Hello from claude"
+    # 100 input + 10 cache_read + 5 cache_creation = 115 prompt tokens.
+    assert usage["prompt_tokens"] == 115
+    assert usage["completion_tokens"] == 50
+    assert usage["total_tokens"] == 165
+    assert usage["prompt_tokens_details"]["cached_tokens"] == 10
+    assert usage["num_turns"] == 3
+    assert meta["coderouter_cost_usd"] == pytest.approx(0.0123)
+    assert meta["coderouter_session_id"] == "sess-abc123"
+
+
+def test_parse_is_error_raises_retryable() -> None:
+    adapter = _make_adapter()
+    payload = json.dumps({"is_error": True, "result": "boom"}).encode()
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_claude(payload, b"")
+    assert info.value.retryable is True
+
+
+def test_parse_malformed_json_raises_retryable() -> None:
+    adapter = _make_adapter()
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_claude(b"not json at all {", b"")
+    assert info.value.retryable is True
+
+
+def test_parse_missing_result_raises_retryable() -> None:
+    adapter = _make_adapter()
+    payload = json.dumps({"is_error": False, "usage": {}}).encode()
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_claude(payload, b"")
+    assert info.value.retryable is True
+
+
+def test_parse_empty_stdout_raises_retryable() -> None:
+    adapter = _make_adapter()
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_claude(b"   ", b"")
+    assert info.value.retryable is True
+
+
+# ---------------------------------------------------------------------------
+# T3 — generate() with a stubbed subprocess
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    proc = _FakeProc(stdout=CLAUDE_JSON, returncode=0)
+    captured = _patch_exec(monkeypatch, proc)
+    adapter = _make_adapter(workdir=str(tmp_path))
+
+    resp = await adapter.generate(_request())
+
+    assert resp.choices[0]["message"]["content"] == "Hello from claude"
+    assert resp.coderouter_provider == "agent-claude"
+    assert resp.model == "opus"
+    # Cost propagated as response metadata.
+    assert resp.coderouter_cost_usd == pytest.approx(0.0123)
+    # Prompt was fed on stdin, not argv.
+    assert proc.stdin_received is not None
+    assert b"hi there" in proc.stdin_received
+    assert all("hi there" not in arg for arg in captured[0])
+
+
+async def test_generate_nonzero_exit_is_retryable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    proc = _FakeProc(stdout=b"", stderr=b"auth failed", returncode=1)
+    _patch_exec(monkeypatch, proc)
+    adapter = _make_adapter(workdir=str(tmp_path))
+    with pytest.raises(AdapterError) as info:
+        await adapter.generate(_request())
+    assert info.value.retryable is True
+
+
+# ---------------------------------------------------------------------------
+# T6 — timeout → process-group kill
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_timeout_kills_and_raises_retryable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    proc = _FakeProc(hang=True)
+    _patch_exec(monkeypatch, proc)
+    adapter = _make_adapter(workdir=str(tmp_path), exec_timeout_s=1.0)
+
+    # Force an immediate timeout regardless of wall-clock so the test is fast.
+    async def instant_timeout(coro: object, timeout: float) -> None:
+        # Close the coroutine we were handed, then raise as if it timed out.
+        if hasattr(coro, "close"):
+            coro.close()  # type: ignore[attr-defined]
+        raise TimeoutError
+
+    monkeypatch.setattr(asyncio, "wait_for", instant_timeout)
+
+    with pytest.raises(AdapterError) as info:
+        await adapter.generate(_request())
+    assert info.value.retryable is True
+    assert "timed out" in str(info.value)
+    # The fake pid can't be group-killed, so the fallback direct kill fired.
+    assert proc.killed is True
+
+
+# ---------------------------------------------------------------------------
+# T8 — recursion depth limit
+# ---------------------------------------------------------------------------
+
+
+async def test_generate_depth_limit_non_retryable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    # Default agent_depth_limit is 2; set current depth at the limit.
+    monkeypatch.setenv("CODEROUTER_AGENT_DEPTH", "2")
+    called = _patch_exec(monkeypatch, _FakeProc(stdout=CLAUDE_JSON))
+    adapter = _make_adapter(workdir=str(tmp_path))
+    with pytest.raises(AdapterError) as info:
+        await adapter.generate(_request())
+    assert info.value.retryable is False
+    # Guard fired before any subprocess was launched.
+    assert called == []
+
+
+# ---------------------------------------------------------------------------
+# healthcheck + unsupported-agent + retryable semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_healthcheck_missing_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("coderouter.adapters.agent_cli.shutil.which", lambda _c: None)
+    adapter = _make_adapter()
+    assert await adapter.healthcheck() is False
+
+
+async def test_healthcheck_present_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "coderouter.adapters.agent_cli.shutil.which", lambda _c: "/usr/bin/claude"
+    )
+    adapter = _make_adapter()
+    assert await adapter.healthcheck() is True
+
+
+def test_unsupported_agent_raises_non_retryable() -> None:
+    provider = ProviderConfig(
+        name="agent-codex",
+        kind="agent_cli",
+        model="gpt-5.5",
+        paid=True,
+        agent_cli=AgentCliConfig(agent="codex"),
+    )
+    with pytest.raises(AdapterError) as info:
+        AgentCliAdapter(provider)
+    assert info.value.retryable is False
+    assert "Phase 1a" in str(info.value)
+
+
+# ---------------------------------------------------------------------------
+# config schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_schema_agent_cli_required_for_kind() -> None:
+    with pytest.raises(ValidationError, match="agent_cli sub-config is required"):
+        ProviderConfig(name="x", kind="agent_cli", model="opus")
+
+
+def test_schema_base_url_optional_for_agent_cli() -> None:
+    p = ProviderConfig(
+        name="x",
+        kind="agent_cli",
+        model="opus",
+        agent_cli=AgentCliConfig(agent="claude"),
+    )
+    assert p.base_url is None
+
+
+def test_schema_base_url_required_for_openai_compat() -> None:
+    with pytest.raises(ValidationError, match="base_url is required"):
+        ProviderConfig(name="x", kind="openai_compat", model="m")
+
+
+def test_schema_command_defaults_to_agent() -> None:
+    cfg = AgentCliConfig(agent="claude")
+    assert cfg.command == "claude"
+
+
+def test_schema_write_conflict_rejected() -> None:
+    with pytest.raises(ValidationError, match="conflicts with"):
+        AgentCliConfig(agent="claude", allow_file_writes=True, sandbox_mode="read_only")
+
+
+# ---------------------------------------------------------------------------
+# T4 — TestClient E2E through /v1/chat/completions
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def e2e_config(tmp_path: object) -> CodeRouterConfig:
+    return CodeRouterConfig(
+        allow_paid=True,
+        default_profile="claude-agent",
+        providers=[
+            ProviderConfig(
+                name="agent-claude",
+                kind="agent_cli",
+                model="opus",
+                paid=True,
+                capabilities=Capabilities(streaming=False),
+                agent_cli=AgentCliConfig(agent="claude", workdir=str(tmp_path)),
+            ),
+        ],
+        profiles=[FallbackChain(name="claude-agent", providers=["agent-claude"])],
+    )
+
+
+@pytest.fixture
+def e2e_client(
+    e2e_config: CodeRouterConfig, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[TestClient]:
+    proc = _FakeProc(stdout=CLAUDE_JSON, returncode=0)
+
+    async def fake_exec(*argv: str, **kwargs: object) -> _FakeProc:
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(
+        "coderouter.ingress.app.load_config", lambda path=None: e2e_config
+    )
+    uninstall_collector()
+    app = create_app()
+    try:
+        with TestClient(app) as tc:
+            yield tc
+    finally:
+        uninstall_collector()
+
+
+def test_e2e_chat_completions(e2e_client: TestClient) -> None:
+    resp = e2e_client.post(
+        "/v1/chat/completions",
+        json={"model": "opus", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"X-CodeRouter-Profile": "claude-agent"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["choices"][0]["message"]["content"] == "Hello from claude"
+    assert body["coderouter_provider"] == "agent-claude"
+    # Cost from claude's total_cost_usd propagated to the client-visible body.
+    assert body["coderouter_cost_usd"] == pytest.approx(0.0123)


### PR DESCRIPTION
docs/designs/external-agents-adapter.md の Phase 1a 実装。kind="agent_cli" で Claude Code CLI を one-shot の外部エージェント provider として統合（サブスクOAuth優先・env allowlist・再帰ガード・read_only既定）。codex/gemini/grok は Phase 1b-1d。テスト30件追加、フルスイート1645件通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169bqKt3eAhtwEe3vd8BP8e