### PR TITLE
feat(guards): circuit-breaker 'skip' action with built-in half-open recovery

### DIFF
--- a/coderouter/config/schemas.py
+++ b/coderouter/config/schemas.py
@@ -627,7 +627,7 @@ class FallbackChain(BaseModel):
     # Distinct from the v1.9-C ``adaptive`` gradient (continuous
     # latency / error-rate buffer with debounce) which handles the
     # "slow but alive" case; L5 handles the "hard crash" case.
-    backend_health_action: Literal["off", "warn", "demote", "exclude"] = Field(
+    backend_health_action: Literal["off", "warn", "demote", "exclude", "skip"] = Field(
         default="warn",
         description=(
             "v1.9-E (L5 phase 2): action when a provider transitions "
@@ -642,9 +642,33 @@ class FallbackChain(BaseModel):
             "self-healing (restart helper if configured, recovery "
             "probe with exponential backoff). On recovery, the "
             "provider is automatically restored to its original "
-            "chain position. ``off`` disables the monitor "
+            "chain position. ``skip`` (v2.x) filters UNHEALTHY providers "
+            "out of the chain like ``exclude`` but with a self-contained "
+            "half-open circuit breaker — no self-healing orchestrator "
+            "required: every ``backend_health_half_open_s`` window one "
+            "trial request is let through, and a single success snaps the "
+            "provider back into rotation. If skipping would empty the "
+            "chain, the unfiltered chain is used as a last resort so a "
+            "uniformly-UNHEALTHY chain still attempts every provider "
+            "rather than 502-ing outright. ``off`` disables the monitor "
             "entirely (zero observation overhead, identical to "
             "v1.9.x behavior)."
+        ),
+    )
+    backend_health_half_open_s: float = Field(
+        default=30.0,
+        ge=5.0,
+        le=600.0,
+        description=(
+            "v2.x: half-open interval (seconds) for the ``skip`` "
+            "backend-health action. While a provider is UNHEALTHY, at most "
+            "one trial request is let through per interval — the built-in "
+            "circuit breaker's half-open probe. A successful trial resets "
+            "the provider to HEALTHY immediately; a failed trial keeps it "
+            "skipped until the next interval elapses. Ignored for every "
+            "other ``backend_health_action``. Default 30 s balances quick "
+            "recovery against hammering a still-down backend; capped at "
+            "600 s (10 min)."
         ),
     )
     backend_health_threshold: int = Field(

--- a/coderouter/guards/backend_health.py
+++ b/coderouter/guards/backend_health.py
@@ -46,6 +46,7 @@ record can't observe a torn state.
 from __future__ import annotations
 
 import threading
+import time
 from dataclasses import dataclass
 from typing import Literal
 
@@ -84,6 +85,15 @@ class HealthTransition:
 class _ProviderHealth:
     state: HealthState = "HEALTHY"
     consecutive_failures: int = 0
+    # v2.x (``skip`` action): monotonic timestamps driving the built-in
+    # half-open trial. ``unhealthy_since`` is stamped when the provider
+    # crosses into UNHEALTHY (diagnostic — "how long has it been down");
+    # ``last_half_open_at`` records the last time :meth:`should_skip` let a
+    # single trial request through. Both are cleared on any success. These
+    # are ``time.monotonic`` values, so they are intentionally NOT persisted
+    # across restarts (see :meth:`save_state`).
+    unhealthy_since: float | None = None
+    last_half_open_at: float | None = None
 
 
 class BackendHealthMonitor:
@@ -140,6 +150,10 @@ class BackendHealthMonitor:
 
             if success:
                 entry.consecutive_failures = 0
+                # v2.x: a single success snaps back to HEALTHY and clears the
+                # half-open bookkeeping so a future crash starts a fresh cycle.
+                entry.unhealthy_since = None
+                entry.last_half_open_at = None
                 if old_state != "HEALTHY":
                     entry.state = "HEALTHY"
                     return HealthTransition(
@@ -168,6 +182,12 @@ class BackendHealthMonitor:
                 return None
 
             entry.state = new_state
+            if new_state == "UNHEALTHY":
+                # v2.x: record the moment we went down (diagnostic). The
+                # half-open trial itself is keyed off ``last_half_open_at``,
+                # which starts unset so the first resolve after this
+                # transition is allowed straight through as a trial.
+                entry.unhealthy_since = time.monotonic()
             return HealthTransition(
                 provider=provider,
                 old_state=old_state,
@@ -200,12 +220,54 @@ class BackendHealthMonitor:
         """True iff ``provider``'s current state is ``UNHEALTHY``."""
         return self.state_for(provider) == "UNHEALTHY"
 
+    def should_skip(self, provider: str, *, half_open_interval_s: float) -> bool:
+        """v2.x: decide whether to skip ``provider`` at chain-resolve time.
+
+        Drives the ``skip`` backend-health action's built-in half-open
+        circuit breaker. Semantics:
+
+        * Not UNHEALTHY → ``False`` (never skip a HEALTHY/DEGRADED provider).
+        * UNHEALTHY, but either never trialed (``last_half_open_at is None``)
+          or the half-open interval has elapsed since the last trial → stamp
+          ``last_half_open_at = now`` and return ``False`` — exactly one
+          request is let through as a probe. If it succeeds,
+          :meth:`record_attempt` snaps the provider back to HEALTHY; if it
+          fails, the counter stays UNHEALTHY and the freshly-stamped trial
+          time keeps the provider skipped until the interval elapses again.
+        * UNHEALTHY and inside the current interval → ``True`` (skip).
+
+        This is a mutating read: the ``last_half_open_at`` stamp is the
+        side effect that makes the half-open trial fire at most once per
+        ``half_open_interval_s`` window. Held under the lock so concurrent
+        resolves can't both slip a trial through the same window.
+        """
+        with self._lock:
+            entry = self._state.get(provider)
+            if entry is None or entry.state != "UNHEALTHY":
+                return False
+            now = time.monotonic()
+            last = entry.last_half_open_at
+            if last is None or (now - last) >= half_open_interval_s:
+                entry.last_half_open_at = now
+                return False
+            return True
+
     # ------------------------------------------------------------------
     # v2.0-K: Persistence
     # ------------------------------------------------------------------
 
     def save_state(self) -> dict[str, object]:
-        """Export the current per-provider health state for persistence."""
+        """Export the current per-provider health state for persistence.
+
+        v2.x: only ``state`` and ``consecutive_failures`` are persisted.
+        ``unhealthy_since`` / ``last_half_open_at`` are ``time.monotonic``
+        values whose zero point is per-process — persisting them across a
+        restart would be meaningless (and could compare against a future
+        process's clock). They are dropped here and default to ``None`` on
+        :meth:`load_state`, which simply means the first resolve after a
+        restart is treated as a fresh half-open trial — safe, since a
+        successful trial resets the provider anyway.
+        """
         with self._lock:
             return {
                 name: {

--- a/coderouter/logging.py
+++ b/coderouter/logging.py
@@ -622,6 +622,66 @@ def log_demote_unhealthy_provider(
 
 
 # ---------------------------------------------------------------------------
+# v2.x: ``skip`` backend-health action log shapes
+# ---------------------------------------------------------------------------
+
+
+class SkipUnhealthyProviderPayload(TypedDict):
+    """Structured shape of the ``skip-unhealthy-provider`` log record."""
+
+    provider: str
+    profile: str
+
+
+class ChainAllUnhealthyLastResortPayload(TypedDict):
+    """Structured shape of the ``chain-all-unhealthy-last-resort`` log record."""
+
+    profile: str
+    providers: list[str]
+
+
+def log_skip_unhealthy_provider(
+    logger: logging.Logger,
+    *,
+    provider: str,
+    profile: str,
+) -> None:
+    """Emit a ``skip-unhealthy-provider`` info line.
+
+    Fires per chain-resolve when the ``skip`` action filters an UNHEALTHY
+    provider out of the chain (and the half-open trial is not currently
+    allowed through). Quiet when a half-open trial lets the provider through
+    — that resolve looks identical to a healthy one.
+    """
+    payload: SkipUnhealthyProviderPayload = {
+        "provider": provider,
+        "profile": profile,
+    }
+    logger.info("skip-unhealthy-provider", extra=payload)
+
+
+def log_chain_all_unhealthy_last_resort(
+    logger: logging.Logger,
+    *,
+    profile: str,
+    providers: list[str],
+) -> None:
+    """Emit a ``chain-all-unhealthy-last-resort`` info line.
+
+    Fires once per chain-resolve when the ``skip`` action would have filtered
+    out every provider — rather than fail the request outright, the engine
+    falls back to the unfiltered chain and attempts everyone. ``providers`` is
+    the last-resort chain (original order) so the operator can see exactly what
+    is being tried despite all members being UNHEALTHY.
+    """
+    payload: ChainAllUnhealthyLastResortPayload = {
+        "profile": profile,
+        "providers": providers,
+    }
+    logger.info("chain-all-unhealthy-last-resort", extra=payload)
+
+
+# ---------------------------------------------------------------------------
 # v2.0-J: self-healing log shapes
 # ---------------------------------------------------------------------------
 

--- a/coderouter/routing/fallback.py
+++ b/coderouter/routing/fallback.py
@@ -72,6 +72,7 @@ from coderouter.logging import (
     get_logger,
     log_backend_health_changed,
     log_cache_observed,
+    log_chain_all_unhealthy_last_resort,
     log_chain_budget_exceeded,
     log_chain_memory_pressure_blocked,
     log_chain_paid_gate_blocked,
@@ -80,6 +81,7 @@ from coderouter.logging import (
     log_memory_pressure_detected,
     log_skip_budget_exceeded,
     log_skip_memory_pressure,
+    log_skip_unhealthy_provider,
     log_tool_loop_detected,
 )
 from coderouter.plugins.registry import PluginRegistry
@@ -2062,6 +2064,41 @@ class FallbackEngine:
             excluded = self.self_healing.excluded_providers()
             if excluded:
                 adapters = [a for a in adapters if a.name not in excluded]
+
+        # Pass 4c: v2.x ``skip`` action — self-contained half-open circuit
+        # breaker. Unlike ``exclude`` (which relies on the self-healing
+        # orchestrator's excluded set + background recovery probes), ``skip``
+        # asks the backend-health monitor directly: an UNHEALTHY provider is
+        # filtered out unless its half-open interval has elapsed, in which
+        # case ``should_skip`` lets exactly one trial request through (a
+        # success snaps it back to HEALTHY). If skipping would empty the
+        # chain, fall back to the unfiltered list as a last resort — a
+        # uniformly-UNHEALTHY chain still attempts everyone rather than
+        # failing with NoProvidersAvailableError before trying anything.
+        if chain.backend_health_action == "skip":
+            kept: list[BaseAdapter] = []
+            for adapter in adapters:
+                if self._backend_health.should_skip(
+                    adapter.name,
+                    half_open_interval_s=chain.backend_health_half_open_s,
+                ):
+                    log_skip_unhealthy_provider(
+                        logger,
+                        provider=adapter.name,
+                        profile=chosen,
+                    )
+                else:
+                    kept.append(adapter)
+            if kept:
+                adapters = kept
+            elif adapters:
+                # Everyone was skipped — last-resort: try the unfiltered
+                # chain rather than 502 without attempting a single provider.
+                log_chain_all_unhealthy_last_resort(
+                    logger,
+                    profile=chosen,
+                    providers=[a.name for a in adapters],
+                )
 
         return adapters
 

--- a/tests/test_backend_health.py
+++ b/tests/test_backend_health.py
@@ -105,6 +105,77 @@ def test_monitor_single_success_resets_to_healthy() -> None:
 
 
 # ----------------------------------------------------------------------
+# Group 1b: should_skip — v2.x ``skip`` action half-open circuit breaker
+# ----------------------------------------------------------------------
+
+
+def test_should_skip_false_when_not_unhealthy() -> None:
+    """A HEALTHY or DEGRADED provider is never skipped."""
+    mon = BackendHealthMonitor()
+    # Never observed → HEALTHY.
+    assert mon.should_skip("p", half_open_interval_s=30.0) is False
+    # DEGRADED (threshold failures, below 2x) → still not skipped.
+    for _ in range(3):
+        mon.record_attempt("p", success=False, threshold=3)
+    assert mon.state_for("p") == "DEGRADED"
+    assert mon.should_skip("p", half_open_interval_s=30.0) is False
+
+
+def test_should_skip_allows_one_trial_then_skips_within_interval() -> None:
+    """The first resolve after going UNHEALTHY is a half-open trial
+    (allowed); further resolves inside the interval are skipped."""
+    mon = BackendHealthMonitor()
+    for _ in range(4):
+        mon.record_attempt("p", success=False, threshold=2)
+    assert mon.is_unhealthy("p") is True
+
+    # Immediate half-open trial: let exactly one request through.
+    assert mon.should_skip("p", half_open_interval_s=30.0) is False
+    # Every subsequent resolve inside the interval: skip.
+    assert mon.should_skip("p", half_open_interval_s=30.0) is True
+    assert mon.should_skip("p", half_open_interval_s=30.0) is True
+
+
+def test_should_skip_allows_trial_after_interval_elapses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once the half-open interval elapses, one more trial is allowed."""
+    import coderouter.guards.backend_health as bh
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(bh.time, "monotonic", lambda: clock["t"])
+
+    mon = bh.BackendHealthMonitor()
+    for _ in range(4):
+        mon.record_attempt("p", success=False, threshold=2)
+
+    # Trial at t=1000, then skip within the 30s window.
+    assert mon.should_skip("p", half_open_interval_s=30.0) is False
+    clock["t"] = 1020.0
+    assert mon.should_skip("p", half_open_interval_s=30.0) is True
+    # Interval elapsed → a fresh trial is allowed, then skips resume.
+    clock["t"] = 1031.0
+    assert mon.should_skip("p", half_open_interval_s=30.0) is False
+    assert mon.should_skip("p", half_open_interval_s=30.0) is True
+
+
+def test_should_skip_success_resets_half_open_state() -> None:
+    """A success snaps the provider back to HEALTHY and clears the
+    half-open bookkeeping, so it is never skipped afterwards."""
+    mon = BackendHealthMonitor()
+    for _ in range(4):
+        mon.record_attempt("p", success=False, threshold=2)
+    assert mon.should_skip("p", half_open_interval_s=30.0) is False  # trial
+    assert mon.should_skip("p", half_open_interval_s=30.0) is True  # skip
+
+    # A successful attempt (e.g. a half-open trial that got through and
+    # succeeded) resets everything.
+    mon.record_attempt("p", success=True, threshold=2)
+    assert mon.state_for("p") == "HEALTHY"
+    assert mon.should_skip("p", half_open_interval_s=30.0) is False
+
+
+# ----------------------------------------------------------------------
 # Group 2: Engine integration — action dispatch
 # ----------------------------------------------------------------------
 
@@ -411,3 +482,114 @@ async def test_demote_no_op_when_chain_uniformly_unhealthy(
     attempted = [r.provider for r in try_records]  # type: ignore[attr-defined]
     assert "primary" in attempted
     assert "fallback" in attempted
+
+
+# ----------------------------------------------------------------------
+# Group 4: v2.x ``skip`` action — half-open circuit breaker at chain resolve
+#
+# These exercise ``_resolve_chain`` directly (no adapter call is attempted):
+# an UNHEALTHY provider is filtered out of the resolved chain, a half-open
+# trial re-admits it once per interval, and a uniformly-UNHEALTHY chain falls
+# back to the unfiltered list as a last resort.
+# ----------------------------------------------------------------------
+
+
+def _drive_unhealthy(engine: FallbackEngine, provider: str, *, threshold: int) -> None:
+    """Push ``provider`` to UNHEALTHY via the monitor (no adapter call)."""
+    for _ in range(2 * threshold):
+        engine._backend_health.record_attempt(  # type: ignore[attr-defined]
+            provider, success=False, threshold=threshold
+        )
+    assert engine._backend_health.is_unhealthy(provider) is True  # type: ignore[attr-defined]
+
+
+def test_skip_filters_unhealthy_provider_from_resolved_chain(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``action=skip``: after the immediate half-open trial is consumed, an
+    UNHEALTHY provider is removed from the resolved chain entirely."""
+    config = _config(["primary", "fallback"], action="skip", threshold=2)
+    primary = _AlwaysFailAdapter(config.provider_by_name("primary"))
+    fallback = _HealthyAdapter(config.provider_by_name("fallback"))
+    engine = _engine(config, {"primary": primary, "fallback": fallback})
+
+    _drive_unhealthy(engine, "primary", threshold=2)
+
+    # First resolve consumes the immediate half-open trial → primary present.
+    first = [a.name for a in engine._resolve_chain("default")]
+    assert first == ["primary", "fallback"]
+
+    # Second resolve inside the interval → primary skipped, log fires.
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        second = [a.name for a in engine._resolve_chain("default")]
+    assert second == ["fallback"]
+    skip_records = [
+        r for r in caplog.records if r.msg == "skip-unhealthy-provider"
+    ]
+    assert len(skip_records) == 1
+    assert skip_records[0].provider == "primary"  # type: ignore[attr-defined]
+
+
+def test_skip_half_open_trial_readmits_after_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After the half-open interval elapses, ``skip`` re-admits the
+    UNHEALTHY provider for exactly one trial resolve."""
+    import coderouter.guards.backend_health as bh
+
+    clock = {"t": 5000.0}
+    monkeypatch.setattr(bh.time, "monotonic", lambda: clock["t"])
+
+    config = _config(["primary", "fallback"], action="skip", threshold=2)
+    primary = _AlwaysFailAdapter(config.provider_by_name("primary"))
+    fallback = _HealthyAdapter(config.provider_by_name("fallback"))
+    engine = _engine(config, {"primary": primary, "fallback": fallback})
+
+    _drive_unhealthy(engine, "primary", threshold=2)
+
+    # Trial consumed on the first resolve.
+    assert [a.name for a in engine._resolve_chain("default")] == [
+        "primary",
+        "fallback",
+    ]
+    # Inside the interval: primary is filtered out.
+    clock["t"] = 5020.0
+    assert [a.name for a in engine._resolve_chain("default")] == ["fallback"]
+    # Interval elapsed (default half_open 30s): primary re-admitted for a trial.
+    clock["t"] = 5031.0
+    assert [a.name for a in engine._resolve_chain("default")] == [
+        "primary",
+        "fallback",
+    ]
+
+
+def test_skip_all_unhealthy_falls_back_to_full_chain(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When every provider is UNHEALTHY, ``skip`` does not empty the chain —
+    it falls back to the unfiltered list (last resort) and logs once."""
+    config = _config(["primary", "fallback"], action="skip", threshold=2)
+    primary = _AlwaysFailAdapter(config.provider_by_name("primary"))
+    fallback = _AlwaysFailAdapter(config.provider_by_name("fallback"))
+    engine = _engine(config, {"primary": primary, "fallback": fallback})
+
+    _drive_unhealthy(engine, "primary", threshold=2)
+    _drive_unhealthy(engine, "fallback", threshold=2)
+
+    # First resolve: both get their immediate half-open trial → full chain.
+    first = [a.name for a in engine._resolve_chain("default")]
+    assert first == ["primary", "fallback"]
+
+    # Second resolve inside the interval: both would be skipped → last resort
+    # returns the full unfiltered chain and logs once.
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="coderouter"):
+        second = [a.name for a in engine._resolve_chain("default")]
+    assert second == ["primary", "fallback"]
+
+    last_resort = [
+        r for r in caplog.records if r.msg == "chain-all-unhealthy-last-resort"
+    ]
+    assert len(last_resort) == 1
+    assert last_resort[0].providers == ["primary", "fallback"]  # type: ignore[attr-defined]

--- a/tests/test_fix_mE_config_validation.py
+++ b/tests/test_fix_mE_config_validation.py
@@ -228,6 +228,47 @@ def test_recovery_probe_initial_above_max_rejected() -> None:
 
 
 # ======================================================================
+# v2.x: ``skip`` backend-health action + half-open interval bounds
+# ======================================================================
+
+
+def test_backend_health_action_skip_accepted() -> None:
+    """``skip`` is a valid ``backend_health_action`` literal."""
+    chain = FallbackChain(
+        name="p",
+        providers=["local"],
+        backend_health_action="skip",
+    )
+    assert chain.backend_health_action == "skip"
+    # Default half-open interval loads cleanly.
+    assert chain.backend_health_half_open_s == 30.0
+
+
+def test_backend_health_half_open_below_floor_rejected() -> None:
+    """``backend_health_half_open_s`` below the 5.0s floor is rejected."""
+    with pytest.raises(ValidationError) as info:
+        FallbackChain(
+            name="p",
+            providers=["local"],
+            backend_health_action="skip",
+            backend_health_half_open_s=1.0,
+        )
+    assert "backend_health_half_open_s" in str(info.value)
+
+
+def test_backend_health_half_open_above_ceiling_rejected() -> None:
+    """``backend_health_half_open_s`` above the 600.0s ceiling is rejected."""
+    with pytest.raises(ValidationError) as info:
+        FallbackChain(
+            name="p",
+            providers=["local"],
+            backend_health_action="skip",
+            backend_health_half_open_s=601.0,
+        )
+    assert "backend_health_half_open_s" in str(info.value)
+
+
+# ======================================================================
 # M13.4: boolean matcher False is a dead rule → reject at load
 # ======================================================================
 


### PR DESCRIPTION
UNHEALTHYプロバイダへの毎リクエストTCP試行を止めるopt-inのサーキットブレーカー。backend_health_action: skip + backend_health_half_open_s(既定30s)。probe非依存のhalf-open復帰、全滅時はlast-resortで全試行。既定はwarnのまま後方互換。テスト10件追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169bqKt3eAhtwEe3vd8BP8e