### PR TITLE
feat(adapters): agent_cli Phase 1d — grok backend (v2.7.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,94 @@ are kept verbatim where the Japanese text itself is the subject).
 
 ---
 
+## [v2.7.8] — 2026-07-10 (agent_cli Phase 1d: grok)
+
+Adds the second target to the `agent_cli` adapter: `agent: grok` (the xAI
+Grok CLI) is now implemented alongside `claude` from Phase 1a. The
+implementation was verified against the real CLI (grok v0.2.93, [stable]
+channel, 2026-07-10), and several design-time assumptions from the 2026-07
+research did not survive contact with it: the CLI now supports OAuth
+subscription login (the design assumed grok was API-key-only with no
+subscription path), `--sandbox` takes a profile value
+(`off|workspace|read-only|strict`) rather than being a bare flag, a
+Claude-Code-compatible `--permission-mode` exists, and `-p`/`--single` only
+accepts the prompt as an argv value (stdin is not accepted as the prompt) —
+so the adapter delivers the prompt via a temp file instead. The grok CLI is
+still early beta: version pinning is recommended, and the JSON output is
+parsed defensively so schema churn degrades into retryable fallback rather
+than hard failure. `codex` / `gemini` remain schema-declared but rejected
+(Phase 1b/1c pending).
+
+### Added
+
+- **`agent: grok` builder/parser in `AgentCliAdapter`**
+  (`coderouter/adapters/agent_cli.py`) — invokes the Grok CLI one-shot as
+  `grok --prompt-file <workdir>/.coderouter-prompt-<uuid>.txt
+  --output-format json -m <model> --cwd <workdir> --max-turns <N>
+  --no-memory --sandbox read-only --permission-mode plan` (read_only
+  default). Auth is subscription-first, same as claude: the CLI's OAuth
+  login (`grok login`, SuperGrok / X Premium+) stores credentials at
+  `~/.grok/auth.json` (7-day expiry, auto-refresh; `GROK_HOME` overrides),
+  which the adapter's `HOME` inheritance reaches with
+  `passthrough_env: []`. For CI/API-key use the CLI reads
+  `GROK_CODE_XAI_API_KEY` (not `XAI_API_KEY`) — list it in
+  `passthrough_env` only if needed; it takes precedence over OAuth.
+- **`sandbox_mode` → grok flag mapping** — `read_only` →
+  `--sandbox read-only --permission-mode plan`; `edit` →
+  `--sandbox workspace --permission-mode acceptEdits`; `full_auto` →
+  `--sandbox workspace --always-approve`. As with claude, the effective
+  mode is clamped to read-only whenever `allow_file_writes=false`,
+  regardless of `sandbox_mode` (defense in depth). Unlike claude,
+  `full_auto` maps distinctly from `edit`.
+- **Prompt delivery via `--prompt-file`** — grok's `-p`/`--single` requires
+  the prompt as an argv VALUE (verified on the real CLI: stdin is not
+  accepted as the prompt), and putting huge prompts on argv would hit
+  Linux's `MAX_ARG_STRLEN` (~128KiB) and expose the full prompt text to
+  `ps`. The adapter instead writes the prompt to a mode-`0600` temp file
+  inside the isolated workdir and passes `--prompt-file`; the file is
+  always deleted afterwards, including on the timeout and error paths.
+- **`--no-memory` always passed** — grok has a cross-session memory
+  feature; disabling it unconditionally preserves the
+  "one request = one stateless transformation" ethos (a previous call's
+  memory can never leak into the next response). Not configurable.
+- **grok JSON parsing + zero-usage reporting** — `--output-format json`
+  emits a single JSON object `{"text", "stopReason", "sessionId",
+  "requestId", "thought"?}` (verified on grok v0.2.93). `text` becomes the
+  final answer; `sessionId` surfaces as the `coderouter_session_id`
+  response metadata. There are NO token-usage or cost fields, so usage is
+  reported as zeros and `coderouter_cost_usd` stays 0 unless the operator
+  sets unit prices in `ProviderConfig.cost` (in contrast to claude's
+  direct `total_cost_usd`). Parsing is defensive: anything malformed
+  raises a retryable `AdapterError` and the fallback chain advances.
+  Runtime errors (exit 1 with the error text on stderr) surface a stderr
+  tail in the `AdapterError` message.
+
+### Changed
+
+- **Unsupported-agent error message** — constructing the adapter with a
+  not-yet-implemented agent now lists what IS implemented (e.g.
+  `agent 'codex' is not implemented yet (implemented: claude, grok)`)
+  instead of the Phase-1a-specific "claude only" wording. Still
+  `retryable=False` — a configuration error, not a fallback candidate.
+- **Schema docstrings** (`coderouter/config/schemas.py`) — `AgentCliConfig`
+  field descriptions updated for the two-agent reality; the design-time
+  "grok requires `XAI_API_KEY` in `passthrough_env`" validation note was
+  dropped as obsolete (grok now supports subscription OAuth).
+- **Docs & examples** — `docs/backends/external-agents.md`/`.en.md` gain a
+  full grok section (config example, adapter argv, sandbox mapping table,
+  prompt-file rationale, `--no-memory` rationale, JSON schema and
+  zero-usage note, OAuth setup steps, early-beta/version-pin caveat) and
+  updated implementation-status wording. The design doc
+  `docs/designs/external-agents-adapter.md` gets a new appendix §11.3
+  recording the verified deltas between the 2026-07 research and grok
+  v0.2.93 (body text left as the historical record).
+  `examples/providers-agent-cli.yaml` promotes grok out of the
+  not-implemented preview into a documented (still commented-out, so
+  copying the file doesn't require grok to be installed) block with the
+  corrected model (`grok-4.5` — `grok-code-fast-1` was retired
+  2026-05-15), `paid: false` for subscription OAuth, and
+  `passthrough_env: []`.
+
 ## [v2.7.7] — 2026-07-10 (External coding agents: agent_cli adapter, Phase 1a claude)
 
 **PR #62 / #63**. Adds a new adapter kind, `agent_cli`, that lets CodeRouter front an external

--- a/coderouter/adapters/agent_cli.py
+++ b/coderouter/adapters/agent_cli.py
@@ -18,24 +18,36 @@ CodeRouter merely performs the one conversion. Following the
 ``openai_compat`` precedent, a *single* adapter class fronts *multiple*
 target agents, dispatched on the ``agent`` field.
 
-Phase 1a scope
-==============
+Implemented agents (Phase 1a + 1d)
+==================================
 
-Only the ``claude`` (Claude Code CLI) target is implemented here — it is
-the most stable CLI, has the most fine-grained safety controls, and is the
-only one that emits ``total_cost_usd`` directly (making it the reference
-implementation for the parser / cost path). The other agents
-(codex / gemini / grok) are declared in the config schema so providers.yaml
-is forward-compatible, but constructing an adapter for them raises a clear
-``AdapterError`` until their phase lands.
+Two targets are implemented here:
+
+* ``claude`` (Claude Code CLI, Phase 1a) — the most stable CLI, the most
+  fine-grained safety controls, and the only one that emits
+  ``total_cost_usd`` directly (making it the reference implementation for
+  the parser / cost path).
+* ``grok`` (grok CLI, Phase 1d) — headless one-shot via ``--prompt-file`` +
+  ``--output-format json``. The CLI emits no token/cost figures, so usage
+  is reported as zeros (cost stays 0 unless the operator sets
+  ``ProviderConfig.cost``, design §5.1.6). ``--no-memory`` is always passed
+  so a user-level cross-session memory setting cannot leak state between
+  requests.
+
+The remaining agents (codex / gemini) are declared in the config schema so
+providers.yaml is forward-compatible, but constructing an adapter for them
+raises a clear ``AdapterError`` until their phase (1b / 1c) lands.
 
 Security (design §6, non-negotiable)
 ====================================
 
 * **allowlist argv only** — the child is launched with
   :func:`asyncio.create_subprocess_exec` and a list argv. ``shell=True`` is
-  never used; the prompt is fed on stdin, so it is never subject to shell
-  interpretation.
+  never used; the prompt is never subject to shell interpretation (claude
+  reads it from stdin; grok reads it from a private ``0600`` prompt file
+  inside the resolved workdir — its ``-p`` requires the prompt as an argv
+  value, and argv would both hit Linux's ~128KiB ``MAX_ARG_STRLEN`` on huge
+  prompts and leak the text into ``ps`` output).
 * **default read-only** — ``allow_file_writes=False`` /
   ``sandbox_mode="read_only"`` are the defaults, mapped to claude's
   ``--permission-mode plan``. Writes require explicit opt-in and the sandbox
@@ -104,6 +116,17 @@ _CLAUDE_PERMISSION_MODE = {
     "full_auto": "acceptEdits",
 }
 
+# sandbox_mode → grok sandbox/approval flags (design §5.4, grok CLI v0.2.93).
+# grok's ``--sandbox`` takes a built-in profile VALUE (off|workspace|
+# read-only|strict) and its ``--permission-mode`` shares Claude Code's value
+# set; ``full_auto`` swaps the permission mode for ``--always-approve``
+# (auto-approve all tool executions).
+_GROK_SANDBOX_ARGS = {
+    "read_only": ["--sandbox", "read-only", "--permission-mode", "plan"],
+    "edit": ["--sandbox", "workspace", "--permission-mode", "acceptEdits"],
+    "full_auto": ["--sandbox", "workspace", "--always-approve"],
+}
+
 
 def _chunk_text(text: str, size: int = _STREAM_CHUNK_CHARS) -> Iterator[str]:
     """Split ``text`` into ``size``-char pieces for the pseudo-stream."""
@@ -112,7 +135,7 @@ def _chunk_text(text: str, size: int = _STREAM_CHUNK_CHARS) -> Iterator[str]:
 
 
 class AgentCliAdapter(BaseAdapter):
-    """Invoke an external coding-agent CLI one-shot (Phase 1a: claude only).
+    """Invoke an external coding-agent CLI one-shot (claude + grok).
 
     The ``agent`` field selects the argv builder / output parser via the
     dispatch tables built in :meth:`__init__`, mirroring how
@@ -122,9 +145,10 @@ class AgentCliAdapter(BaseAdapter):
     def __init__(self, config: ProviderConfig) -> None:
         """Bind to a ``ProviderConfig`` and reject unsupported agents.
 
-        Constructing an adapter for an agent other than ``claude`` raises a
-        non-retryable :class:`AdapterError` — the other targets are declared
-        in the schema but not implemented until their phase (design §9).
+        Constructing an adapter for an agent other than ``claude`` / ``grok``
+        raises a non-retryable :class:`AdapterError` — the other targets are
+        declared in the schema but not implemented until their phase
+        (design §9).
         """
         super().__init__(config)
         if config.agent_cli is None:  # pragma: no cover - schema enforces this
@@ -134,21 +158,30 @@ class AgentCliAdapter(BaseAdapter):
                 retryable=False,
             )
         self.acfg: AgentCliConfig = config.agent_cli
-        if self.acfg.agent != "claude":
+        if self.acfg.agent not in ("claude", "grok"):
             raise AdapterError(
-                f"agent {self.acfg.agent!r} is not implemented in Phase 1a "
-                f"(claude only). Configure agent='claude' or wait for the "
-                f"agent's phase.",
+                f"agent {self.acfg.agent!r} is not implemented yet "
+                f"(implemented: claude, grok). Wait for Phase 1b/1c.",
                 provider=config.name,
                 retryable=False,
             )
-        # agent → argv builder / output parser dispatch tables. Phase 1a
-        # registers only claude; later phases add codex / gemini / grok.
-        self._builders = {"claude": self._build_claude_argv}
-        self._parsers = {"claude": self._parse_claude}
-        # claude reads its print-mode prompt from stdin (10MB cap), which
-        # keeps argv free of the (potentially huge) prompt text.
-        self._uses_stdin = True
+        # agent → argv builder / output parser dispatch tables. claude landed
+        # in Phase 1a, grok in Phase 1d; Phase 1b/1c add codex / gemini.
+        self._builders = {
+            "claude": self._build_claude_argv,
+            "grok": self._build_grok_argv,
+        }
+        self._parsers = {
+            "claude": self._parse_claude,
+            "grok": self._parse_grok,
+        }
+        # Prompt delivery is per-agent: claude reads its print-mode prompt
+        # from stdin (10MB cap), which keeps argv free of the (potentially
+        # huge) prompt text. grok's ``-p`` REQUIRES the prompt as its argv
+        # value (piped stdin is only appended as extra context, verified on
+        # v0.2.93), so grok gets the prompt via ``--prompt-file`` instead —
+        # see ``_write_prompt_file`` for the rationale.
+        self._uses_stdin = self.acfg.agent == "claude"
 
     # ------------------------------------------------------------------
     # BaseAdapter contract
@@ -177,8 +210,7 @@ class AgentCliAdapter(BaseAdapter):
         depth = self._current_depth()
         if depth >= self.acfg.agent_depth_limit:
             raise AdapterError(
-                f"agent recursion depth {depth} >= limit "
-                f"{self.acfg.agent_depth_limit}",
+                f"agent recursion depth {depth} >= limit {self.acfg.agent_depth_limit}",
                 provider=self.name,
                 retryable=False,
             )
@@ -195,68 +227,82 @@ class AgentCliAdapter(BaseAdapter):
 
         prompt = self._render_prompt(request, overrides)
         workdir = self._resolve_workdir()
-        argv = self._builders[self.acfg.agent](workdir)
-        # Resolve the executable to an absolute path so argv[0] is a concrete
-        # binary independent of the child's minimal PATH (design §6 allowlist).
-        resolved = shutil.which(argv[0])
-        if resolved is not None:
-            argv = [resolved, *argv[1:]]
-        env = self._build_child_env()
 
-        logger.info(
-            "agent-cli-exec",
-            extra={
-                "provider": self.name,
-                "agent": self.acfg.agent,
-                "argv0": argv[0],
-                "timeout_s": timeout,
-            },
-        )
-
+        # Agents that cannot take the prompt on stdin (grok) get it through a
+        # private temp file inside the workdir; it is ALWAYS removed in the
+        # ``finally`` below, including on timeout / exception paths.
+        prompt_file = None if self._uses_stdin else self._write_prompt_file(prompt, workdir)
         try:
-            proc = await asyncio.create_subprocess_exec(
-                *argv,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=workdir,
-                env=env,
-                # New session/process group so a timeout can SIGKILL the whole
-                # group (the CLI hangs its real LLM call off a child).
-                start_new_session=True,
-            )
-        except (FileNotFoundError, OSError) as exc:
-            raise AdapterError(
-                f"failed to launch {self.acfg.command!r}: {exc}",
-                provider=self.name,
-                retryable=False,
-            ) from exc
+            argv = self._builders[self.acfg.agent](workdir, prompt_file)
+            # Resolve the executable to an absolute path so argv[0] is a
+            # concrete binary independent of the child's minimal PATH
+            # (design §6 allowlist).
+            resolved = shutil.which(argv[0])
+            if resolved is not None:
+                argv = [resolved, *argv[1:]]
+            env = self._build_child_env()
 
-        stdin_bytes = prompt.encode("utf-8") if self._uses_stdin else None
-        try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(input=stdin_bytes), timeout=timeout
-            )
-        except TimeoutError as exc:
-            self._kill_process_group(proc)
-            with contextlib.suppress(Exception):
-                await proc.wait()
-            raise AdapterError(
-                f"{self.acfg.agent} exec timed out after {timeout}s",
-                provider=self.name,
-                retryable=True,
-            ) from exc
-
-        if proc.returncode != 0:
-            detail = self._error_detail(stdout, stderr)
-            raise AdapterError(
-                f"{self.acfg.agent} exited {proc.returncode}: {detail}",
-                provider=self.name,
-                status_code=None,
-                retryable=self._is_retryable_exit(proc.returncode),
+            logger.info(
+                "agent-cli-exec",
+                extra={
+                    "provider": self.name,
+                    "agent": self.acfg.agent,
+                    "argv0": argv[0],
+                    "timeout_s": timeout,
+                },
             )
 
-        final_text, usage, meta = self._parsers[self.acfg.agent](stdout, stderr)
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *argv,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=workdir,
+                    env=env,
+                    # New session/process group so a timeout can SIGKILL the
+                    # whole group (the CLI hangs its real LLM call off a
+                    # child).
+                    start_new_session=True,
+                )
+            except (FileNotFoundError, OSError) as exc:
+                raise AdapterError(
+                    f"failed to launch {self.acfg.command!r}: {exc}",
+                    provider=self.name,
+                    retryable=False,
+                ) from exc
+
+            stdin_bytes = prompt.encode("utf-8") if self._uses_stdin else None
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(input=stdin_bytes), timeout=timeout
+                )
+            except TimeoutError as exc:
+                self._kill_process_group(proc)
+                with contextlib.suppress(Exception):
+                    await proc.wait()
+                raise AdapterError(
+                    f"{self.acfg.agent} exec timed out after {timeout}s",
+                    provider=self.name,
+                    retryable=True,
+                ) from exc
+
+            if proc.returncode != 0:
+                detail = self._error_detail(stdout, stderr)
+                raise AdapterError(
+                    f"{self.acfg.agent} exited {proc.returncode}: {detail}",
+                    provider=self.name,
+                    status_code=None,
+                    retryable=self._is_retryable_exit(proc.returncode),
+                )
+
+            final_text, usage, meta = self._parsers[self.acfg.agent](stdout, stderr)
+        finally:
+            if prompt_file is not None:
+                # Best-effort cleanup — the child may already have exited and
+                # a vanished file is not an error worth surfacing.
+                with contextlib.suppress(OSError):
+                    os.unlink(prompt_file)
         return self._to_chat_response(final_text, usage, meta)
 
     async def stream(
@@ -281,9 +327,7 @@ class AgentCliAdapter(BaseAdapter):
                 id=resp.id,
                 created=resp.created,
                 model=resp.model,
-                choices=[
-                    {"index": 0, "delta": {"content": piece}, "finish_reason": None}
-                ],
+                choices=[{"index": 0, "delta": {"content": piece}, "finish_reason": None}],
             )
         yield StreamChunk(
             id=resp.id,
@@ -297,7 +341,7 @@ class AgentCliAdapter(BaseAdapter):
     # claude argv builder + output parser
     # ------------------------------------------------------------------
 
-    def _build_claude_argv(self, workdir: str) -> list[str]:
+    def _build_claude_argv(self, workdir: str, prompt_file: str | None = None) -> list[str]:
         """Assemble the ``claude -p`` argv (design §5.1.5 / §5.4).
 
         Shape::
@@ -305,10 +349,13 @@ class AgentCliAdapter(BaseAdapter):
             claude -p --output-format json --model <m> --max-turns <n>
                    --permission-mode <plan|acceptEdits> --add-dir <workdir>
 
-        The prompt is fed on stdin (not argv), so it never appears here.
-        ``--bare`` is deliberately NOT added — it would skip OAuth/keychain
-        reads and break subscription auth (design §5.3.4).
+        The prompt is fed on stdin (not argv), so it never appears here and
+        ``prompt_file`` is ignored (it exists only to keep the builder
+        signature uniform across agents). ``--bare`` is deliberately NOT
+        added — it would skip OAuth/keychain reads and break subscription
+        auth (design §5.3.4).
         """
+        del prompt_file  # claude takes the prompt on stdin, not from a file.
         model = self.acfg.model or self.config.model
         argv = [self.acfg.command, "-p", "--output-format", "json", "--model", model]
         if self.acfg.max_turns is not None:
@@ -419,8 +466,152 @@ class AgentCliAdapter(BaseAdapter):
         return usage
 
     # ------------------------------------------------------------------
+    # grok argv builder + output parser (Phase 1d)
+    # ------------------------------------------------------------------
+
+    def _build_grok_argv(self, workdir: str, prompt_file: str | None = None) -> list[str]:
+        """Assemble the grok headless argv (design §5, grok CLI v0.2.93).
+
+        Shape::
+
+            grok --prompt-file <f> --output-format json -m <m> --cwd <w>
+                 --max-turns <n> --no-memory --sandbox <profile>
+                 [--permission-mode <mode> | --always-approve]
+
+        The prompt travels via ``--prompt-file`` (never argv / stdin): grok's
+        ``-p`` requires the prompt as its argv value, and putting it there
+        would hit Linux's ~128KiB ``MAX_ARG_STRLEN`` on large prompts and
+        leak the text into ``ps`` output. ``--no-memory`` is deliberate: it
+        enforces the one-request-one-transformation statelessness even if
+        the user's grok config enables cross-session memory.
+        """
+        if prompt_file is None:  # pragma: no cover - generate() always supplies it
+            raise AdapterError(
+                "grok argv requires a prompt file",
+                provider=self.name,
+                retryable=False,
+            )
+        model = self.acfg.model or self.config.model
+        argv = [
+            self.acfg.command,
+            "--prompt-file",
+            prompt_file,
+            "--output-format",
+            "json",
+            "-m",
+            model,
+            "--cwd",
+            workdir,
+        ]
+        if self.acfg.max_turns is not None:
+            argv += ["--max-turns", str(self.acfg.max_turns)]
+        argv += ["--no-memory"]
+        argv += self._grok_sandbox_args()
+        return argv
+
+    def _grok_sandbox_args(self) -> list[str]:
+        """Map ``sandbox_mode`` → grok sandbox/approval flags, clamped.
+
+        Same clamp as claude (design §5.4): when ``allow_file_writes`` is
+        False the effective mode is forced to ``read_only`` regardless of
+        ``sandbox_mode``, so writes always require the explicit opt-in.
+        """
+        mode = self.acfg.sandbox_mode if self.acfg.allow_file_writes else "read_only"
+        return list(_GROK_SANDBOX_ARGS[mode])
+
+    def _parse_grok(
+        self, stdout: bytes, stderr: bytes
+    ) -> tuple[str, dict[str, Any], dict[str, Any]]:
+        """Parse grok ``--output-format json`` output (verified v0.2.93).
+
+        Real-run shape::
+
+            {"text": "...", "stopReason": "EndTurn", "sessionId": "<uuid>",
+             "requestId": "<uuid>", "thought": "..."}
+
+        The CLI is early beta, so parsing is deliberately defensive: empty /
+        non-JSON / non-object stdout and a missing ``text`` field all raise
+        a retryable :class:`AdapterError` so the chain can fall through.
+        ``thought`` is ignored — only the final ``text`` is the answer.
+        """
+        text = stdout.decode("utf-8", "replace").strip()
+        if not text:
+            raise AdapterError(
+                "grok produced no stdout to parse",
+                provider=self.name,
+                retryable=True,
+            )
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise AdapterError(
+                f"grok emitted non-JSON output: {exc}",
+                provider=self.name,
+                retryable=True,
+            ) from exc
+        if not isinstance(data, dict):
+            raise AdapterError(
+                "grok JSON output was not an object",
+                provider=self.name,
+                retryable=True,
+            )
+        result = data.get("text")
+        if not isinstance(result, str):
+            raise AdapterError(
+                "grok JSON output missing string 'text' field",
+                provider=self.name,
+                retryable=True,
+            )
+
+        # grok emits NO token usage / cost fields (verified), so usage is
+        # all-zeros; the cost dashboard shows 0 for this provider unless the
+        # operator sets ``ProviderConfig.cost`` rates (design §5.1.6).
+        usage: dict[str, Any] = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        }
+        meta: dict[str, Any] = {}
+        session_id = data.get("sessionId")
+        if isinstance(session_id, str):
+            meta["coderouter_session_id"] = session_id
+        return result, usage, meta
+
+    # ------------------------------------------------------------------
     # helpers: prompt rendering, response shaping, env, workdir, kill
     # ------------------------------------------------------------------
+
+    def _write_prompt_file(self, prompt: str, workdir: str) -> str:
+        """Write the prompt to a private ``0600`` temp file in ``workdir``.
+
+        Rationale: grok's ``-p`` requires the prompt as an argv value, but a
+        huge prompt would hit Linux's ~128KiB ``MAX_ARG_STRLEN`` and argv
+        leaks into ``ps`` output; file delivery keeps argv small and private,
+        and ``0600`` + the isolated workdir bounds exposure. ``O_EXCL`` with
+        a uuid4 name makes creation race-free; the caller (``generate``)
+        deletes the file in a ``finally`` block on every path.
+        """
+        path = os.path.join(workdir, f".coderouter-prompt-{uuid.uuid4().hex}.txt")
+        try:
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except OSError as exc:
+            raise AdapterError(
+                f"failed to create prompt file in {workdir}: {exc}",
+                provider=self.name,
+                retryable=False,
+            ) from exc
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(prompt)
+        except OSError as exc:
+            with contextlib.suppress(OSError):
+                os.unlink(path)
+            raise AdapterError(
+                f"failed to write prompt file {path}: {exc}",
+                provider=self.name,
+                retryable=False,
+            ) from exc
+        return path
 
     def _to_chat_response(
         self, final_text: str, usage: dict[str, Any], meta: dict[str, Any]
@@ -442,9 +633,7 @@ class AgentCliAdapter(BaseAdapter):
             **meta,
         )
 
-    def _render_prompt(
-        self, request: ChatRequest, overrides: ProviderCallOverrides | None
-    ) -> str:
+    def _render_prompt(self, request: ChatRequest, overrides: ProviderCallOverrides | None) -> str:
         """Flatten the chat messages into a single role-tagged prompt string.
 
         The profile-level ``append_system_prompt`` (if any) is prepended as a

--- a/coderouter/config/schemas.py
+++ b/coderouter/config/schemas.py
@@ -170,10 +170,17 @@ class AgentCliConfig(BaseModel):
     ``agent_cli`` sub-config drives the :class:`AgentCliAdapter`, which
     invokes an external coding-agent CLI (codex / gemini / grok / claude)
     in a single one-shot ``exec`` and returns the final answer as one
-    ``prompt in → text out`` transformation. Phase 1a implements the
-    ``claude`` (Claude Code CLI) target only; the other agents are declared
-    at the schema level so configs are forward-compatible, but the adapter
-    rejects them until their phase lands.
+    ``prompt in → text out`` transformation. ``claude`` (Claude Code CLI,
+    Phase 1a) and ``grok`` (grok CLI, Phase 1d) are implemented;
+    codex / gemini are declared at the schema level so configs are
+    forward-compatible, but the adapter rejects them until their phase
+    lands.
+
+    Auth note (grok): the grok CLI uses OAuth credentials stored under
+    ``~/.grok`` (``grok login``), which the adapter's HOME inheritance
+    already covers — no extra config needed. For CI / API-key setups, list
+    ``GROK_CODE_XAI_API_KEY`` in ``passthrough_env`` (this is grok's key
+    env var — NOT ``XAI_API_KEY``).
 
     Follows the ``extra="forbid"`` convention used across this module so a
     typo'd key fails at config-load rather than being silently ignored.
@@ -183,7 +190,10 @@ class AgentCliConfig(BaseModel):
 
     agent: Literal["codex", "gemini", "grok", "claude"] = Field(
         ...,
-        description="External coding-agent CLI to invoke. Phase 1a: 'claude' only.",
+        description=(
+            "External coding-agent CLI to invoke. 'claude' (Phase 1a) and "
+            "'grok' (Phase 1d) are implemented; 'codex' / 'gemini' pending."
+        ),
     )
     command: str | None = Field(
         default=None,
@@ -248,7 +258,9 @@ class AgentCliConfig(BaseModel):
             "Allowlist of environment variable NAMES forwarded from the "
             "parent process into the child. The child otherwise inherits "
             "no parent environment (subscription-first auth policy). "
-            "``ANTHROPIC_API_KEY`` is NOT forwarded unless listed here."
+            "``ANTHROPIC_API_KEY`` is NOT forwarded unless listed here. "
+            "For grok in CI, list ``GROK_CODE_XAI_API_KEY`` here; OAuth "
+            "logins under ``~/.grok`` work without it (HOME is inherited)."
         ),
     )
     agent_depth_limit: int = Field(

--- a/docs/backends/external-agents.en.md
+++ b/docs/backends/external-agents.en.md
@@ -2,7 +2,7 @@
 
 > 日本語版: [`external-agents.md`](./external-agents.md)
 
-`kind: "agent_cli"` is an adapter that registers an external coding-agent CLI, such as the Claude Code CLI, as a single CodeRouter provider. It was newly added in v2.7.7 (Phase 1a). See [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) for the full design.
+`kind: "agent_cli"` is an adapter that registers an external coding-agent CLI, such as the Claude Code CLI, as a single CodeRouter provider. It was newly added in v2.7.7 (Phase 1a: claude), and v2.7.8 added grok (Phase 1d). See [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) for the full design.
 
 ---
 
@@ -11,16 +11,16 @@
 A coding-agent CLI is normally a stateful control loop that runs many turns autonomously while editing files — a poor fit for CodeRouter's "one request = one transformation" ethos. `agent_cli` reconciles the two by collapsing the CLI into a **one-shot `exec`** (prompt in → final answer text out). Orchestration (multi-turn control, tool execution) stays entirely inside the agent CLI process; from CodeRouter's side it looks like just another provider that answers a single exchange.
 
 - **Supported CLIs**: the `agent` field can declare `claude` / `codex` / `gemini` / `grok`.
-- **Implementation status (as of v2.7.7)**: **only `claude` (Claude Code CLI) is implemented**. `codex` / `gemini` / `grok` can be written into `providers.yaml` at the schema level, but constructing the adapter always rejects them (Phase 1b–1d are not yet implemented):
+- **Implementation status (as of v2.7.8)**: **`claude` (Claude Code CLI, Phase 1a) and `grok` (Grok CLI, Phase 1d) are implemented**. `codex` / `gemini` can be written into `providers.yaml` at the schema level, but constructing the adapter always rejects them (Phase 1b/1c are not yet implemented). The error message looks roughly like the following (the exact wording may differ between versions):
 
   ```
-  AdapterError: agent 'codex' is not implemented in Phase 1a (claude only).
-  Configure agent='claude' or wait for the agent's phase.
+  AdapterError: agent 'codex' is not implemented yet (implemented: claude, grok).
+  Wait for the agent's phase (1b/1c).
   ```
 
   This rejection is `retryable=False` — even if other providers exist in the fallback chain, it stops immediately as a configuration error.
 
-- This is a **new, claude-only** feature at this stage, and this document is written against the `claude` target. Example configs for the other targets exist only as a commented-out preview at the bottom of `examples/providers-agent-cli.yaml` and do not work.
+- The shared parts of this document (authentication design, configuration reference, limitations) are written against the `claude` target; grok-specific behavior is collected in the [grok (Grok CLI)](#grok-grok-cli) section. Example configs for `codex` / `gemini` exist only as a commented-out preview at the bottom of `examples/providers-agent-cli.yaml` and do not work.
 
 ---
 
@@ -96,30 +96,109 @@ All fields of the `agent_cli:` sub-config (`AgentCliConfig`) in `providers.yaml`
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `agent` | `"claude" \| "codex" \| "gemini" \| "grok"` | (required) | Which CLI to invoke. **As of v2.7.7, anything other than `claude` is rejected when the adapter is constructed** |
+| `agent` | `"claude" \| "codex" \| "gemini" \| "grok"` | (required) | Which CLI to invoke. **As of v2.7.8, `claude` and `grok` are implemented; `codex` / `gemini` are rejected when the adapter is constructed** |
 | `command` | `str \| null` | `null` (defaults to the same name as `agent`) | CLI executable name or absolute path, resolved via `PATH` |
 | `workdir` | `str \| null` | `null` (defaults to `~/.coderouter/agents/<provider name>`) | Working directory for the one-shot exec. `~` / env-var expansion is applied; a path containing `..` is rejected |
 | `exec_timeout_s` | `float` | `600.0` (range `1.0`–`1800.0`) | Forced timeout (seconds) for the whole exec. **Separate** from `ProviderConfig.timeout_s` (the latter is not used by agent_cli) |
 | `allow_file_writes` | `bool` | `false` | Whether to allow file writes. When `false`, the effective mode is clamped to read-only regardless of `sandbox_mode` |
-| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | Maps to claude's `--permission-mode` (see the [table below](#sandbox_mode--permission-mode-mapping)) |
-| `model` | `str \| null` | `null` (defaults to `ProviderConfig.model`) | Model name passed to the CLI's `--model` (e.g. `opus` / `sonnet` / `haiku` / `fable`) |
+| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | Maps to each CLI's sandbox/approval flags (claude: [table below](#sandbox_mode--permission-mode-mapping-claude); grok: [grok section](#sandbox_mode--grok-flag-mapping)) |
+| `model` | `str \| null` | `null` (defaults to `ProviderConfig.model`) | Model name passed to the CLI's `--model` / `-m` (claude: `opus` / `sonnet` / `haiku` / `fable` etc.; grok: `grok-4.5` etc.) |
 | `max_turns` | `int \| null` | `8` (range `1`–`50`) | Turn cap inside the CLI. Passed as `--max-turns` |
 | `passthrough_env` | `list[str]` | `[]` | Allowlist of environment variable names forwarded from the parent process into the child. `ANTHROPIC_API_KEY` is not forwarded unless listed here |
 | `agent_depth_limit` | `int` | `2` (range `1`–`4`) | Recursion nesting cap. When `CODEROUTER_AGENT_DEPTH` reaches or exceeds this, the call stops immediately with `AdapterError(retryable=False)` |
 
 When `command` is unset it defaults to the same name as `agent`. Also, specifying `allow_file_writes: true` together with `sandbox_mode: read_only` is treated as a contradictory configuration and raises a **`ValueError` at config-load time** (set `sandbox_mode` to `edit` or `full_auto` if you want to permit writes).
 
-### `sandbox_mode` → `--permission-mode` mapping
+### `sandbox_mode` → `--permission-mode` mapping (claude)
 
 | `sandbox_mode` | claude `--permission-mode` | Notes |
 |---|---|---|
 | `read_only` (default) | `plan` | No file changes. Always clamped to this mode when `allow_file_writes=false` |
 | `edit` | `acceptEdits` | Auto-approves file edits |
-| `full_auto` | `acceptEdits` | Maps the same as `edit` in Phase 1a (claude has no separate full_auto-equivalent mode in use yet) |
+| `full_auto` | `acceptEdits` | For claude this maps the same as `edit` (claude has no separate full_auto-equivalent mode in use yet). grok distinguishes it via `--always-approve` (see the [grok section](#sandbox_mode--grok-flag-mapping)) |
 
 ### Why `paid: false`
 
 The `agent-claude` provider in the example config `examples/providers-agent-cli.yaml` is set to `paid: false`. That's because running on subscription OAuth incurs **zero metered cost** (only the 5-hour window / weekly quota described below is consumed). If you want to run it on metered API-key billing instead, change it to `paid: true` and pass `ALLOW_PAID=true` as an environment variable when starting CodeRouter. Note that the `ALLOW_PAID` environment variable **overrides** whatever `allow_paid` value is written in `providers.yaml` at startup — a `paid: true` provider is excluded from routing whenever `ALLOW_PAID` is unset.
+
+---
+
+## grok (Grok CLI)
+
+v2.7.8 (Phase 1d) implements `agent: grok`. It uses the same one-shot exec scheme as claude, but grok has its own behavior around prompt delivery, cross-session memory disabling, and usage reporting. Everything below is based on grok CLI **v0.2.93** ([stable] channel, field-verified on 2026-07-10).
+
+### Example configuration
+
+```yaml
+providers:
+  - name: agent-grok
+    kind: agent_cli
+    model: grok-4.5              # the default model on a current install; list with `grok models`
+    paid: false                  # subscription OAuth = zero metered cost
+    capabilities:
+      streaming: false
+      tools: false
+    agent_cli:
+      agent: grok
+      command: grok
+      workdir: ~/.coderouter/agents/grok
+      exec_timeout_s: 600
+      allow_file_writes: false
+      sandbox_mode: read_only
+      max_turns: 8
+      passthrough_env: []        # OAuth reads ~/.grok/auth.json via the inherited HOME, so empty is fine.
+                                 # Only list GROK_CODE_XAI_API_KEY when using an API key in CI
+```
+
+### The argv the adapter builds
+
+With `sandbox_mode: read_only` (the default), the adapter builds the following argv.
+
+```
+grok --prompt-file <workdir>/.coderouter-prompt-<uuid>.txt \
+     --output-format json -m <model> --cwd <workdir> \
+     --max-turns <N> --no-memory \
+     --sandbox read-only --permission-mode plan
+```
+
+### The prompt is delivered via a file (`--prompt-file`)
+
+grok's `-p` / `--single` accepts the prompt **only as an argv value** (verified on the real CLI: stdin is not accepted as the prompt). Putting a huge prompt on argv runs into Linux's `MAX_ARG_STRLEN` limit (~128KiB) and exposes the full prompt text to `ps`. The adapter therefore writes the prompt to a mode-`0600` temp file inside the isolated workdir (`.coderouter-prompt-<uuid>.txt`) and passes it via `--prompt-file`. That temp file is **always deleted** after the exec finishes, including the timeout and error paths.
+
+### `sandbox_mode` → grok flag mapping
+
+As with claude, when `allow_file_writes=false` the effective mode is clamped to `read_only` regardless of `sandbox_mode`.
+
+| `sandbox_mode` | grok flags | Notes |
+|---|---|---|
+| `read_only` (default) | `--sandbox read-only --permission-mode plan` | No file changes. Always clamped to this mode when `allow_file_writes=false` |
+| `edit` | `--sandbox workspace --permission-mode acceptEdits` | Auto-approves file edits inside the workspace sandbox |
+| `full_auto` | `--sandbox workspace --always-approve` | Unlike claude, grok maps this distinctly from `edit` |
+
+### `--no-memory` is always passed
+
+The grok CLI has a cross-session memory feature. Letting a previous call's memory leak into the next response conflicts with CodeRouter's "one request = one stateless transformation" ethos, so the adapter **always** passes `--no-memory` to disable it (this cannot be turned off in config).
+
+### JSON output and usage / cost
+
+The `--output-format json` output is a single JSON object `{"text", "stopReason", "sessionId", "requestId", "thought"?}` (verified on grok v0.2.93). `text` becomes the final answer, and `sessionId` is surfaced as the `coderouter_session_id` response metadata. **There are no token-usage or cost fields**, so usage is reported as all zeros, and `coderouter_cost_usd` stays 0 unless the operator sets unit prices in `ProviderConfig.cost` (in contrast to claude, which emits `total_cost_usd` directly). The JSON is parsed defensively: anything malformed becomes an `AdapterError(retryable=True)` and the fallback chain advances to the next provider.
+
+### Authentication (subscription OAuth / API key)
+
+The grok CLI supports OAuth subscription login (SuperGrok / X Premium+). Credentials are stored at `~/.grok/auth.json` (7-day expiry with auto-refresh; `GROK_HOME` overrides the location), and the adapter's `HOME` inheritance makes OAuth work with `passthrough_env: []`. Setup steps:
+
+1. Run `grok login` to complete the subscription login.
+2. Smoke-check by running `grok models` and confirming the model list comes back. On a current install it lists `grok-4.5` (default) and `grok-composer-2.5-fast`.
+
+Only when running on API-key metered billing (e.g. CI) should you list `passthrough_env: [GROK_CODE_XAI_API_KEY]`. Note that the environment variable name is **`GROK_CODE_XAI_API_KEY`, not `XAI_API_KEY`**. When the API key is forwarded, it takes precedence over OAuth.
+
+### Error reporting
+
+The grok CLI exits 0 on success, and exits 1 on auth/network/runtime errors with the error text on **stderr**. The adapter includes a tail of stderr in the `AdapterError` message, so you can use the message shown as your lead.
+
+### Early-beta caveat
+
+The grok CLI is early beta (v0.2.93 [stable] channel as of 2026-07-10). Its JSON schema may still churn, so **version pinning is recommended** (you can point `command` at a pinned binary's full path). If the schema does change, defensive parsing turns it into a retryable `AdapterError` and the fallback chain demotes to the next provider.
 
 ---
 
@@ -128,7 +207,7 @@ The `agent-claude` provider in the example config `examples/providers-agent-cli.
 | Limitation | Details |
 |---|---|
 | **One-shot only** | No session continuation (resume). Every call launches a fresh CLI process; nothing from a previous call carries over (this is an intentional non-goal, not a bug) |
-| **Pseudo-streaming** | No CLI in Phase 1a exposes a stable token-level stream, so `stream()` just splits the final text from `generate()` into fixed-size chunks and yields them in order. The example config explicitly sets `capabilities.streaming: false` (the default `true` must be overridden) |
+| **Pseudo-streaming** | No implemented CLI exposes a stable token-level stream, so `stream()` just splits the final text from `generate()` into fixed-size chunks and yields them in order. The example config explicitly sets `capabilities.streaming: false` (the default `true` must be overridden) |
 | **May carry plan-mode framing** | The default `sandbox_mode: read_only` maps to `--permission-mode plan`. Plan mode is designed as a response format for an interactive human-review UI, so in one-shot execution the returned text can lean toward "here's my plan" phrasing rather than a direct answer, since no actual change is made |
 | **Consumes subscription quota** | Uses up the Claude Code subscription's 5-hour window / weekly quota. Zero API billing doesn't mean unlimited calls |
 | **Recursion cap** | Nested calls beyond `agent_depth_limit` (default 2, max 4) are rejected. Be careful if you build a setup where the agent CLI calls back into CodeRouter internally |
@@ -142,7 +221,8 @@ The `agent-claude` provider in the example config `examples/providers-agent-cli.
 | Fails with `Not logged in · Please run /login` | The claude CLI isn't logged in for the user/environment it's running as | First run `claude` interactively and check the `/login` state. On macOS headless runs, versions before v2.7.7 failed to forward the `USER` environment variable to the child process, causing this error; v2.7.7 fixes it by also inheriting `USER` / `LOGNAME` |
 | Requests are rejected / not routed, effectively "paid gate blocked" | The `agent_cli` provider has `paid: true` but `ALLOW_PAID` isn't set | For subscription usage, set `paid: false`. For metered API-key billing, set `ALLOW_PAID=true` when starting CodeRouter |
 | `claude exited 1: ...` shows a specific reason | The claude CLI sometimes reports auth/API errors as an `is_error: true` JSON document on **stdout** (with stderr left empty) and exits with code 1 | v2.7.7's `_error_detail()` now prefers the `result` field of that stdout `is_error` JSON (the actual error text, e.g. `Not logged in · Please run /login`) even when stderr is empty, and includes it in the raised error message — use the message shown as your lead |
-| CLI fails to launch (`failed to launch ...`) | `command` (defaults to the same name as `agent`) isn't on `PATH` | Confirm `claude --version` works. You can also point `command` at a full path |
+| Fails with `grok exited 1: ...` | The grok CLI exits with code 1 on auth/network/runtime errors, with the error text on stderr | The adapter includes a tail of stderr in the `AdapterError`, so use the message shown as your lead. For auth errors, re-run `grok login` and smoke-check that `grok models` works |
+| CLI fails to launch (`failed to launch ...`) | `command` (defaults to the same name as `agent`) isn't on `PATH` | Confirm `claude --version` / `grok --version` works. You can also point `command` at a full path |
 
 ---
 

--- a/docs/backends/external-agents.md
+++ b/docs/backends/external-agents.md
@@ -2,7 +2,7 @@
 
 > English: [`external-agents.en.md`](./external-agents.en.md)
 
-`kind: "agent_cli"` は、Claude Code CLI のような外部コーディングエージェントを CodeRouter の 1 プロバイダとして登録するアダプタである。v2.7.7 で新規追加された(Phase 1a)。詳細設計は [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) を参照。
+`kind: "agent_cli"` は、Claude Code CLI のような外部コーディングエージェントを CodeRouter の 1 プロバイダとして登録するアダプタである。v2.7.7 で新規追加され(Phase 1a: claude)、v2.7.8 で grok が追加された(Phase 1d)。詳細設計は [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) を参照。
 
 ---
 
@@ -11,16 +11,16 @@
 コーディングエージェント CLI は本来、ファイルを書き換えながら何ターンも自律的に動くステートフルな制御ループであり、CodeRouter の「1リクエスト = 1変換」という思想とは相性が悪い。`agent_cli` はこれを **ワンショット `exec`**(プロンプト in → 最終回答テキスト out)に押し込めることで両立させている。オーケストレーション(マルチターン制御・ツール実行)はエージェント CLI 内部で完結し、CodeRouter 側からは「1回の対話で答えを返すだけの1つのプロバイダ」として見える。
 
 - **対象 CLI**: `agent` フィールドで `claude` / `codex` / `gemini` / `grok` の4種を宣言できる。
-- **実装状況(v2.7.7 時点)**: **`claude`(Claude Code CLI)のみ実装済み**。`codex` / `gemini` / `grok` は `providers.yaml` のスキーマ上は書けるが、アダプタ構築時に必ず次のエラーで拒否される(Phase 1b〜1d は未実装)。
+- **実装状況(v2.7.8 時点)**: **`claude`(Claude Code CLI・Phase 1a)と `grok`(Grok CLI・Phase 1d)が実装済み**。`codex` / `gemini` は `providers.yaml` のスキーマ上は書けるが、アダプタ構築時に必ず AdapterError で拒否される(Phase 1b/1c は未実装)。エラーメッセージは概ね次の形である(正確な文言はバージョンにより変わりうる):
 
   ```
-  AdapterError: agent 'codex' is not implemented in Phase 1a (claude only).
-  Configure agent='claude' or wait for the agent's phase.
+  AdapterError: agent 'codex' is not implemented yet (implemented: claude, grok).
+  Wait for the agent's phase (1b/1c).
   ```
 
   この拒否は `retryable=False` — フォールバックチェーンに他プロバイダがあっても、設定ミスとして即座に停止する。
 
-- **新機能・claude のみ**という段階であり、本ドキュメントも claude ターゲットを前提に記述する。他ターゲットの設定例は `examples/providers-agent-cli.yaml` 末尾にコメントアウトされたプレビューとして置かれているが、動作しない。
+- 本ドキュメントの共通部分(認証設計・設定リファレンス・制限事項)は claude ターゲットを軸に記述し、grok 固有の挙動は [grok(Grok CLI)](#grokgrok-cli) セクションにまとめる。codex / gemini の設定例は `examples/providers-agent-cli.yaml` 末尾にコメントアウトされたプレビューとして置かれているが、動作しない。
 
 ---
 
@@ -96,30 +96,109 @@ Claude Code CLI は Keychain からトークンを解決する際に `USER` 環�
 
 | フィールド | 型 | 既定値 | 説明 |
 |---|---|---|---|
-| `agent` | `"claude" \| "codex" \| "gemini" \| "grok"` | (必須) | 呼び出す CLI。**v2.7.7 では `claude` 以外はアダプタ構築時に拒否される** |
+| `agent` | `"claude" \| "codex" \| "gemini" \| "grok"` | (必須) | 呼び出す CLI。**v2.7.8 で実装済みなのは `claude` と `grok`。`codex` / `gemini` はアダプタ構築時に拒否される** |
 | `command` | `str \| null` | `null`(未設定時は `agent` と同名) | CLI 実行ファイル名 or 絶対パス。`PATH` から解決 |
 | `workdir` | `str \| null` | `null`(未設定時は `~/.coderouter/agents/<プロバイダ名>`) | ワンショット exec の作業ディレクトリ。`~` / 環境変数展開あり。`..` を含むパスは拒否される |
 | `exec_timeout_s` | `float` | `600.0`(範囲 `1.0`–`1800.0`) | exec 全体の強制タイムアウト(秒)。`ProviderConfig.timeout_s` とは**別系統**(後者は agent_cli では使われない) |
 | `allow_file_writes` | `bool` | `false` | ファイル書き込みを許可するか。`false` のときは `sandbox_mode` の値に関わらず read-only にクランプされる |
-| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | claude の `--permission-mode` へマッピングされる([下表](#sandbox_mode--permission-mode-マッピング)参照) |
-| `model` | `str \| null` | `null`(未設定時は `ProviderConfig.model` を使用) | CLI の `--model` に渡すモデル名(`opus` / `sonnet` / `haiku` / `fable` 等) |
+| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | 各 CLI のサンドボックス/承認フラグへマッピングされる(claude は[下表](#sandbox_mode--permission-mode-マッピングclaude)、grok は [grok セクション](#sandbox_mode--grok-フラグのマッピング)参照) |
+| `model` | `str \| null` | `null`(未設定時は `ProviderConfig.model` を使用) | CLI の `--model` / `-m` に渡すモデル名(claude: `opus` / `sonnet` / `haiku` / `fable` 等、grok: `grok-4.5` 等) |
 | `max_turns` | `int \| null` | `8`(範囲 `1`–`50`) | CLI 内部のターン上限。`--max-turns` として渡る |
 | `passthrough_env` | `list[str]` | `[]` | 親環境から子プロセスへ転送する環境変数名のallowlist。`ANTHROPIC_API_KEY` はここに書かない限り渡らない |
 | `agent_depth_limit` | `int` | `2`(範囲 `1`–`4`) | 再帰ネストの上限。`CODEROUTER_AGENT_DEPTH` が上限以上なら `AdapterError(retryable=False)` で即停止 |
 
 `command` が未設定の場合は `agent` と同名がデフォルトになる。また、`allow_file_writes: true` と `sandbox_mode: read_only` を同時に指定すると、矛盾した設定として**設定読み込み時に `ValueError`** で弾かれる(書き込みを許可したいなら `sandbox_mode` を `edit` か `full_auto` にすること)。
 
-### `sandbox_mode` → `--permission-mode` マッピング
+### `sandbox_mode` → `--permission-mode` マッピング(claude)
 
 | `sandbox_mode` | claude `--permission-mode` | 備考 |
 |---|---|---|
 | `read_only`(既定) | `plan` | ファイル変更なし。`allow_file_writes=false` のとき常にこのモードにクランプされる |
 | `edit` | `acceptEdits` | ファイル編集を自動承認 |
-| `full_auto` | `acceptEdits` | Phase 1a では `edit` と同じマッピング(claude 側に full_auto 相当の別モードは未使用) |
+| `full_auto` | `acceptEdits` | claude では `edit` と同じマッピング(claude 側に full_auto 相当の別モードは未使用)。grok は `--always-approve` で区別される([grok セクション](#sandbox_mode--grok-フラグのマッピング)参照) |
 
 ### `paid: false` の理由
 
 サンプル設定 `examples/providers-agent-cli.yaml` の `agent-claude` プロバイダは `paid: false` になっている。これはサブスクリプション OAuth で運用する限り**従量課金が一切発生しない**(消費するのは後述の5時間窓/週次クォータのみ)ためである。API キー従量課金で運用したい場合は `paid: true` に変更し、CodeRouter 起動時に `ALLOW_PAID=true` を環境変数として渡す必要がある。`ALLOW_PAID` 環境変数は `providers.yaml` に書いた値(`allow_paid`)を**起動時に上書きする**ため、`paid: true` のプロバイダは `ALLOW_PAID` 未設定時にはルーティングから除外される点に注意する。
+
+---
+
+## grok(Grok CLI)
+
+v2.7.8(Phase 1d)で `agent: grok` が実装された。claude と同じワンショット exec 方式だが、プロンプトの渡し方・クロスセッションメモリの無効化・usage 報告の各点で grok 固有の挙動がある。以下は grok CLI **v0.2.93**([stable] チャネル、2026-07-10 実機検証)を基準とする。
+
+### 設定例
+
+```yaml
+providers:
+  - name: agent-grok
+    kind: agent_cli
+    model: grok-4.5              # 現行インストールの既定モデル。`grok models` で一覧確認
+    paid: false                  # サブスクリプション OAuth 運用 = 従量課金ゼロ
+    capabilities:
+      streaming: false
+      tools: false
+    agent_cli:
+      agent: grok
+      command: grok
+      workdir: ~/.coderouter/agents/grok
+      exec_timeout_s: 600
+      allow_file_writes: false
+      sandbox_mode: read_only
+      max_turns: 8
+      passthrough_env: []        # OAuth は ~/.grok/auth.json を HOME 継承で読むため空でよい。
+                                 # CI で API キーを使う場合のみ GROK_CODE_XAI_API_KEY を列挙
+```
+
+### アダプタが構築する argv
+
+`sandbox_mode: read_only`(既定)の場合、アダプタは次の argv を構築する。
+
+```
+grok --prompt-file <workdir>/.coderouter-prompt-<uuid>.txt \
+     --output-format json -m <model> --cwd <workdir> \
+     --max-turns <N> --no-memory \
+     --sandbox read-only --permission-mode plan
+```
+
+### プロンプトはファイル経由で渡す(`--prompt-file`)
+
+grok の `-p` / `--single` はプロンプトを **argv の値としてしか受け取らない**(stdin をプロンプトとして受け付けないことを実 CLI で確認済み)。argv に巨大なプロンプトを載せると Linux の `MAX_ARG_STRLEN`(約 128KiB)の上限に当たるうえ、`ps` からプロンプト全文が見えてしまう。そのためアダプタは隔離 workdir 内にパーミッション `0600` の一時ファイル(`.coderouter-prompt-<uuid>.txt`)としてプロンプトを書き出し、`--prompt-file` で渡す。この一時ファイルは exec 終了後に**必ず削除される**(タイムアウト・エラー経路を含む)。
+
+### `sandbox_mode` → grok フラグのマッピング
+
+claude と同様、`allow_file_writes=false` のときは `sandbox_mode` の値に関わらず `read_only` にクランプされる。
+
+| `sandbox_mode` | grok フラグ | 備考 |
+|---|---|---|
+| `read_only`(既定) | `--sandbox read-only --permission-mode plan` | ファイル変更なし。`allow_file_writes=false` のとき常にこのモードにクランプされる |
+| `edit` | `--sandbox workspace --permission-mode acceptEdits` | workspace サンドボックス内でのファイル編集を自動承認 |
+| `full_auto` | `--sandbox workspace --always-approve` | claude と異なり grok では `edit` と区別されたマッピングになる |
+
+### `--no-memory` を常に付与する
+
+grok CLI はセッションをまたぐメモリ機能を持つ。前回呼び出しの記憶が次の応答へ漏れることは CodeRouter の「1リクエスト = 1ステートレス変換」思想と衝突するため、アダプタは**常に** `--no-memory` を付与してこれを無効化する(設定で外すことはできない)。
+
+### JSON 出力と usage / cost
+
+`--output-format json` の出力は単一 JSON オブジェクト `{"text", "stopReason", "sessionId", "requestId", "thought"?}` である(grok v0.2.93 で確認)。`text` が最終回答として、`sessionId` がレスポンスメタデータ `coderouter_session_id` として返る。**トークン usage・コストのフィールドは存在しない**ため、usage はすべてゼロで報告され、`coderouter_cost_usd` も運用者が `ProviderConfig.cost` に単価を設定しない限り 0 のままである(claude が `total_cost_usd` を直接出力するのとは対照的)。JSON は防御的にパースされ、想定外の形は `AdapterError(retryable=True)` としてフォールバックチェーンを次のプロバイダへ進める。
+
+### 認証(サブスクリプション OAuth / API キー)
+
+grok CLI は OAuth によるサブスクリプションログインに対応している(SuperGrok / X Premium+)。資格情報は `~/.grok/auth.json` に保存され(7日で失効・自動リフレッシュあり。`GROK_HOME` で保管場所を上書き可能)、アダプタの `HOME` 継承によって `passthrough_env: []` のままで OAuth が機能する。セットアップ手順:
+
+1. `grok login` を実行してサブスクリプションログインを済ませる。
+2. `grok models` でモデル一覧が返ることをスモーク確認する。現行インストールでは `grok-4.5`(既定)と `grok-composer-2.5-fast` が返る。
+
+CI などで API キー従量課金を使う場合のみ、`passthrough_env: [GROK_CODE_XAI_API_KEY]` を列挙する。環境変数名は **`GROK_CODE_XAI_API_KEY` であり `XAI_API_KEY` ではない**点に注意。API キーが渡っている場合は OAuth より優先される。
+
+### エラー報告
+
+grok CLI は成功時に終了コード 0、認証・ネットワーク・実行時エラーでは終了コード 1 でエラーテキストを **stderr** に出力する。アダプタは stderr の末尾を `AdapterError` メッセージに含めるため、表示されたメッセージをそのまま手がかりにできる。
+
+### early beta であることの注意
+
+grok CLI は early beta である(v0.2.93 [stable] チャネル、2026-07-10 時点)。JSON スキーマが今後変わる可能性があるため、**バージョンの pin を推奨する**(`command` に固定版バイナリのフルパスを指定できる)。スキーマ変化が起きた場合も防御的パースにより retryable な `AdapterError` となり、フォールバックチェーンの次のプロバイダへ降格する。
 
 ---
 
@@ -142,7 +221,8 @@ Claude Code CLI は Keychain からトークンを解決する際に `USER` 環�
 | `Not logged in · Please run /login` で失敗する | claude CLI がその実行ユーザー/環境でログイン状態にない | まず `claude` を対話起動して `/login` の状態を確認する。macOS でヘッドレス実行している場合、v2.7.7 以前は `USER` 環境変数が子プロセスに渡らずこのエラーになっていたが、v2.7.7 で修正済み(`USER` / `LOGNAME` を継承するようになった) |
 | リクエストが `paid gate blocked` 相当で弾かれる/ルーティングされない | `agent_cli` プロバイダが `paid: true` なのに `ALLOW_PAID` が立っていない | サブスク運用なら `paid: false` にする。API キー従量課金で使うなら CodeRouter 起動時に `ALLOW_PAID=true` を設定する |
 | `claude exited 1: ...` のエラーメッセージに具体的な理由が出る | claude CLI は認証エラー等を **stdout** に `is_error: true` の JSON として出力し(stderr は空のまま)終了コード1で終わることがある | v2.7.7 の `_error_detail()` は stderr が空でも stdout の `is_error` JSON から `result` フィールド(実際のエラー文言、例: `Not logged in · Please run /login`)を優先的に拾ってエラーメッセージに含めるようになっている。表示されたメッセージをそのまま手がかりにできる |
-| CLI 起動に失敗する(`failed to launch ...`) | `command`(既定は `agent` と同名)が `PATH` 上に無い | `claude --version` が通ることを確認する。フルパスを `command` に指定してもよい |
+| `grok exited 1: ...` で失敗する | grok CLI は認証・ネットワーク・実行時エラーを終了コード1で終わり、エラーテキストを stderr に出す | アダプタが stderr の末尾を `AdapterError` に含めるので、そのメッセージを手がかりにする。認証エラーなら `grok login` を再実行し、`grok models` が通ることをスモーク確認する |
+| CLI 起動に失敗する(`failed to launch ...`) | `command`(既定は `agent` と同名)が `PATH` 上に無い | `claude --version` / `grok --version` が通ることを確認する。フルパスを `command` に指定してもよい |
 
 ---
 

--- a/docs/designs/external-agents-adapter.md
+++ b/docs/designs/external-agents-adapter.md
@@ -2,7 +2,7 @@
 
 > 対象バージョン: CodeRouter v2.x 系 / Phase 1（in-core adapter）
 > 関連: [`docs/future.md`](../future.md) §1.2・§5、[`docs/backends/launcher.md`](../backends/launcher.md)
-> ステータス: 設計確定（実装前）
+> ステータス: 設計確定 / Phase 1a (claude)・Phase 1d (grok) 実装済み
 
 本設計書は、OpenAI Codex CLI・Google Gemini CLI・xAI Grok・Anthropic Claude Code CLI の4つの外部コーディングエージェントを、CodeRouter の新しいアダプタ種別 `kind="agent_cli"` として本体に組み込む方式を定義するものである。CLI のフラグ・認証仕様はすべて調査レポート（`RESEARCH-cli.md`、2026-07 時点）を、コード上の拡張点はすべてコード解析報告書（`ANALYSIS-code.md`）を典拠とする。ユーザー確定事項（`DECISIONS.md`）は拘束条件であり、本書はそれを厳密に実装する。
 
@@ -602,5 +602,22 @@ Grok の公式 API は OpenAI 互換であり、**既存 `kind="openai_compat"` 
 | 資格情報解決 | `config/loader.py` L95 |
 | テスト雛形 | `tests/test_launcher_mtp.py` L340, L368 |
 | 設計思想（透過性・ステートレス） | `docs/future.md` §1.2 L164, §5 L636-815（特に L647, L677） |
-</content>
-</invoke>
+
+### 11.3 Phase 1d 実CLI検証結果（grok v0.2.93, 2026-07-10）
+
+Phase 1d（grok）実装時に、設計時点の調査（`RESEARCH-cli.md`、2026-07 時点）と実 CLI（grok v0.2.93、[stable] チャネル）との差分を検証した。本設計書の本文（§3.1・§5.1.5・§5.2.1・§5.3.3・§5.4・§11.1）のうち grok に関する記述は以下の検証結果で読み替えること（歴史的記録として本文は改変しない）。
+
+| 項目 | 設計時の想定 | 実 CLI での検証結果（v0.2.93） |
+|---|---|---|
+| `--sandbox` | 値なしフラグ（書込拒否）と想定（§5.4） | **プロファイル値を取る**: `--sandbox off\|workspace\|read-only\|strict`。read_only は `--sandbox read-only` |
+| 承認モード | `--allow`（値未確定）/ `--always-approve` のみ把握 | **`--permission-mode` が存在**し、Claude Code 互換の値を取る。read_only=`--permission-mode plan`、edit=`--sandbox workspace --permission-mode acceptEdits`、full_auto=`--sandbox workspace --always-approve` |
+| プロンプト投入 | `-p "<prompt>"`（§5.1.5） | `-p` / `--single` は **argv 値必須で stdin をプロンプトとして受け付けない**。argv の肥大化（Linux MAX_ARG_STRLEN 約128KiB）と `ps` 露出を避けるため、**`--prompt-file`**（workdir 内 0600 一時ファイル、終了後必ず削除）を採用した |
+| 認証 | 「grok はサブスク非対応・`XAI_API_KEY` 必須」（§5.3.3・§11.1） | **廃止された前提**。OAuth サブスクリプションログインに対応（`grok login`、SuperGrok / X Premium+。資格情報は `~/.grok/auth.json`、7日失効・自動リフレッシュ、`GROK_HOME` で上書き可）。`HOME` 継承により `passthrough_env: []` で動作する |
+| API キー環境変数 | `XAI_API_KEY` | **`GROK_CODE_XAI_API_KEY`**（`XAI_API_KEY` ではない）。転送時は OAuth より優先される |
+| JSON 出力 | 「応答本文フィールド」「トークンフィールド」と仮置き（§5.1.6） | 単一 JSON `{"text", "stopReason", "sessionId", "requestId", "thought"?}`。**usage / cost フィールドは存在しない** → usage はゼロ報告、cost は `ProviderConfig.cost` 単価設定時のみ算出 |
+| モデル | `grok-code-fast-1`（§3.1） | **`grok-code-fast-1` は 2026-05-15 に廃止**。現行は `grok-4.5`（既定）/ `grok-composer-2.5-fast`（`grok models` で一覧） |
+| `--max-turns` | 存在（§11.1） | **確認済み**（そのまま採用） |
+| `--allow` / `--deny` | 値の形式未確認（§5.4 注記） | ToolPrefix（glob）形式のルールを取ることを確認。ただし **Phase 1d のアダプタでは使用しない** |
+| メモリ | （記載なし） | grok はクロスセッションメモリを持つ。ステートレス性維持のためアダプタは **`--no-memory` を常時付与** |
+
+あわせて、§5.2.1 の検証ルール #1（`agent=="grok"` かつ `passthrough_env` に `XAI_API_KEY` が無い場合の警告）は前提の消滅により**廃止**した（実装には含まれない）。§9.2 の「API 直（openai_compat）推奨」は引き続き有効な代替経路である。

--- a/examples/providers-agent-cli.yaml
+++ b/examples/providers-agent-cli.yaml
@@ -1,24 +1,26 @@
 # ============================================================
 # CodeRouter providers.yaml — 外部コーディングエージェント CLI (agent_cli)
-# 【カテゴリ】 kind="agent_cli" アダプタ / Phase 1a (claude のみ実装)
+# 【カテゴリ】 kind="agent_cli" アダプタ / Phase 1a (claude)・Phase 1d (grok) 実装済み
 #
 # 出典: docs/designs/external-agents-adapter.md
-# 目的: Claude Code CLI (`claude -p --output-format json`) を CodeRouter の
-#       1プロバイダとして登録し、他のオーケストレータ (別の Claude Code /
-#       Cursor 等) から「1つのモデル」として透過的に呼び出せるようにする。
+# 目的: Claude Code CLI (`claude -p --output-format json`) や Grok CLI を
+#       CodeRouter の1プロバイダとして登録し、他のオーケストレータ
+#       (別の Claude Code / Cursor 等) から「1つのモデル」として透過的に
+#       呼び出せるようにする。
 #       CodeRouter はワンショット exec (プロンプト in → テキスト out) の
 #       1変換だけを担い、エージェントのマルチターン制御ループそのものは
 #       中で完結させる (future.md の「1リクエスト=1変換」思想を維持)。
 #
-# Phase 1a スコープ:
-#   - agent: claude のみ実装済み。サブスクリプション OAuth
-#     (`~/.claude/.credentials.json` または `claude setup-token`) を優先し、
-#     子プロセスには ANTHROPIC_API_KEY を含む親環境を継承させない
+# 実装スコープ (v2.7.8 時点):
+#   - agent: claude (Phase 1a) と grok (Phase 1d) が実装済み。いずれも
+#     サブスクリプション OAuth を優先し (claude: `~/.claude/.credentials.json`
+#     または `claude setup-token`、grok: `~/.grok/auth.json`)、子プロセスには
+#     ANTHROPIC_API_KEY 等を含む親環境を継承させない
 #     (env allowlist、下記 passthrough_env 参照)。
-#   - agent: codex / gemini / grok は config スキーマ上は宣言できるが、
-#     アダプタ構築時に AdapterError("not implemented in Phase 1a") で
-#     拒否される。末尾にコメントアウトした Phase 1b-1d のプレビュー
-#     ブロック (未実装) を参照。
+#   - agent: codex / gemini は config スキーマ上は宣言できるが、
+#     アダプタ構築時に AdapterError ("not implemented yet" — 実装済み
+#     エージェントの列挙付き) で拒否される。末尾にコメントアウトした
+#     Phase 1b-1c のプレビューブロック (未実装) を参照。
 #   - 既定は read_only (書き込み不可)。書き込みを許可するには
 #     allow_file_writes: true と sandbox_mode: edit|full_auto を両方
 #     明示する必要がある (片方だけだと config load 時に ValueError)。
@@ -39,6 +41,11 @@
 #          -H 'Content-Type: application/json' \
 #          -H 'X-CodeRouter-Profile: claude-agent' \
 #          -d '{"model":"opus","messages":[{"role":"user","content":"1行でこんにちはと言って"}]}'
+#      下記の grok ブロックを有効化した場合の動作確認 (要 `grok login` 済み):
+#        curl http://localhost:8088/v1/chat/completions \
+#          -H 'Content-Type: application/json' \
+#          -H 'X-CodeRouter-Profile: grok' \
+#          -d '{"model":"grok-4.5","messages":[{"role":"user","content":"1行でこんにちはと言って"}]}'
 #
 # 注意: この例は claude をサブスクリプション OAuth で使う前提のため
 #   paid: false としている (従量課金が発生しない経路。サブスクの
@@ -72,6 +79,49 @@ providers:
       passthrough_env: [CLAUDE_CODE_OAUTH_TOKEN]   # setup-token を使う場合のみ (任意)
       agent_depth_limit: 2         # ネスト再帰 (CODEROUTER_AGENT_DEPTH) の上限
 
+  # ---- xAI Grok CLI (Phase 1d・実装済み — v2.7.8) ----
+  # 実装済みだが既定ではコメントアウトしてある: このファイルをそのまま
+  # コピーしても grok CLI のインストールを要求しないようにするため。
+  # grok CLI (v0.2.93 [stable] で検証) を導入し `grok login` を済ませて
+  # から有効化すること (`grok models` が通れば認証 OK)。
+  # early beta のためバージョン pin 推奨 (command にフルパス指定可)。
+  #
+  # 認証: OAuth サブスクリプションログイン対応 (SuperGrok / X Premium+、
+  #   資格情報は ~/.grok/auth.json・7日失効・自動リフレッシュ)。かつての
+  #   「grok は API 課金必須 (サブスク非対応)」という前提は Grok Build
+  #   beta (2026-05) 以降 obsolete。
+  # usage/cost: grok の JSON 出力にはトークン usage / コストのフィールドが
+  #   無いため usage はゼロ報告、cost も ProviderConfig.cost に単価を
+  #   設定しない限り 0 のまま。
+  #
+  # - name: agent-grok
+  #   kind: agent_cli
+  #   model: grok-4.5              # 現行の既定モデル (`grok models` で一覧)
+  #   paid: false                  # サブスク OAuth 運用 = 従量課金ゼロ
+  #   capabilities:
+  #     streaming: false
+  #     tools: false
+  #   agent_cli:
+  #     agent: grok
+  #     command: grok
+  #     workdir: ~/.coderouter/agents/grok
+  #     exec_timeout_s: 600
+  #     allow_file_writes: false
+  #     sandbox_mode: read_only    # --sandbox read-only --permission-mode plan にマップ
+  #     max_turns: 8               # --max-turns
+  #     passthrough_env: []        # OAuth は ~/.grok/auth.json を HOME 継承で読むため空でよい。
+  #                                # CI で API キーを使う場合のみ GROK_CODE_XAI_API_KEY を
+  #                                # 列挙する (XAI_API_KEY ではない点に注意。転送時は
+  #                                # OAuth より優先される)
+  #
+  # 有効化する場合は profiles にも次を追加する:
+  #   - name: grok
+  #     providers: [agent-grok]
+  #
+  # 補足: Grok の公式 API は OpenAI 互換なので、CLI を経由しない
+  #   kind: openai_compat + base_url: https://api.x.ai/v1 という代替経路も
+  #   引き続き有効 (docs/designs/external-agents-adapter.md §9.2)。
+
 profiles:
   # claude-agent — Claude Code CLI 専用プロファイル。単独 (fallback なし)。
   # agent_cli は「プロンプト in → テキスト out」の不透明なテキスト
@@ -89,15 +139,14 @@ profiles:
 #       match: { model_pattern: "claude-agent.*" }
 
 # ============================================================
-# 以下はプレビュー (Phase 1b-1d・未実装) — コメントアウト
+# 以下はプレビュー (Phase 1b-1c・未実装) — コメントアウト
 #
-# 下記の agent: codex / gemini / grok は config スキーマとしては
-# 有効 (providers.yaml として読み込める) だが、AgentCliAdapter の
-# __init__ が Phase 1a では claude 以外を拒否するため、実際に
-# リクエストを投げると起動時に
-#   AdapterError: agent 'codex' is not implemented in Phase 1a
-#   (claude only). Configure agent='claude' or wait for the agent's
-#   phase.
+# 下記の agent: codex / gemini は config スキーマとしては
+# 有効 (providers.yaml として読み込める) だが、AgentCliAdapter が
+# claude / grok 以外を拒否するため、実際にリクエストを投げると
+# 起動時におおよそ次の形の AdapterError (正確な文言は変わりうる)
+#   AdapterError: agent 'codex' is not implemented yet
+#   (implemented: claude, grok). Wait for the agent's phase (1b/1c).
 # で失敗する (retryable=False)。将来のフェーズが実装されるまでの
 # forward-compatible なプレースホルダとして参照用に残してある。
 # 詳細: docs/designs/external-agents-adapter.md §3, §9
@@ -108,7 +157,7 @@ profiles:
 #   - name: agent-codex
 #     kind: agent_cli
 #     model: gpt-5.5
-#     paid: false               # サブスク OAuth 運用なら false (grok のみ API 従量で true)
+#     paid: false               # サブスク OAuth 運用なら false
 #     capabilities:
 #       streaming: false
 #     agent_cli:
@@ -124,7 +173,7 @@ profiles:
 #   - name: agent-gemini
 #     kind: agent_cli
 #     model: gemini-2.5-pro
-#     paid: false               # サブスク OAuth 運用なら false (grok のみ API 従量で true)
+#     paid: false               # サブスク OAuth 運用なら false
 #     capabilities:
 #       streaming: false
 #     agent_cli:
@@ -137,30 +186,8 @@ profiles:
 #       sandbox_mode: read_only
 #       passthrough_env: [GEMINI_API_KEY]   # OAuth キャッシュが無い場合の保険
 #
-#   # ---- xAI Grok (Phase 1d・未実装・CLI 経路) ----
-#   # 補足: Grok の公式 API は OpenAI 互換なので、CLI 経路より
-#   #   kind: openai_compat + base_url: https://api.x.ai/v1 の方が
-#   #   現状は安定 (§9.2)。以下は CLI 統一運用を望む場合の代替経路。
-#   - name: agent-grok
-#     kind: agent_cli
-#     model: grok-code-fast-1
-#     paid: true
-#     capabilities:
-#       streaming: false
-#     agent_cli:
-#       agent: grok
-#       command: grok
-#       workdir: ~/.coderouter/agents/grok
-#       exec_timeout_s: 600
-#       allow_file_writes: false
-#       max_turns: 8
-#       sandbox_mode: read_only
-#       passthrough_env: [XAI_API_KEY]      # grok は API 課金必須 (サブスク非対応)
-#
 # profiles:
 #   - name: codex
 #     providers: [agent-codex]
 #   - name: gemini
 #     providers: [agent-gemini]
-#   - name: grok
-#     providers: [agent-grok]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 # in plan.md §11.B; once granted, this name will become an alias and
 # `coderouter` will become the canonical distribution name.
 name = "coderouter-cli"
-version = "2.7.7"
+version = "2.7.8"
 description = "Local-first, free-first, fallback-built-in LLM router. Claude Code / OpenAI compatible."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,15 +1,20 @@
-"""Tests for the agent_cli adapter (Phase 1a — claude only).
+"""Tests for the agent_cli adapter (Phase 1a claude + Phase 1d grok).
 
-Implements the design's §8 test plan for the Phase 1a scope:
+Implements the design's §8 test plan for the Phase 1a/1d scope:
 
 * T1  argv construction (model / max-turns / permission-mode mapping,
-      allow_file_writes clamp).
-* T2  claude JSON parsing (success / is_error / malformed / missing fields).
-* T3  stubbed subprocess via ``asyncio.create_subprocess_exec`` monkeypatch.
+      allow_file_writes clamp) — for both claude and grok (grok adds the
+      --prompt-file / --no-memory / --sandbox shape).
+* T2  claude / grok JSON parsing (success / is_error / malformed / missing
+      fields; grok's zero-usage + sessionId meta).
+* T3  stubbed subprocess via ``asyncio.create_subprocess_exec`` monkeypatch
+      (grok additionally checks the prompt-file lifecycle: 0600 file exists
+      and contains the prompt DURING the exec, deleted afterwards, also on
+      failure / timeout paths).
 * T4  TestClient E2E through ``POST /v1/chat/completions``.
 * T6  timeout → process-group kill + retryable AdapterError.
 * T7  child-env isolation (no ANTHROPIC_API_KEY leak, NO_COLOR present,
-      passthrough allowlist, depth +1).
+      passthrough allowlist incl. GROK_CODE_XAI_API_KEY, depth +1).
 * T8  recursion depth limit → non-retryable AdapterError.
 
 Plus config-schema validation (agent_cli required, base_url optionality,
@@ -24,7 +29,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import stat
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -64,6 +72,20 @@ CLAUDE_RESULT = {
 }
 CLAUDE_JSON = json.dumps(CLAUDE_RESULT).encode("utf-8")
 
+# ---------------------------------------------------------------------------
+# Canned grok `--output-format json` result (verified on grok CLI v0.2.93 —
+# NO token usage / cost fields exist; "thought" may or may not be present)
+# ---------------------------------------------------------------------------
+
+GROK_RESULT = {
+    "text": "Hello from grok",
+    "stopReason": "EndTurn",
+    "sessionId": "0f9b6a3c-1d2e-4f56-8a7b-9c0d1e2f3a4b",
+    "requestId": "7a1b2c3d-4e5f-4a6b-8c7d-9e0f1a2b3c4d",
+    "thought": "The user greeted me; respond briefly.",
+}
+GROK_JSON = json.dumps(GROK_RESULT).encode("utf-8")
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -78,6 +100,21 @@ def _make_adapter(**agent_cli_overrides: object) -> AgentCliAdapter:
         name="agent-claude",
         kind="agent_cli",
         model="opus",
+        paid=True,
+        capabilities=Capabilities(streaming=False),
+        agent_cli=AgentCliConfig(**acfg),  # type: ignore[arg-type]
+    )
+    return AgentCliAdapter(provider)
+
+
+def _make_grok_adapter(**agent_cli_overrides: object) -> AgentCliAdapter:
+    """Build an AgentCliAdapter with a grok sub-config + overrides."""
+    acfg: dict[str, object] = {"agent": "grok"}
+    acfg.update(agent_cli_overrides)
+    provider = ProviderConfig(
+        name="agent-grok",
+        kind="agent_cli",
+        model="grok-4.5",
         paid=True,
         capabilities=Capabilities(streaming=False),
         agent_cli=AgentCliConfig(**acfg),  # type: ignore[arg-type]
@@ -121,6 +158,28 @@ class _FakeProc:
 
     def kill(self) -> None:
         self.killed = True
+
+
+class _GrokFakeProc(_FakeProc):
+    """_FakeProc that snapshots the ``--prompt-file`` contents at
+    ``communicate()`` time — i.e. while the real CLI would be running — so
+    tests can prove the file existed, held the prompt, and was mode 0600
+    DURING the exec (it is deleted again before generate() returns)."""
+
+    def __init__(self, captured: list[list[str]], **kwargs: object) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self._captured = captured
+        self.prompt_file_path: str | None = None
+        self.prompt_file_content: str | None = None
+        self.prompt_file_mode: int | None = None
+
+    async def communicate(self, input: bytes | None = None) -> tuple[bytes, bytes]:
+        argv = self._captured[0]
+        path = argv[argv.index("--prompt-file") + 1]
+        self.prompt_file_path = path
+        self.prompt_file_mode = stat.S_IMODE(os.stat(path).st_mode)
+        self.prompt_file_content = Path(path).read_text(encoding="utf-8")
+        return await super().communicate(input)
 
 
 def _patch_exec(monkeypatch: pytest.MonkeyPatch, proc: _FakeProc) -> list[list[str]]:
@@ -197,6 +256,81 @@ def test_argv_never_includes_bare_flag() -> None:
 
 
 # ---------------------------------------------------------------------------
+# T1 (grok) — argv construction
+# ---------------------------------------------------------------------------
+
+
+def test_grok_argv_read_only_default_full_snapshot() -> None:
+    adapter = _make_grok_adapter(workdir="/tmp/wd")
+    argv = adapter._build_grok_argv("/tmp/wd", "/tmp/wd/.coderouter-prompt-x.txt")
+    assert argv == [
+        "grok",
+        "--prompt-file",
+        "/tmp/wd/.coderouter-prompt-x.txt",
+        "--output-format",
+        "json",
+        "-m",
+        "grok-4.5",
+        "--cwd",
+        "/tmp/wd",
+        "--max-turns",
+        "8",
+        "--no-memory",
+        "--sandbox",
+        "read-only",
+        "--permission-mode",
+        "plan",
+    ]
+
+
+def test_grok_argv_edit_maps_workspace_accept_edits() -> None:
+    adapter = _make_grok_adapter(sandbox_mode="edit", allow_file_writes=True)
+    argv = adapter._build_grok_argv("/w", "/w/p.txt")
+    assert argv[argv.index("--sandbox") + 1] == "workspace"
+    assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
+
+
+def test_grok_argv_full_auto_maps_always_approve() -> None:
+    adapter = _make_grok_adapter(sandbox_mode="full_auto", allow_file_writes=True)
+    argv = adapter._build_grok_argv("/w", "/w/p.txt")
+    assert argv[argv.index("--sandbox") + 1] == "workspace"
+    assert "--always-approve" in argv
+    # full_auto uses auto-approval INSTEAD of a permission mode.
+    assert "--permission-mode" not in argv
+
+
+def test_grok_argv_read_only_clamp_when_writes_disabled() -> None:
+    # sandbox_mode=edit but allow_file_writes=False → clamp to read-only/plan.
+    adapter = _make_grok_adapter(sandbox_mode="edit", allow_file_writes=False)
+    argv = adapter._build_grok_argv("/w", "/w/p.txt")
+    assert argv[argv.index("--sandbox") + 1] == "read-only"
+    assert argv[argv.index("--permission-mode") + 1] == "plan"
+
+
+def test_grok_argv_omits_max_turns_when_none() -> None:
+    adapter = _make_grok_adapter(max_turns=None)
+    argv = adapter._build_grok_argv("/w", "/w/p.txt")
+    assert "--max-turns" not in argv
+
+
+def test_grok_argv_model_override() -> None:
+    adapter = _make_grok_adapter(model="grok-composer-2.5-fast")
+    argv = adapter._build_grok_argv("/w", "/w/p.txt")
+    assert argv[argv.index("-m") + 1] == "grok-composer-2.5-fast"
+
+
+def test_grok_argv_no_memory_and_no_prompt_in_argv() -> None:
+    adapter = _make_grok_adapter()
+    argv = adapter._build_grok_argv("/w", "/w/p.txt")
+    # --no-memory enforces one-request-one-transformation statelessness.
+    assert "--no-memory" in argv
+    # The builder only ever receives the prompt-FILE path — grok's -p/--single
+    # (prompt as argv value) is never used, so prompt text can't reach argv.
+    assert "-p" not in argv
+    assert "--single" not in argv
+
+
+# ---------------------------------------------------------------------------
 # T7 — child-env isolation
 # ---------------------------------------------------------------------------
 
@@ -230,8 +364,7 @@ def test_error_detail_prefers_is_error_stdout_json() -> None:
     from coderouter.adapters.agent_cli import AgentCliAdapter
 
     stdout = (
-        b'{"type":"result","is_error":true,'
-        b'"result":"Not logged in \xc2\xb7 Please run /login"}'
+        b'{"type":"result","is_error":true,"result":"Not logged in \xc2\xb7 Please run /login"}'
     )
     detail = AgentCliAdapter._error_detail(stdout, b"")
     assert "Not logged in" in detail
@@ -252,6 +385,17 @@ def test_env_passthrough_allowlist_only(monkeypatch: pytest.MonkeyPatch) -> None
     env = adapter._build_child_env()
     assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "tok-123"
     assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_env_grok_api_key_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GROK_CODE_XAI_API_KEY (grok's CI key env — NOT XAI_API_KEY) is
+    forwarded only when allowlisted; OAuth under ~/.grok rides on HOME."""
+    monkeypatch.setenv("GROK_CODE_XAI_API_KEY", "xai-tok-123")
+    monkeypatch.setenv("XAI_API_KEY", "wrong-var-should-not-leak")
+    adapter = _make_grok_adapter(passthrough_env=["GROK_CODE_XAI_API_KEY"])
+    env = adapter._build_child_env()
+    assert env["GROK_CODE_XAI_API_KEY"] == "xai-tok-123"
+    assert "XAI_API_KEY" not in env
 
 
 def test_env_depth_incremented(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -318,13 +462,68 @@ def test_parse_empty_stdout_raises_retryable() -> None:
 
 
 # ---------------------------------------------------------------------------
+# T2 (grok) — grok JSON parsing
+# ---------------------------------------------------------------------------
+
+
+def test_grok_parse_success() -> None:
+    adapter = _make_grok_adapter()
+    text, usage, meta = adapter._parse_grok(GROK_JSON, b"")
+    assert text == "Hello from grok"
+    # grok emits NO token counts — usage is all zeros (cost stays 0 unless
+    # the operator sets ProviderConfig.cost, design §5.1.6).
+    assert usage == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    # sessionId is the only surfaced meta; thought / requestId / stopReason
+    # are deliberately ignored.
+    assert meta == {"coderouter_session_id": GROK_RESULT["sessionId"]}
+
+
+def test_grok_parse_missing_text_raises_retryable() -> None:
+    adapter = _make_grok_adapter()
+    payload = json.dumps({"stopReason": "EndTurn", "sessionId": "s"}).encode()
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_grok(payload, b"")
+    assert info.value.retryable is True
+    assert "missing string 'text'" in str(info.value)
+
+
+def test_grok_parse_non_json_raises_retryable() -> None:
+    adapter = _make_grok_adapter()
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_grok(b"grok exploded {", b"")
+    assert info.value.retryable is True
+
+
+def test_grok_parse_non_object_raises_retryable() -> None:
+    adapter = _make_grok_adapter()
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_grok(b'["not", "an", "object"]', b"")
+    assert info.value.retryable is True
+
+
+def test_grok_parse_empty_stdout_raises_retryable() -> None:
+    adapter = _make_grok_adapter()
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_grok(b"   \n", b"")
+    assert info.value.retryable is True
+
+
+def test_grok_parse_thought_field_ignored() -> None:
+    # "thought" may or may not be present (early beta) — absence is fine and
+    # presence never leaks into text/usage/meta.
+    adapter = _make_grok_adapter()
+    payload = json.dumps({"text": "ok", "sessionId": "s-1"}).encode()
+    text, _usage, meta = adapter._parse_grok(payload, b"")
+    assert text == "ok"
+    assert meta == {"coderouter_session_id": "s-1"}
+
+
+# ---------------------------------------------------------------------------
 # T3 — generate() with a stubbed subprocess
 # ---------------------------------------------------------------------------
 
 
-async def test_generate_success(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: object
-) -> None:
+async def test_generate_success(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
     proc = _FakeProc(stdout=CLAUDE_JSON, returncode=0)
     captured = _patch_exec(monkeypatch, proc)
     adapter = _make_adapter(workdir=str(tmp_path))
@@ -354,6 +553,65 @@ async def test_generate_nonzero_exit_is_retryable(
 
 
 # ---------------------------------------------------------------------------
+# T3 (grok) — generate() with a stubbed subprocess + prompt-file lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_grok_generate_success_prompt_file_lifecycle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: list[list[str]] = []
+    proc = _GrokFakeProc(captured, stdout=GROK_JSON, returncode=0)
+
+    async def fake_exec(*argv: str, **kwargs: object) -> _GrokFakeProc:
+        captured.append(list(argv))
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    adapter = _make_grok_adapter(workdir=str(tmp_path))
+
+    resp = await adapter.generate(_request())
+
+    assert resp.choices[0]["message"]["content"] == "Hello from grok"
+    assert resp.coderouter_provider == "agent-grok"
+    assert resp.model == "grok-4.5"
+    assert resp.coderouter_session_id == GROK_RESULT["sessionId"]
+    # grok takes the prompt via --prompt-file — never stdin, never argv.
+    assert proc.stdin_received is None
+    argv = captured[0]
+    assert "--prompt-file" in argv
+    assert all("hi there" not in arg for arg in argv)
+    # DURING the exec the private prompt file existed in the workdir with
+    # mode 0600 and held the rendered prompt (_GrokFakeProc snapshots it
+    # inside communicate()).
+    assert proc.prompt_file_path is not None
+    assert proc.prompt_file_path.startswith(str(tmp_path))
+    assert Path(proc.prompt_file_path).name.startswith(".coderouter-prompt-")
+    assert proc.prompt_file_mode == 0o600
+    assert proc.prompt_file_content is not None
+    assert "hi there" in proc.prompt_file_content
+    # ...and it is deleted once generate() returns.
+    assert not os.path.exists(proc.prompt_file_path)
+    assert list(tmp_path.glob(".coderouter-prompt-*")) == []
+
+
+async def test_grok_generate_nonzero_exit_cleans_prompt_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    proc = _FakeProc(stdout=b"", stderr=b"auth failed", returncode=1)
+    captured = _patch_exec(monkeypatch, proc)
+    adapter = _make_grok_adapter(workdir=str(tmp_path))
+    with pytest.raises(AdapterError) as info:
+        await adapter.generate(_request())
+    assert info.value.retryable is True
+    # The prompt file is cleaned up on the failure path too.
+    argv = captured[0]
+    path = argv[argv.index("--prompt-file") + 1]
+    assert not os.path.exists(path)
+    assert list(tmp_path.glob(".coderouter-prompt-*")) == []
+
+
+# ---------------------------------------------------------------------------
 # T6 — timeout → process-group kill
 # ---------------------------------------------------------------------------
 
@@ -380,6 +638,32 @@ async def test_generate_timeout_kills_and_raises_retryable(
     assert "timed out" in str(info.value)
     # The fake pid can't be group-killed, so the fallback direct kill fired.
     assert proc.killed is True
+
+
+async def test_grok_generate_timeout_cleans_prompt_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    proc = _FakeProc(hang=True)
+    captured = _patch_exec(monkeypatch, proc)
+    adapter = _make_grok_adapter(workdir=str(tmp_path), exec_timeout_s=1.0)
+
+    # Force an immediate timeout regardless of wall-clock so the test is fast.
+    async def instant_timeout(coro: object, timeout: float) -> None:
+        if hasattr(coro, "close"):
+            coro.close()  # type: ignore[attr-defined]
+        raise TimeoutError
+
+    monkeypatch.setattr(asyncio, "wait_for", instant_timeout)
+
+    with pytest.raises(AdapterError) as info:
+        await adapter.generate(_request())
+    assert info.value.retryable is True
+    assert "timed out" in str(info.value)
+    # Even on the timeout path the finally block removed the prompt file.
+    argv = captured[0]
+    path = argv[argv.index("--prompt-file") + 1]
+    assert not os.path.exists(path)
+    assert list(tmp_path.glob(".coderouter-prompt-*")) == []
 
 
 # ---------------------------------------------------------------------------
@@ -413,9 +697,7 @@ async def test_healthcheck_missing_binary(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 async def test_healthcheck_present_binary(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "coderouter.adapters.agent_cli.shutil.which", lambda _c: "/usr/bin/claude"
-    )
+    monkeypatch.setattr("coderouter.adapters.agent_cli.shutil.which", lambda _c: "/usr/bin/claude")
     adapter = _make_adapter()
     assert await adapter.healthcheck() is True
 
@@ -431,7 +713,8 @@ def test_unsupported_agent_raises_non_retryable() -> None:
     with pytest.raises(AdapterError) as info:
         AgentCliAdapter(provider)
     assert info.value.retryable is False
-    assert "Phase 1a" in str(info.value)
+    assert "not implemented yet" in str(info.value)
+    assert "implemented: claude, grok" in str(info.value)
 
 
 # ---------------------------------------------------------------------------
@@ -503,9 +786,7 @@ def e2e_client(
         return proc
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-    monkeypatch.setattr(
-        "coderouter.ingress.app.load_config", lambda path=None: e2e_config
-    )
+    monkeypatch.setattr("coderouter.ingress.app.load_config", lambda path=None: e2e_config)
     uninstall_collector()
     app = create_app()
     try:
@@ -527,3 +808,61 @@ def test_e2e_chat_completions(e2e_client: TestClient) -> None:
     assert body["coderouter_provider"] == "agent-claude"
     # Cost from claude's total_cost_usd propagated to the client-visible body.
     assert body["coderouter_cost_usd"] == pytest.approx(0.0123)
+
+
+# ---------------------------------------------------------------------------
+# T4 (grok) — TestClient E2E through /v1/chat/completions
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def grok_e2e_config(tmp_path: Path) -> CodeRouterConfig:
+    return CodeRouterConfig(
+        allow_paid=True,
+        default_profile="grok-agent",
+        providers=[
+            ProviderConfig(
+                name="agent-grok",
+                kind="agent_cli",
+                model="grok-4.5",
+                paid=True,
+                capabilities=Capabilities(streaming=False),
+                agent_cli=AgentCliConfig(agent="grok", workdir=str(tmp_path)),
+            ),
+        ],
+        profiles=[FallbackChain(name="grok-agent", providers=["agent-grok"])],
+    )
+
+
+@pytest.fixture
+def grok_e2e_client(
+    grok_e2e_config: CodeRouterConfig, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[TestClient]:
+    proc = _FakeProc(stdout=GROK_JSON, returncode=0)
+
+    async def fake_exec(*argv: str, **kwargs: object) -> _FakeProc:
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr("coderouter.ingress.app.load_config", lambda path=None: grok_e2e_config)
+    uninstall_collector()
+    app = create_app()
+    try:
+        with TestClient(app) as tc:
+            yield tc
+    finally:
+        uninstall_collector()
+
+
+def test_e2e_grok_chat_completions(grok_e2e_client: TestClient) -> None:
+    resp = grok_e2e_client.post(
+        "/v1/chat/completions",
+        json={"model": "grok-4.5", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"X-CodeRouter-Profile": "grok-agent"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["choices"][0]["message"]["content"] == "Hello from grok"
+    assert body["coderouter_provider"] == "agent-grok"
+    # grok emits no token counts — usage is reported as zeros end-to-end.
+    assert body["usage"]["total_tokens"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "coderouter-cli"
-version = "2.7.7"
+version = "2.7.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Adds the **grok (Grok CLI)** target to the `agent_cli` adapter (Phase 1d of
docs/designs/external-agents-adapter.md), so orchestrators can call Grok as
one transparent CodeRouter provider via `X-CodeRouter-Profile: grok`.
Implemented agents are now **claude (1a) + grok (1d)**; codex/gemini remain
schema-declared and rejected until Phase 1b/1c.

All grok flags and the JSON schema were verified against the **real CLI
(v0.2.93 [stable])** before implementation, per the design's §5.4
requirement. Two design-time assumptions are now obsolete and superseded
(recorded in design doc §11.3):

- Grok **supports subscription OAuth** (`grok login`, `~/.grok/auth.json`,
  works via HOME inheritance with `passthrough_env: []`) — the old
  "API-billing only / XAI_API_KEY required" rule is dropped. CI key env is
  `GROK_CODE_XAI_API_KEY` (not `XAI_API_KEY`).
- `--sandbox` takes a **profile value** (`off|workspace|read-only|strict`).

## Implementation

- argv (read_only default):
  `grok --prompt-file <f> --output-format json -m <model> --cwd <w>
  --max-turns <n> --no-memory --sandbox read-only --permission-mode plan`
- Prompt via a `0600` `O_EXCL` temp file in the isolated workdir, always
  deleted in `finally` (grok's `-p` is argv-only; argv would hit
  `MAX_ARG_STRLEN` and leak into `ps`).
- `sandbox_mode` mapping with the same `allow_file_writes` clamp as claude;
  `full_auto` → `--always-approve`.
- `--no-memory` always passed (statelessness even if the user's grok config
  enables cross-session memory).
- Defensive parser: `text` → answer, `sessionId` → `coderouter_session_id`;
  grok emits **no token/cost fields** → usage zeros, cost 0 unless
  `ProviderConfig.cost` is set; malformed output → retryable AdapterError.

## Verification

- Unit: `tests/test_agent_cli.py` **32 → 50 passed** (ruff clean); claude
  argv snapshot unchanged byte-for-byte.
- Real-CLI dress rehearsal: the exact production argv returned valid JSON
  on grok v0.2.93 (macOS).
- E2E (T9): `coderouter serve` → `POST /v1/chat/completions` with
  `X-CodeRouter-Profile: grok` → `"11"`, `coderouter_provider=agent-grok`,
  `coderouter_session_id` propagated, HTTP 200.

## Docs

- `docs/backends/external-agents.md` / `.en.md`: grok section (config,
  argv, sandbox table, OAuth setup, zero-usage note, beta/version-pin
  caveat, troubleshooting).
- `docs/designs/external-agents-adapter.md`: status header + §11.3
  real-CLI verification record (also removed stray `</content>` artifact
  lines at EOF).
- `examples/providers-agent-cli.yaml`: grok block promoted to 実装済み
  (kept commented so the copy-paste path doesn't require grok installed).
- CHANGELOG: v2.7.8 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NM473z8MscgHUsGDkiuDTq
