### PR TITLE
fix(ingress): fail fast with real HTTP status when a stream dies before the first event

### DIFF
--- a/coderouter/ingress/anthropic_routes.py
+++ b/coderouter/ingress/anthropic_routes.py
@@ -65,6 +65,88 @@ _STREAM_TIMEOUT_MULTIPLIER = 20.0
 _STREAM_TIMEOUT_DEFAULT_S = 900.0
 _STREAM_TIMEOUT_MIN_S = 60.0
 
+# v2.x: peek-timeout for the first streamed event. See
+# ``_resolve_first_event_timeout_s`` — this is the per-call provider timeout
+# flavor (no stream multiplier), used only to bound the pre-stream peek that
+# maps a total failover failure to a real HTTP status.
+_FIRST_EVENT_TIMEOUT_DEFAULT_S = 60.0
+_FIRST_EVENT_TIMEOUT_MIN_S = 10.0
+
+# v2.x: sentinels for the peek/continuation handshake in
+# ``_anthropic_sse_iterator``. ``_UNSET`` means "no peeked event was supplied,
+# create + iterate the source yourself" (the legacy call convention still used
+# by unit tests). ``_EMPTY_STREAM`` means "the peek observed an immediately
+# exhausted stream" — legal, emit nothing extra and let the (empty) source run
+# to completion.
+_UNSET: Any = object()
+_EMPTY_STREAM: Any = object()
+
+
+async def _aclose_quiet(source: Any) -> None:
+    """v2.x: best-effort close an async generator, swallowing any error.
+
+    Used to finalize the engine ``stream_anthropic`` generator when the
+    pre-stream peek fails and we raise an :class:`HTTPException` instead of
+    committing a streaming response. Closing runs the generator's ``finally``
+    blocks so the adapter's ``httpx`` streaming context releases the upstream
+    connection rather than leaking it until GC.
+    """
+    aclose = getattr(source, "aclose", None)
+    if aclose is not None:
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await aclose()
+
+
+async def _anext_or_empty(source: AsyncIterator[Any]) -> Any:
+    """v2.x: pull the first event, mapping an empty stream to ``_EMPTY_STREAM``.
+
+    Wrapping ``__anext__`` so ``StopAsyncIteration`` never has to cross the
+    :func:`asyncio.wait_for` task boundary (where it would be awkward to
+    catch) — an immediately exhausted stream returns the ``_EMPTY_STREAM``
+    sentinel. Any other exception (``NoProvidersAvailableError``,
+    ``ToolLoopBreakError``, ...) propagates unchanged for the caller to map.
+    """
+    try:
+        return await source.__anext__()
+    except StopAsyncIteration:
+        return _EMPTY_STREAM
+
+
+def _resolve_first_event_timeout_s(
+    engine: FallbackEngine, profile: str | None
+) -> float:
+    """v2.x: derive the pre-stream peek timeout (seconds) for a profile.
+
+    Mirrors :func:`_resolve_stream_timeout_s`'s config access but WITHOUT the
+    stream multiplier — this bounds only the wait for the *first* streamed
+    event (which the engine emits after any failover completes), not the whole
+    generation. Uses the profile's per-call ``timeout_s`` (or the first
+    provider's, or the default), floored at ``_FIRST_EVENT_TIMEOUT_MIN_S`` so a
+    tiny configured timeout can't spuriously 504 a chain that briefly fails
+    over before the first token. Any resolution failure falls back to
+    ``_FIRST_EVENT_TIMEOUT_DEFAULT_S``. Does NOT change the config schema.
+    """
+    per_call: float | None = None
+    try:
+        config = engine.config
+        chosen = profile or config.default_profile
+        chain_cfg = config.profile_by_name(chosen)
+        per_call = getattr(chain_cfg, "timeout_s", None)
+        if per_call is None:
+            for pname in getattr(chain_cfg, "providers", []) or []:
+                pconf = next(
+                    (p for p in config.providers if p.name == pname), None
+                )
+                if pconf is not None:
+                    per_call = getattr(pconf, "timeout_s", None)
+                    break
+    except (AttributeError, KeyError, ValueError):
+        per_call = None
+
+    if per_call is None:
+        return _FIRST_EVENT_TIMEOUT_DEFAULT_S
+    return max(_FIRST_EVENT_TIMEOUT_MIN_S, float(per_call))
+
 
 def _resolve_stream_timeout_s(engine: FallbackEngine, profile: str | None) -> float:
     """M14: derive the overall stream ceiling (seconds) for a profile.
@@ -258,12 +340,66 @@ async def messages(
         drift_severity = engine.last_drift_severity
         if drift_severity:
             stream_headers[_DRIFT_HEADER] = drift_severity
+        # v2.x: fail-fast peek. The engine performs its whole failover BEFORE
+        # emitting the first stream event (total failure / tool-loop-break /
+        # tool-count guards all raise pre-yield). By pulling that first event
+        # here — before the StreamingResponse commits HTTP 200 + SSE headers —
+        # a total pre-stream failure surfaces as a real HTTP status (502 / 400
+        # / 504) instead of a 200 carrying an in-band ``event: error`` frame.
+        # Once the first event is in hand, headers can ship safely: anything
+        # that goes wrong afterwards is a genuine mid-stream error handled by
+        # ``_anthropic_sse_iterator`` (MidStreamError / partial stitch).
+        source = engine.stream_anthropic(anth_req)
+        peek_timeout_s = _resolve_first_event_timeout_s(engine, anth_req.profile)
+        try:
+            first_ev = await asyncio.wait_for(
+                _anext_or_empty(source), timeout=peek_timeout_s
+            )
+        except NoProvidersAvailableError as exc:
+            await _aclose_quiet(source)
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+        except ToolLoopBreakError as exc:
+            await _aclose_quiet(source)
+            # Same structured 400 as the non-streaming path — the guard fires
+            # before any byte ships, so we can still use a real status code.
+            raise HTTPException(
+                status_code=400,
+                detail=_tool_loop_break_detail(exc),
+            ) from exc
+        except ToolCountExceededError as exc:
+            await _aclose_quiet(source)
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "tool_count_exceeded",
+                    "message": str(exc),
+                    "total_count": exc.exceeded.total_count,
+                    "max_allowed": exc.exceeded.max_allowed,
+                    "profile": exc.profile,
+                },
+            ) from exc
+        except TimeoutError as exc:
+            # No provider produced a first event within the peek budget.
+            # (asyncio.wait_for raises asyncio.TimeoutError, which is an alias
+            # of the builtin TimeoutError on 3.11+.)
+            await _aclose_quiet(source)
+            raise HTTPException(
+                status_code=504,
+                detail=(
+                    f"no stream event within {peek_timeout_s:.0f}s "
+                    "(all providers timed out before the first token)"
+                ),
+            ) from exc
+
         # M14: wrap the SSE iterator with an overall timeout + client
         # disconnect cleanup so a wedged upstream cannot pin the client
-        # (or the upstream socket) open forever.
+        # (or the upstream socket) open forever. The peeked first event is
+        # replayed by the iterator before it delegates to the live source.
         timeout_s = _resolve_stream_timeout_s(engine, anth_req.profile)
         guarded = _guard_stream(
-            _anthropic_sse_iterator(engine, anth_req),
+            _anthropic_sse_iterator(
+                engine, anth_req, source=source, first_ev=first_ev
+            ),
             timeout_s=timeout_s,
             label="anthropic",
         )
@@ -425,7 +561,11 @@ async def count_tokens_route(
 
 
 async def _anthropic_sse_iterator(
-    engine: FallbackEngine, anth_req: AnthropicRequest
+    engine: FallbackEngine,
+    anth_req: AnthropicRequest,
+    *,
+    source: AsyncIterator[AnthropicStreamEvent] | None = None,
+    first_ev: Any = _UNSET,
 ) -> AsyncIterator[str]:
     """Serialize engine.stream_anthropic() onto the Anthropic SSE wire.
 
@@ -433,9 +573,25 @@ async def _anthropic_sse_iterator(
     Anthropic spec (distinct from OpenAI's `data:`-only format).
     Errors map to in-stream `event: error` events — we never switch an
     in-flight HTTP response to a 5xx once headers have shipped.
+
+    v2.x: when ``source`` / ``first_ev`` are supplied by the fail-fast peek
+    in :func:`messages`, this iterator replays the already-pulled first event
+    then continues the *same* live generator. In that mode the pre-yield
+    exception branches below (``NoProvidersAvailableError`` /
+    ``ToolLoopBreakError`` / ``ToolCountExceededError``) are effectively dead
+    code — those all raise before the first event, which the peek already
+    consumed and mapped to a real HTTP status. They are retained as defensive
+    fallbacks (and for the legacy no-peek call convention used by unit tests,
+    where ``source is None`` and this iterator drives the generator itself).
+    ``MidStreamError`` handling below is the live path for a stream that fails
+    *after* the first event.
     """
+    if source is None:
+        source = engine.stream_anthropic(anth_req)
     try:
-        async for ev in engine.stream_anthropic(anth_req):
+        if first_ev is not _UNSET and first_ev is not _EMPTY_STREAM:
+            yield _format_anthropic_sse(first_ev)
+        async for ev in source:
             yield _format_anthropic_sse(ev)
     except NoProvidersAvailableError as exc:
         # No provider produced even the first event — surface as overloaded.

--- a/coderouter/ingress/openai_routes.py
+++ b/coderouter/ingress/openai_routes.py
@@ -47,6 +47,78 @@ _STREAM_TIMEOUT_MULTIPLIER = 20.0
 _STREAM_TIMEOUT_DEFAULT_S = 900.0
 _STREAM_TIMEOUT_MIN_S = 60.0
 
+# v2.x: peek-timeout for the first streamed chunk — see anthropic_routes for
+# rationale. Per-call provider timeout flavor (no stream multiplier).
+_FIRST_EVENT_TIMEOUT_DEFAULT_S = 60.0
+_FIRST_EVENT_TIMEOUT_MIN_S = 10.0
+
+# v2.x: peek/continuation handshake sentinels for ``_sse_iterator``. ``_UNSET``
+# means "no peeked chunk supplied, create + drive the source yourself" (legacy
+# call convention used by unit tests); ``_EMPTY_STREAM`` means "the peek saw an
+# immediately exhausted stream" (legal — just emit the terminal ``[DONE]``).
+_UNSET: Any = object()
+_EMPTY_STREAM: Any = object()
+
+
+async def _aclose_quiet(source: Any) -> None:
+    """v2.x: best-effort close an async generator, swallowing any error.
+
+    Finalizes the engine ``stream`` generator when the pre-stream peek fails
+    and we raise an :class:`HTTPException` instead of committing a streaming
+    response, so the adapter's ``httpx`` streaming context releases the
+    upstream connection.
+    """
+    aclose = getattr(source, "aclose", None)
+    if aclose is not None:
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await aclose()
+
+
+async def _anext_or_empty(source: AsyncIterator[Any]) -> Any:
+    """v2.x: pull the first chunk, mapping an empty stream to ``_EMPTY_STREAM``.
+
+    Keeps ``StopAsyncIteration`` from crossing the :func:`asyncio.wait_for`
+    task boundary. Any other exception (``NoProvidersAvailableError``, ...)
+    propagates unchanged for the caller to map to an HTTP status.
+    """
+    try:
+        return await source.__anext__()
+    except StopAsyncIteration:
+        return _EMPTY_STREAM
+
+
+def _resolve_first_event_timeout_s(
+    engine: FallbackEngine, profile: str | None
+) -> float:
+    """v2.x: derive the pre-stream peek timeout (seconds) for a profile.
+
+    Mirrors :func:`_resolve_stream_timeout_s`'s config access but WITHOUT the
+    stream multiplier — bounds only the wait for the first streamed chunk (the
+    engine emits it after any failover completes). Floored at
+    ``_FIRST_EVENT_TIMEOUT_MIN_S``; any resolution failure falls back to
+    ``_FIRST_EVENT_TIMEOUT_DEFAULT_S``. Does not change the config schema.
+    """
+    per_call: float | None = None
+    try:
+        config = engine.config
+        chosen = profile or config.default_profile
+        chain_cfg = config.profile_by_name(chosen)
+        per_call = getattr(chain_cfg, "timeout_s", None)
+        if per_call is None:
+            for pname in getattr(chain_cfg, "providers", []) or []:
+                pconf = next(
+                    (p for p in config.providers if p.name == pname), None
+                )
+                if pconf is not None:
+                    per_call = getattr(pconf, "timeout_s", None)
+                    break
+    except (AttributeError, KeyError, ValueError):
+        per_call = None
+
+    if per_call is None:
+        return _FIRST_EVENT_TIMEOUT_DEFAULT_S
+    return max(_FIRST_EVENT_TIMEOUT_MIN_S, float(per_call))
+
 
 def _resolve_stream_timeout_s(engine: FallbackEngine, profile: str | None) -> float:
     """M14: derive the overall stream ceiling (seconds) for a profile.
@@ -239,10 +311,44 @@ async def chat_completions(
             ) from exc
 
     if chat_req.stream:
-        # M14: overall stream timeout + client-disconnect cleanup.
+        # v2.x: fail-fast peek. The engine finishes its failover before the
+        # first stream chunk, so a total pre-stream failure raises
+        # NoProvidersAvailableError here — before the StreamingResponse commits
+        # HTTP 200 — and can surface as a real 502 instead of a 200 carrying an
+        # in-band error frame. (No tool-loop / tool-count guards on this path.)
+        source = engine.stream(chat_req)
+        peek_timeout_s = _resolve_first_event_timeout_s(engine, chat_req.profile)
+        try:
+            first_chunk = await asyncio.wait_for(
+                _anext_or_empty(source), timeout=peek_timeout_s
+            )
+        except NoProvidersAvailableError as exc:
+            await _aclose_quiet(source)
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+        except TimeoutError as exc:
+            # asyncio.wait_for raises asyncio.TimeoutError (== builtin
+            # TimeoutError on 3.11+) when the peek budget elapses.
+            await _aclose_quiet(source)
+            raise HTTPException(
+                status_code=504,
+                detail=(
+                    f"no stream chunk within {peek_timeout_s:.0f}s "
+                    "(all providers timed out before the first token)"
+                ),
+            ) from exc
+
+        # M14: overall stream timeout + client-disconnect cleanup. The peeked
+        # first chunk is replayed by the iterator before it delegates to the
+        # live source.
         timeout_s = _resolve_stream_timeout_s(engine, chat_req.profile)
         return StreamingResponse(
-            _sse_iterator(engine, chat_req, timeout_s=timeout_s),
+            _sse_iterator(
+                engine,
+                chat_req,
+                source=source,
+                first_chunk=first_chunk,
+                timeout_s=timeout_s,
+            ),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
@@ -259,6 +365,8 @@ async def _sse_iterator(
     engine: FallbackEngine,
     chat_req: ChatRequest,
     *,
+    source: AsyncIterator[Any] | None = None,
+    first_chunk: Any = _UNSET,
     timeout_s: float = _STREAM_TIMEOUT_DEFAULT_S,
 ) -> AsyncIterator[str]:
     """Wrap the engine's stream into SSE wire format.
@@ -267,10 +375,22 @@ async def _sse_iterator(
     upstream engine generator is finalized on client disconnect
     (``CancelledError``) or timeout, so the upstream connection is
     released instead of leaking.
+
+    v2.x: when ``source`` / ``first_chunk`` are supplied by the fail-fast peek
+    in :func:`chat_completions`, this iterator replays the already-pulled first
+    chunk then continues the *same* live generator. In that mode the
+    ``NoProvidersAvailableError`` branch below is defensive dead code (a total
+    failure raises during the peek, which maps it to a real 502). It is
+    retained for the legacy no-peek call convention (``source is None``) used
+    by unit tests, where this iterator drives the generator itself.
     """
-    source = engine.stream(chat_req)
+    if source is None:
+        source = engine.stream(chat_req)
     try:
         async with asyncio.timeout(timeout_s):
+            if first_chunk is not _UNSET and first_chunk is not _EMPTY_STREAM:
+                data = first_chunk.model_dump(exclude_none=True)
+                yield f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
             async for chunk in source:
                 data = chunk.model_dump(exclude_none=True)
                 yield f"data: {json.dumps(data, ensure_ascii=False)}\n\n"

--- a/tests/test_ingress_anthropic.py
+++ b/tests/test_ingress_anthropic.py
@@ -294,6 +294,55 @@ class _LoopBreakingEngine:
         yield  # pragma: no cover  # generator protocol
 
 
+class _HangingStreamEngine:
+    """Engine whose stream never yields a first event (sleeps forever).
+
+    Exercises the v2.x pre-stream peek timeout: the ingress must give up
+    after the resolved first-event budget and return HTTP 504 rather than
+    committing a streaming response that would hang the client.
+    """
+
+    def __init__(self) -> None:
+        self.last_drift_severity: str | None = None
+        self.closed = False
+
+    def apply_context_budget(
+        self, request: AnthropicRequest
+    ) -> tuple[AnthropicRequest, str | None]:
+        return request, None
+
+    async def stream_anthropic(
+        self, request: AnthropicRequest
+    ) -> AsyncIterator[AnthropicStreamEvent]:
+        try:
+            import asyncio
+
+            await asyncio.sleep(3600)
+        finally:
+            self.closed = True
+        yield  # pragma: no cover  # generator protocol
+
+
+@pytest.fixture
+def client_and_hanging_engine(
+    two_profile_config: CodeRouterConfig, monkeypatch: pytest.MonkeyPatch
+) -> tuple[TestClient, _HangingStreamEngine]:
+    monkeypatch.setattr(
+        "coderouter.ingress.app.load_config",
+        lambda path=None: two_profile_config,
+    )
+    # Force a tiny peek budget so the test doesn't actually wait 60s.
+    monkeypatch.setattr(
+        "coderouter.ingress.anthropic_routes._resolve_first_event_timeout_s",
+        lambda engine, profile: 0.05,
+    )
+    app = create_app()
+    engine = _HangingStreamEngine()
+    app.state.engine = engine
+    app.state.config = two_profile_config
+    return TestClient(app), engine
+
+
 @pytest.fixture
 def client_and_engine(
     two_profile_config: CodeRouterConfig, monkeypatch: pytest.MonkeyPatch
@@ -724,28 +773,35 @@ def test_streaming_emits_anthropic_event_sequence(
     assert engine.seen_profiles == [None]
 
 
-def test_streaming_error_emits_error_event(
+def test_streaming_total_failure_returns_502(
     client_and_failing_engine: tuple[TestClient, _FailingEngine],
 ) -> None:
-    """When the engine raises NoProvidersAvailableError before any event
-    ships, the SSE channel should emit a single `error` event (not a 5xx
-    HTTP status, since headers have already flushed).
+    """v2.x fail-fast: when the engine raises NoProvidersAvailableError
+    before any event ships, the ingress peeks the first event *before*
+    committing the streaming response, so a total pre-stream failure now
+    surfaces as a real HTTP 502 (same as the non-streaming path) instead
+    of a 200 carrying an in-band ``event: error`` frame.
     """
     client, _ = client_and_failing_engine
     body = {**_MINIMAL_BODY, "stream": True}
-    with client.stream("POST", "/v1/messages", json=body) as resp:
-        assert resp.status_code == 200
-        raw = b"".join(resp.iter_bytes()).decode("utf-8")
+    resp = client.post("/v1/messages", json=body)
+    assert resp.status_code == 502, resp.text
+    # NoProvidersAvailableError message embeds the profile name.
+    assert "all providers failed" in resp.text
 
-    events = _parse_sse(raw)
-    assert any(t == "error" for t, _ in events), raw
 
-    import json as _json
-
-    err = next(d for t, d in events if t == "error")
-    err_payload = _json.loads(err)
-    assert err_payload["type"] == "error"
-    assert err_payload["error"]["type"] == "overloaded_error"
+def test_streaming_peek_timeout_returns_504(
+    client_and_hanging_engine: tuple[TestClient, _HangingStreamEngine],
+) -> None:
+    """v2.x fail-fast: if no provider emits a first event within the peek
+    budget, the ingress returns HTTP 504 (and closes the engine generator)
+    rather than committing a streaming response that hangs the client.
+    """
+    client, _engine = client_and_hanging_engine
+    body = {**_MINIMAL_BODY, "stream": True}
+    resp = client.post("/v1/messages", json=body)
+    assert resp.status_code == 504, resp.text
+    assert "before the first token" in resp.text
 
 
 # ----------------------------------------------------------------------
@@ -832,47 +888,34 @@ def test_break_action_non_streaming_returns_400_with_structured_detail(
     assert "args_canonical" not in detail
 
 
-def test_break_action_streaming_emits_invalid_request_error_event(
+def test_break_action_streaming_returns_400_with_structured_detail(
     client_and_loop_breaking_engine: tuple[TestClient, _LoopBreakingEngine],
 ) -> None:
-    """Streaming counterpart: ``break`` must emit a single SSE error event.
+    """v2.x fail-fast: streaming ``break`` now returns a real HTTP 400.
 
-    The HTTP status stays 200 because StreamingResponse has already
-    committed headers by the time the iterator runs (same constraint
-    as MidStreamError). The Anthropic-shaped envelope uses
-    ``error.type == "invalid_request_error"`` so existing SDKs render
-    a sensible message; the structured detection fields live under a
-    ``tool_loop`` extension key for CodeRouter-aware clients.
+    The tool-loop ``break`` guard fires before the first stream event, so
+    the ingress peek catches ``ToolLoopBreakError`` *before* the
+    StreamingResponse commits HTTP 200. The response is therefore an
+    ordinary 400 with the same structured ``detail`` dict as the
+    non-streaming path — no in-band SSE error frame, no committed 200.
     """
     client, _ = client_and_loop_breaking_engine
     body = {**_MINIMAL_BODY, "stream": True}
-    with client.stream("POST", "/v1/messages", json=body) as resp:
-        assert resp.status_code == 200
-        raw = b"".join(resp.iter_bytes()).decode("utf-8")
+    resp = client.post("/v1/messages", json=body)
+    assert resp.status_code == 400, resp.text
 
-    events = _parse_sse(raw)
-    event_types = [t for t, _ in events]
-    # The guard fires before any provider event ships, so the only
-    # event in the stream is the error event itself.
-    assert event_types == ["error"], raw
-
-    import json as _json
-
-    err_data = _json.loads(events[0][1])
-    assert err_data["type"] == "error"
-    err = err_data["error"]
-    # Anthropic-standard envelope for SDK compatibility.
-    assert err["type"] == "invalid_request_error"
-    assert "tool loop detected" in err["message"]
-    # Structured detection fields under the extension key.
-    tl = err["tool_loop"]
-    assert tl["profile"] == "default"
-    assert tl["tool_name"] == "Read"
-    assert tl["repeat_count"] == 3
-    assert tl["threshold"] == 3
-    assert tl["window"] == 5
-    # Same hygiene as the non-streaming path: no args_canonical leakage.
-    assert "args_canonical" not in tl
+    detail = resp.json()["detail"]
+    assert isinstance(detail, dict), detail
+    # Discriminator clients branch on — identical to the non-streaming 400.
+    assert detail["error"] == "tool_loop_detected"
+    assert detail["profile"] == "default"
+    assert detail["tool_name"] == "Read"
+    assert detail["repeat_count"] == 3
+    assert detail["threshold"] == 3
+    assert detail["window"] == 5
+    assert "tool loop detected" in detail["message"]
+    # ``args_canonical`` must NOT leak into the response.
+    assert "args_canonical" not in detail
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_ingress_profile.py
+++ b/tests/test_ingress_profile.py
@@ -327,3 +327,59 @@ def test_mode_header_alone_reaches_engine_as_aliased_profile(
     )
     assert resp.status_code == 200, resp.text
     assert engine.seen_profiles == ["default"]
+
+
+# ----------------------------------------------------------------------
+# v2.x: streaming fail-fast peek — total failure / peek timeout map to a
+# real HTTP status instead of a 200 carrying an in-band error frame.
+# ----------------------------------------------------------------------
+
+
+class _FailingStreamEngine:
+    """Engine whose stream raises NoProvidersAvailableError before any chunk."""
+
+    def __init__(self, profile: str = "default") -> None:
+        self.profile = profile
+
+    async def generate(self, request: ChatRequest) -> ChatResponse:
+        from coderouter.routing import NoProvidersAvailableError
+
+        raise NoProvidersAvailableError(self.profile, [])
+
+    async def stream(self, request: ChatRequest) -> AsyncIterator[StreamChunk]:
+        from coderouter.routing import NoProvidersAvailableError
+
+        raise NoProvidersAvailableError(self.profile, [])
+        yield  # pragma: no cover  # generator protocol
+
+
+@pytest.fixture
+def client_and_failing_stream_engine(
+    two_profile_config: CodeRouterConfig, monkeypatch: pytest.MonkeyPatch
+) -> tuple[TestClient, _FailingStreamEngine]:
+    monkeypatch.setattr(
+        "coderouter.ingress.app.load_config",
+        lambda path=None: two_profile_config,
+    )
+    app = create_app()
+    engine = _FailingStreamEngine()
+    app.state.engine = engine
+    app.state.config = two_profile_config
+    return TestClient(app), engine
+
+
+def test_streaming_total_failure_returns_502(
+    client_and_failing_stream_engine: tuple[TestClient, _FailingStreamEngine],
+) -> None:
+    """v2.x fail-fast: a total pre-stream failure on the OpenAI route peeks
+    the first chunk before committing the streaming response, so it now
+    surfaces as HTTP 502 (same as the non-streaming path) rather than a 200
+    with an in-band ``no_providers_available`` error frame.
+    """
+    client, _ = client_and_failing_stream_engine
+    resp = client.post(
+        "/v1/chat/completions",
+        json={**_MINIMAL_BODY, "stream": True},
+    )
+    assert resp.status_code == 502, resp.text
+    assert "all providers failed" in resp.text


### PR DESCRIPTION
全プロバイダ失敗時のstreamingが200+SSE overloaded_errorを返しClaude Codeのリトライ嵐を誘発していた実地インシデントの修正。最初のイベントをpeekしてからステータス確定: 全滅502 / ガード400 / 初回タイムアウト504。mid-streamフェイルオーバーは無傷。テスト1659件通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169bqKt3eAhtwEe3vd8BP8e