### PR TITLE
feat(adapters): agent_cli Phase 1b — codex backend (v2.7.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,100 @@ are kept verbatim where the Japanese text itself is the subject).
 
 ---
 
+## [v2.7.9] — 2026-07-11 (agent_cli Phase 1b: codex)
+
+Adds the third target to the `agent_cli` adapter: `agent: codex` (the OpenAI
+Codex CLI) is now implemented alongside `claude` (Phase 1a) and `grok`
+(Phase 1d). The implementation was verified against the real CLI (codex-cli
+0.144.1, 2026-07-11), and one design-time assumption from the 2026-07
+research did not survive contact with it: `codex exec` has no approval flag
+at all (`-a`/`--ask-for-approval` doesn't exist in `exec --help` on
+0.144.1, since non-interactive execution has no approval prompt to control
+in the first place), so the design's separate `edit`/`full_auto` mappings
+(`-a on-request` / `-a never`) collapse into a single `-s workspace-write`
+mapping — unlike claude/grok, codex does not distinguish `edit` from
+`full_auto`. The verified JSONL `turn.completed.usage` payload also carries
+a field the design didn't record, `reasoning_output_tokens`, which is now
+normalized defensively into `completion_tokens_details.reasoning_tokens`.
+Everything else (stdin prompt delivery, `--skip-git-repo-check`,
+`--ephemeral`, the absence of `--max-turns`/`--timeout`, the ~8-day OAuth
+staleness) matched the design closely. `gemini` remains schema-declared but
+rejected (Phase 1c pending).
+
+### Added
+
+- **`agent: codex` builder/parser in `AgentCliAdapter`**
+  (`coderouter/adapters/agent_cli.py`) — invokes the Codex CLI one-shot as
+  `codex exec --json --skip-git-repo-check --ephemeral -m <model>
+  -C <workdir> -s read-only -` (read_only default). The prompt is delivered
+  on stdin with an explicit trailing `-` sentinel — the same channel as
+  claude, unlike grok's `--prompt-file` delivery. Output is JSONL on
+  stdout (progress goes to stderr); the final answer is the `item.text` of
+  the **last** `item.completed` event whose `item.type=="agent_message"`.
+  Usage comes from `turn.completed.usage` and is normalized as
+  `prompt_tokens=input_tokens` / `completion_tokens=output_tokens`, with
+  `cached_input_tokens` kept as `prompt_tokens_details.cached_tokens` (a
+  subset of `input_tokens`, not added on top — verified 13810 ⊃ 9984) and
+  `reasoning_output_tokens` kept as
+  `completion_tokens_details.reasoning_tokens` when nonzero; multiple
+  `turn.completed` events, if seen, are summed. `thread_id` (from
+  `thread.started`) surfaces as `coderouter_session_id`. Parsing is
+  defensive line-by-line — a non-JSON line doesn't abort the rest of the
+  stream, but no valid `agent_message` (or empty stdout) raises a
+  retryable `AdapterError`, as does any `error` event or `turn.failed`.
+  The CLI is pre-1.0 and `--json`'s alias is still `--experimental-json`
+  (schema not frozen), so version pinning is recommended alongside the
+  defensive parsing.
+- **`sandbox_mode` → codex flag mapping** — `read_only` → `-s read-only`;
+  `edit` → `-s workspace-write`; `full_auto` → `-s workspace-write` (same
+  as `edit` — `exec` has no approval flag in 0.144.1, and
+  `--dangerously-bypass-approvals-and-sandbox` is never used). As with
+  claude/grok, the effective mode is clamped to read-only whenever
+  `allow_file_writes=false`, regardless of `sandbox_mode`.
+- **`--skip-git-repo-check` always passed** — CodeRouter's isolated workdir
+  is never a git repository, and codex's default "trusted directory" check
+  fails immediately outside one (exit 1, stderr `Not inside a trusted
+  directory and --skip-git-repo-check was not specified.` — field-verified).
+  The adapter always passes this flag, so that error should never surface
+  in normal operation.
+- **`--ephemeral` always passed** — prevents the session from persisting to
+  disk, for the same stateless-transformation rationale as grok's
+  `--no-memory`. Not configurable.
+- **`max_turns` ignored for codex** — `codex exec` has neither
+  `--max-turns` nor `--timeout`; `AgentCliConfig.max_turns` has no effect
+  when `agent: codex`, and `exec_timeout_s` + process-group `SIGKILL` is
+  the only time bound.
+- **`coderouter_session_id` via `thread_id`** — same response-metadata
+  treatment as claude's `session_id` and grok's `sessionId`.
+
+### Changed
+
+- **Unsupported-agent error message** — constructing the adapter with a
+  not-yet-implemented agent now lists all three implemented agents (e.g.
+  `agent 'gemini' is not implemented yet (implemented: claude, codex,
+  grok)`) instead of the two-agent wording from v2.7.8.
+- **Schema docstrings** (`coderouter/config/schemas.py`) — `AgentCliConfig`
+  field descriptions updated for the three-agent reality, including the
+  `max_turns` docstring noting codex ignores it.
+- **Docs & examples** — `docs/backends/external-agents.md`/`.en.md` gain a
+  full codex section (config example, adapter argv, stdin-vs-`--prompt-file`
+  contrast with grok, sandbox mapping table with the no-approval-flag-in-exec
+  note, JSONL schema and usage normalization including
+  `reasoning_output_tokens`, OAuth setup with the ~8-day staleness caveat
+  and `CODEX_API_KEY`/`OPENAI_API_KEY`/`CODEX_HOME`, and the pre-1.0
+  version-pin caveat) and updated implementation-status wording (claude +
+  codex + grok implemented; gemini-only rejected). The design doc
+  `docs/designs/external-agents-adapter.md` gets a new appendix §11.4
+  recording the verified deltas between the 2026-07 research and
+  codex-cli 0.144.1 (body text left as the historical record); its header
+  status line now lists Phase 1b alongside 1a/1d.
+  `examples/providers-agent-cli.yaml` promotes codex out of the
+  not-implemented preview into a documented (still commented-out, so
+  copying the file doesn't require codex to be installed) block with
+  `model: gpt-5.5`, `paid: false` for subscription OAuth, and
+  `passthrough_env: []`; the preview section at the bottom is retitled to
+  Phase 1c (gemini only), with codex removed from it.
+
 ## [v2.7.8] — 2026-07-10 (agent_cli Phase 1d: grok)
 
 **PR #68**. Adds the second target to the `agent_cli` adapter: `agent: grok` (the xAI

--- a/coderouter/adapters/agent_cli.py
+++ b/coderouter/adapters/agent_cli.py
@@ -18,15 +18,24 @@ CodeRouter merely performs the one conversion. Following the
 ``openai_compat`` precedent, a *single* adapter class fronts *multiple*
 target agents, dispatched on the ``agent`` field.
 
-Implemented agents (Phase 1a + 1d)
-==================================
+Implemented agents (Phase 1a + 1b + 1d)
+========================================
 
-Two targets are implemented here:
+Three targets are implemented here:
 
 * ``claude`` (Claude Code CLI, Phase 1a) — the most stable CLI, the most
   fine-grained safety controls, and the only one that emits
   ``total_cost_usd`` directly (making it the reference implementation for
   the parser / cost path).
+* ``codex`` (codex CLI, Phase 1b) — headless one-shot via ``codex exec
+  --json``, prompt on stdin (like claude). The CLI is pre-1.0 and emits
+  defensively-parsed JSONL (one event per line); usage comes from
+  ``turn.completed`` events, normalized per design §5.1.6 with
+  ``cached_input_tokens`` kept as a *subset* of ``input_tokens`` (unlike
+  claude, which folds its cache buckets into ``prompt_tokens``).
+  ``--skip-git-repo-check`` and ``--ephemeral`` are always passed — the
+  isolated workdir is not a git repo, and the adapter never wants
+  session persistence.
 * ``grok`` (grok CLI, Phase 1d) — headless one-shot via ``--prompt-file`` +
   ``--output-format json``. The CLI emits no token/cost figures, so usage
   is reported as zeros (cost stays 0 unless the operator sets
@@ -34,9 +43,9 @@ Two targets are implemented here:
   so a user-level cross-session memory setting cannot leak state between
   requests.
 
-The remaining agents (codex / gemini) are declared in the config schema so
-providers.yaml is forward-compatible, but constructing an adapter for them
-raises a clear ``AdapterError`` until their phase (1b / 1c) lands.
+The remaining agent (gemini) is declared in the config schema so
+providers.yaml is forward-compatible, but constructing an adapter for it
+raises a clear ``AdapterError`` until its phase (1c) lands.
 
 Security (design §6, non-negotiable)
 ====================================
@@ -44,10 +53,11 @@ Security (design §6, non-negotiable)
 * **allowlist argv only** — the child is launched with
   :func:`asyncio.create_subprocess_exec` and a list argv. ``shell=True`` is
   never used; the prompt is never subject to shell interpretation (claude
-  reads it from stdin; grok reads it from a private ``0600`` prompt file
-  inside the resolved workdir — its ``-p`` requires the prompt as an argv
-  value, and argv would both hit Linux's ~128KiB ``MAX_ARG_STRLEN`` on huge
-  prompts and leak the text into ``ps`` output).
+  and codex read it from stdin — codex's argv carries a trailing ``-``
+  sentinel making that explicit; grok reads it from a private ``0600``
+  prompt file inside the resolved workdir — its ``-p`` requires the prompt
+  as an argv value, and argv would both hit Linux's ~128KiB
+  ``MAX_ARG_STRLEN`` on huge prompts and leak the text into ``ps`` output).
 * **default read-only** — ``allow_file_writes=False`` /
   ``sandbox_mode="read_only"`` are the defaults, mapped to claude's
   ``--permission-mode plan``. Writes require explicit opt-in and the sandbox
@@ -127,6 +137,17 @@ _GROK_SANDBOX_ARGS = {
     "full_auto": ["--sandbox", "workspace", "--always-approve"],
 }
 
+# sandbox_mode → codex ``-s/--sandbox`` value (design §5.4, codex-cli
+# 0.144.1, verified via facts-codex.md). ``codex exec`` has NO approval
+# flag at all (non-interactive, so there is no prompt to approve/skip), so
+# ``full_auto`` collapses onto the same ``workspace-write`` value as
+# ``edit`` — there is nothing further to "auto" beyond granting writes.
+_CODEX_SANDBOX_ARGS = {
+    "read_only": ["-s", "read-only"],
+    "edit": ["-s", "workspace-write"],
+    "full_auto": ["-s", "workspace-write"],
+}
+
 
 def _chunk_text(text: str, size: int = _STREAM_CHUNK_CHARS) -> Iterator[str]:
     """Split ``text`` into ``size``-char pieces for the pseudo-stream."""
@@ -135,7 +156,7 @@ def _chunk_text(text: str, size: int = _STREAM_CHUNK_CHARS) -> Iterator[str]:
 
 
 class AgentCliAdapter(BaseAdapter):
-    """Invoke an external coding-agent CLI one-shot (claude + grok).
+    """Invoke an external coding-agent CLI one-shot (claude + codex + grok).
 
     The ``agent`` field selects the argv builder / output parser via the
     dispatch tables built in :meth:`__init__`, mirroring how
@@ -145,10 +166,10 @@ class AgentCliAdapter(BaseAdapter):
     def __init__(self, config: ProviderConfig) -> None:
         """Bind to a ``ProviderConfig`` and reject unsupported agents.
 
-        Constructing an adapter for an agent other than ``claude`` / ``grok``
-        raises a non-retryable :class:`AdapterError` — the other targets are
-        declared in the schema but not implemented until their phase
-        (design §9).
+        Constructing an adapter for an agent other than ``claude`` /
+        ``codex`` / ``grok`` raises a non-retryable :class:`AdapterError` —
+        the remaining target (gemini) is declared in the schema but not
+        implemented until its phase (design §9).
         """
         super().__init__(config)
         if config.agent_cli is None:  # pragma: no cover - schema enforces this
@@ -158,30 +179,34 @@ class AgentCliAdapter(BaseAdapter):
                 retryable=False,
             )
         self.acfg: AgentCliConfig = config.agent_cli
-        if self.acfg.agent not in ("claude", "grok"):
+        if self.acfg.agent not in ("claude", "codex", "grok"):
             raise AdapterError(
                 f"agent {self.acfg.agent!r} is not implemented yet "
-                f"(implemented: claude, grok). Wait for Phase 1b/1c.",
+                f"(implemented: claude, codex, grok). Wait for Phase 1c.",
                 provider=config.name,
                 retryable=False,
             )
         # agent → argv builder / output parser dispatch tables. claude landed
-        # in Phase 1a, grok in Phase 1d; Phase 1b/1c add codex / gemini.
+        # in Phase 1a, codex in Phase 1b, grok in Phase 1d; Phase 1c adds
+        # gemini.
         self._builders = {
             "claude": self._build_claude_argv,
+            "codex": self._build_codex_argv,
             "grok": self._build_grok_argv,
         }
         self._parsers = {
             "claude": self._parse_claude,
+            "codex": self._parse_codex,
             "grok": self._parse_grok,
         }
-        # Prompt delivery is per-agent: claude reads its print-mode prompt
-        # from stdin (10MB cap), which keeps argv free of the (potentially
+        # Prompt delivery is per-agent: claude and codex read their prompt
+        # from stdin (10MB cap; codex's argv carries a trailing "-" sentinel
+        # making that explicit), which keeps argv free of the (potentially
         # huge) prompt text. grok's ``-p`` REQUIRES the prompt as its argv
         # value (piped stdin is only appended as extra context, verified on
         # v0.2.93), so grok gets the prompt via ``--prompt-file`` instead —
         # see ``_write_prompt_file`` for the rationale.
-        self._uses_stdin = self.acfg.agent == "claude"
+        self._uses_stdin = self.acfg.agent in ("claude", "codex")
 
     # ------------------------------------------------------------------
     # BaseAdapter contract
@@ -464,6 +489,178 @@ class AgentCliAdapter(BaseAdapter):
         if isinstance(data.get("duration_ms"), (int, float)):
             usage["duration_ms"] = data["duration_ms"]
         return usage
+
+    # ------------------------------------------------------------------
+    # codex argv builder + output parser (Phase 1b)
+    # ------------------------------------------------------------------
+
+    def _build_codex_argv(self, workdir: str, prompt_file: str | None = None) -> list[str]:
+        """Assemble the ``codex exec`` argv (design §5.1.5 / §5.4, verified
+        against codex-cli 0.144.1 — see ``_codex/facts-codex.md``).
+
+        Shape::
+
+            codex exec --json --skip-git-repo-check --ephemeral
+                       -m <model> -C <workdir> -s <read-only|workspace-write> -
+
+        The prompt is fed on stdin (not argv), so it never appears here and
+        ``prompt_file`` is ignored (it exists only to keep the builder
+        signature uniform across agents) — the trailing ``-`` makes the
+        stdin intent explicit to ``codex exec``, which otherwise treats a
+        bare invocation with no PROMPT arg the same way but reads more
+        ambiguously in a fixed argv list. ``--skip-git-repo-check`` is
+        ALWAYS passed because the isolated workdir is not a git repository
+        (without it the CLI exits 1). ``--ephemeral`` is ALWAYS passed so no
+        session state persists to disk, matching the adapter's stateless
+        one-shot ethos (the same rationale as grok's ``--no-memory``). codex
+        has no ``--max-turns`` equivalent, so ``AgentCliConfig.max_turns`` is
+        silently ignored here (documented in the schema).
+        """
+        del prompt_file  # codex takes the prompt on stdin, not from a file.
+        model = self.acfg.model or self.config.model
+        argv = [
+            self.acfg.command,
+            "exec",
+            "--json",
+            "--skip-git-repo-check",
+            "--ephemeral",
+            "-m",
+            model,
+            "-C",
+            workdir,
+        ]
+        argv += self._codex_sandbox_args()
+        argv += ["-"]
+        return argv
+
+    def _codex_sandbox_args(self) -> list[str]:
+        """Map ``sandbox_mode`` → codex ``-s/--sandbox`` flags, clamped.
+
+        Same clamp as claude/grok (design §5.4): when ``allow_file_writes``
+        is False the effective mode is forced to ``read_only`` regardless of
+        ``sandbox_mode``, so writes always require the explicit opt-in.
+        ``codex exec`` has no approval flag in 0.144.1 (non-interactive, so
+        there is nothing to approve), so ``full_auto`` maps onto the same
+        ``workspace-write`` value as ``edit`` —
+        ``--dangerously-bypass-approvals-and-sandbox`` is never used.
+        """
+        mode = self.acfg.sandbox_mode if self.acfg.allow_file_writes else "read_only"
+        return list(_CODEX_SANDBOX_ARGS[mode])
+
+    def _parse_codex(
+        self, stdout: bytes, stderr: bytes
+    ) -> tuple[str, dict[str, Any], dict[str, Any]]:
+        """Parse codex ``exec --json`` JSONL output (verified codex-cli
+        0.144.1, ``_codex/facts-codex.md``).
+
+        Real-run shape (one JSON object per line, newline-delimited)::
+
+            {"type":"thread.started","thread_id":"<uuid>"}
+            {"type":"turn.started"}
+            {"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"2"}}
+            {"type":"turn.completed","usage":{"input_tokens":13810,"cached_input_tokens":9984,"output_tokens":5,"reasoning_output_tokens":0}}
+
+        The CLI is pre-1.0 and its JSON schema is not frozen, so parsing is
+        deliberately defensive at every level: individual lines that fail to
+        parse (or parse to something other than a JSON object) are SKIPPED
+        rather than aborting the whole parse — stray non-JSON noise on
+        stdout should not sink an otherwise-valid answer. The final answer
+        is the LAST ``item.completed`` event whose ``item`` is an
+        ``agent_message`` with a string ``text``. If a completed answer was
+        found, it is returned even when a later ``error`` / ``turn.failed``
+        event also appears (a completed answer beats a trailing error); if
+        no answer was found, an ``error`` / ``turn.failed`` event (or the
+        total absence of any agent_message) raises a retryable
+        :class:`AdapterError`.
+        """
+        text = stdout.decode("utf-8", "replace")
+        if not text.strip():
+            raise AdapterError(
+                "codex produced no stdout to parse",
+                provider=self.name,
+                retryable=True,
+            )
+
+        final_text: str | None = None
+        thread_id: str | None = None
+        failure_event: dict[str, Any] | None = None
+        prompt_tokens = 0
+        completion_tokens = 0
+        cached_tokens = 0
+        reasoning_tokens = 0
+
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                # Defensive against stray non-JSON noise (progress text that
+                # leaked onto stdout, partial writes, etc.) — skip the line.
+                continue
+            if not isinstance(event, dict):
+                continue
+
+            etype = event.get("type")
+            if etype == "thread.started":
+                tid = event.get("thread_id")
+                if isinstance(tid, str):
+                    thread_id = tid
+            elif etype == "item.completed":
+                item = event.get("item")
+                if (
+                    isinstance(item, dict)
+                    and item.get("type") == "agent_message"
+                    and isinstance(item.get("text"), str)
+                ):
+                    final_text = item["text"]
+            elif etype == "turn.completed":
+                usage = event.get("usage")
+                usage = usage if isinstance(usage, dict) else {}
+
+                def _int(key: str, _usage: dict[str, Any] = usage) -> int:
+                    value = _usage.get(key)
+                    return int(value) if isinstance(value, (int, float)) else 0
+
+                prompt_tokens += _int("input_tokens")
+                completion_tokens += _int("output_tokens")
+                cached_tokens += _int("cached_input_tokens")
+                reasoning_tokens += _int("reasoning_output_tokens")
+            elif etype in ("error", "turn.failed"):
+                failure_event = event
+
+        if final_text is None:
+            if failure_event is not None:
+                raise AdapterError(
+                    f"codex reported {failure_event.get('type')}: {failure_event!r}"[:500],
+                    provider=self.name,
+                    retryable=True,
+                )
+            raise AdapterError(
+                "codex JSONL output contained no agent_message",
+                provider=self.name,
+                retryable=True,
+            )
+
+        # cached_input_tokens is a SUBSET of input_tokens (not additive) —
+        # verified sample: input 13810 ⊇ cached 9984 — so it is preserved
+        # under prompt_tokens_details rather than folded into prompt_tokens
+        # (this differs from claude's normalization, design §5.1.6).
+        usage_out: dict[str, Any] = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+        if cached_tokens > 0:
+            usage_out["prompt_tokens_details"] = {"cached_tokens": cached_tokens}
+        if reasoning_tokens > 0:
+            usage_out["completion_tokens_details"] = {"reasoning_tokens": reasoning_tokens}
+
+        meta: dict[str, Any] = {}
+        if thread_id is not None:
+            meta["coderouter_session_id"] = thread_id
+        return final_text, usage_out, meta
 
     # ------------------------------------------------------------------
     # grok argv builder + output parser (Phase 1d)

--- a/coderouter/config/schemas.py
+++ b/coderouter/config/schemas.py
@@ -171,16 +171,24 @@ class AgentCliConfig(BaseModel):
     invokes an external coding-agent CLI (codex / gemini / grok / claude)
     in a single one-shot ``exec`` and returns the final answer as one
     ``prompt in → text out`` transformation. ``claude`` (Claude Code CLI,
-    Phase 1a) and ``grok`` (grok CLI, Phase 1d) are implemented;
-    codex / gemini are declared at the schema level so configs are
-    forward-compatible, but the adapter rejects them until their phase
-    lands.
+    Phase 1a), ``codex`` (codex CLI, Phase 1b) and ``grok`` (grok CLI,
+    Phase 1d) are implemented; ``gemini`` is declared at the schema level
+    so configs are forward-compatible, but the adapter rejects it until its
+    phase (1c) lands.
 
     Auth note (grok): the grok CLI uses OAuth credentials stored under
     ``~/.grok`` (``grok login``), which the adapter's HOME inheritance
     already covers — no extra config needed. For CI / API-key setups, list
     ``GROK_CODE_XAI_API_KEY`` in ``passthrough_env`` (this is grok's key
     env var — NOT ``XAI_API_KEY``).
+
+    Auth note (codex): the codex CLI uses a ChatGPT-plan OAuth login stored
+    under ``~/.codex`` (``codex login``), which the adapter's HOME
+    inheritance already covers — the credentials go stale after roughly 8
+    days and are auto-refreshed on use, so no extra config is needed for
+    interactive/subscription setups. For CI / API-key setups, list
+    ``CODEX_API_KEY`` (exec-only) or ``OPENAI_API_KEY`` (general) in
+    ``passthrough_env``.
 
     Follows the ``extra="forbid"`` convention used across this module so a
     typo'd key fails at config-load rather than being silently ignored.
@@ -191,8 +199,9 @@ class AgentCliConfig(BaseModel):
     agent: Literal["codex", "gemini", "grok", "claude"] = Field(
         ...,
         description=(
-            "External coding-agent CLI to invoke. 'claude' (Phase 1a) and "
-            "'grok' (Phase 1d) are implemented; 'codex' / 'gemini' pending."
+            "External coding-agent CLI to invoke. 'claude' (Phase 1a), "
+            "'codex' (Phase 1b) and 'grok' (Phase 1d) are implemented; "
+            "'gemini' (Phase 1c) pending."
         ),
     )
     command: str | None = Field(

--- a/docs/backends/external-agents.en.md
+++ b/docs/backends/external-agents.en.md
@@ -2,7 +2,7 @@
 
 > 日本語版: [`external-agents.md`](./external-agents.md)
 
-`kind: "agent_cli"` is an adapter that registers an external coding-agent CLI, such as the Claude Code CLI, as a single CodeRouter provider. It was newly added in v2.7.7 (Phase 1a: claude), and v2.7.8 added grok (Phase 1d). See [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) for the full design.
+`kind: "agent_cli"` is an adapter that registers an external coding-agent CLI, such as the Claude Code CLI, as a single CodeRouter provider. It was newly added in v2.7.7 (Phase 1a: claude), v2.7.8 added grok (Phase 1d), and v2.7.9 added codex (Phase 1b). See [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) for the full design.
 
 ---
 
@@ -11,16 +11,16 @@
 A coding-agent CLI is normally a stateful control loop that runs many turns autonomously while editing files — a poor fit for CodeRouter's "one request = one transformation" ethos. `agent_cli` reconciles the two by collapsing the CLI into a **one-shot `exec`** (prompt in → final answer text out). Orchestration (multi-turn control, tool execution) stays entirely inside the agent CLI process; from CodeRouter's side it looks like just another provider that answers a single exchange.
 
 - **Supported CLIs**: the `agent` field can declare `claude` / `codex` / `gemini` / `grok`.
-- **Implementation status (as of v2.7.8)**: **`claude` (Claude Code CLI, Phase 1a) and `grok` (Grok CLI, Phase 1d) are implemented**. `codex` / `gemini` can be written into `providers.yaml` at the schema level, but constructing the adapter always rejects them (Phase 1b/1c are not yet implemented). The error message looks roughly like the following (the exact wording may differ between versions):
+- **Implementation status (as of v2.7.9)**: **`claude` (Claude Code CLI, Phase 1a), `codex` (OpenAI Codex CLI, Phase 1b), and `grok` (Grok CLI, Phase 1d) are implemented**. Only `gemini` can be written into `providers.yaml` at the schema level, but constructing the adapter always rejects it (Phase 1c is not yet implemented). The error message looks roughly like the following (the exact wording may differ between versions):
 
   ```
-  AdapterError: agent 'codex' is not implemented yet (implemented: claude, grok).
-  Wait for the agent's phase (1b/1c).
+  AdapterError: agent 'gemini' is not implemented yet (implemented: claude, codex, grok).
+  Wait for the agent's phase (1c).
   ```
 
   This rejection is `retryable=False` — even if other providers exist in the fallback chain, it stops immediately as a configuration error.
 
-- The shared parts of this document (authentication design, configuration reference, limitations) are written against the `claude` target; grok-specific behavior is collected in the [grok (Grok CLI)](#grok-grok-cli) section. Example configs for `codex` / `gemini` exist only as a commented-out preview at the bottom of `examples/providers-agent-cli.yaml` and do not work.
+- The shared parts of this document (authentication design, configuration reference, limitations) are written against the `claude` target; codex- and grok-specific behavior are collected in the [codex (OpenAI Codex CLI)](#codex-openai-codex-cli) and [grok (Grok CLI)](#grok-grok-cli) sections, respectively. Example configs for `gemini` exist only as a commented-out preview at the bottom of `examples/providers-agent-cli.yaml` and do not work.
 
 ---
 
@@ -96,14 +96,14 @@ All fields of the `agent_cli:` sub-config (`AgentCliConfig`) in `providers.yaml`
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `agent` | `"claude" \| "codex" \| "gemini" \| "grok"` | (required) | Which CLI to invoke. **As of v2.7.8, `claude` and `grok` are implemented; `codex` / `gemini` are rejected when the adapter is constructed** |
+| `agent` | `"claude" \| "codex" \| "gemini" \| "grok"` | (required) | Which CLI to invoke. **As of v2.7.9, `claude`, `codex`, and `grok` are implemented; `gemini` is rejected when the adapter is constructed** |
 | `command` | `str \| null` | `null` (defaults to the same name as `agent`) | CLI executable name or absolute path, resolved via `PATH` |
 | `workdir` | `str \| null` | `null` (defaults to `~/.coderouter/agents/<provider name>`) | Working directory for the one-shot exec. `~` / env-var expansion is applied; a path containing `..` is rejected |
 | `exec_timeout_s` | `float` | `600.0` (range `1.0`–`1800.0`) | Forced timeout (seconds) for the whole exec. **Separate** from `ProviderConfig.timeout_s` (the latter is not used by agent_cli) |
 | `allow_file_writes` | `bool` | `false` | Whether to allow file writes. When `false`, the effective mode is clamped to read-only regardless of `sandbox_mode` |
-| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | Maps to each CLI's sandbox/approval flags (claude: [table below](#sandbox_mode--permission-mode-mapping-claude); grok: [grok section](#sandbox_mode--grok-flag-mapping)) |
-| `model` | `str \| null` | `null` (defaults to `ProviderConfig.model`) | Model name passed to the CLI's `--model` / `-m` (claude: `opus` / `sonnet` / `haiku` / `fable` etc.; grok: `grok-4.5` etc.) |
-| `max_turns` | `int \| null` | `8` (range `1`–`50`) | Turn cap inside the CLI. Passed as `--max-turns` |
+| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | Maps to each CLI's sandbox/approval flags (claude: [table below](#sandbox_mode--permission-mode-mapping-claude); codex: [codex section](#sandbox_mode--codex-flag-mapping); grok: [grok section](#sandbox_mode--grok-flag-mapping)) |
+| `model` | `str \| null` | `null` (defaults to `ProviderConfig.model`) | Model name passed to the CLI's `--model` / `-m` (claude: `opus` / `sonnet` / `haiku` / `fable` etc.; codex: `gpt-5.5` etc.; grok: `grok-4.5` etc.) |
+| `max_turns` | `int \| null` | `8` (range `1`–`50`) | Turn cap inside the CLI. Passed as `--max-turns`. **codex has no corresponding CLI flag, so this is always ignored** (for codex, `exec_timeout_s` + process-group kill is the only time bound) |
 | `passthrough_env` | `list[str]` | `[]` | Allowlist of environment variable names forwarded from the parent process into the child. `ANTHROPIC_API_KEY` is not forwarded unless listed here |
 | `agent_depth_limit` | `int` | `2` (range `1`–`4`) | Recursion nesting cap. When `CODEROUTER_AGENT_DEPTH` reaches or exceeds this, the call stops immediately with `AdapterError(retryable=False)` |
 
@@ -120,6 +120,104 @@ When `command` is unset it defaults to the same name as `agent`. Also, specifyin
 ### Why `paid: false`
 
 The `agent-claude` provider in the example config `examples/providers-agent-cli.yaml` is set to `paid: false`. That's because running on subscription OAuth incurs **zero metered cost** (only the 5-hour window / weekly quota described below is consumed). If you want to run it on metered API-key billing instead, change it to `paid: true` and pass `ALLOW_PAID=true` as an environment variable when starting CodeRouter. Note that the `ALLOW_PAID` environment variable **overrides** whatever `allow_paid` value is written in `providers.yaml` at startup — a `paid: true` provider is excluded from routing whenever `ALLOW_PAID` is unset.
+
+---
+
+## codex (OpenAI Codex CLI)
+
+v2.7.9 (Phase 1b) implements `agent: codex`. Like claude, it delivers the prompt via **stdin** (unlike grok's file-based delivery). It has its own behavior around JSONL output, `--ephemeral`, and running outside a git repository. Everything below is based on codex CLI **0.144.1** (field-verified on the author's Mac, 2026-07-11).
+
+### Example configuration
+
+```yaml
+providers:
+  - name: agent-codex
+    kind: agent_cli
+    model: gpt-5.5                # a current frontier-model example; the default depends on the environment/plan, so set it explicitly
+    paid: false                   # ChatGPT-plan subscription OAuth = zero metered cost
+    capabilities:
+      streaming: false
+      tools: false
+    agent_cli:
+      agent: codex
+      command: codex
+      workdir: ~/.coderouter/agents/codex
+      exec_timeout_s: 600
+      allow_file_writes: false
+      sandbox_mode: read_only
+      max_turns: 8                 # ignored by codex — no corresponding flag (see below)
+      passthrough_env: []          # OAuth reads ~/.codex/auth.json via the inherited HOME, so empty is fine.
+                                    # Only list CODEX_API_KEY (exec-only) or OPENAI_API_KEY
+                                    # when using an API key in CI
+```
+
+### The argv the adapter builds
+
+With `sandbox_mode: read_only` (the default), the adapter builds the following argv.
+
+```
+codex exec --json --skip-git-repo-check --ephemeral -m <model> -C <workdir> -s read-only -
+```
+
+### The prompt is delivered via stdin (same as claude, unlike grok)
+
+codex's `exec` subcommand reads the prompt from stdin when the PROMPT argument is omitted (or explicitly given as `-`). The adapter places an explicit trailing `-` on the argv to force this path. Unlike grok, there's no need for a temp file (`--prompt-file`) inside the isolated workdir — this is the same stdin scheme as claude.
+
+### Why `--skip-git-repo-check` is always passed
+
+CodeRouter's isolated workdir is not a git repository. By default, codex runs a "trusted directory" check and, outside a git repo in an unrecognized directory, fails immediately with exit 1 and stderr `Not inside a trusted directory and --skip-git-repo-check was not specified.` (field-verified). The adapter always passes this flag, so this error message should never appear in normal operation.
+
+### Why `--ephemeral` is always passed
+
+`--ephemeral` prevents the session from being persisted to disk. For the same reason as grok's `--no-memory` — keeping with CodeRouter's "one request = one stateless transformation" ethos — the adapter always passes this flag (it cannot be turned off in config).
+
+### `sandbox_mode` → codex flag mapping
+
+As with claude/grok, when `allow_file_writes=false` the effective mode is clamped to `read_only` regardless of `sandbox_mode`.
+
+| `sandbox_mode` | codex flags | Notes |
+|---|---|---|
+| `read_only` (default) | `-s read-only` | No file changes. Always clamped to this mode when `allow_file_writes=false` |
+| `edit` | `-s workspace-write` | Permits file edits inside the workspace-write sandbox |
+| `full_auto` | `-s workspace-write` | **`codex exec` has no approval flag (`-a` / `--ask-for-approval`)** — it's absent from `exec --help` in 0.144.1, since non-interactive execution has no approval prompt to control in the first place. So this maps identically to `edit`. `--dangerously-bypass-approvals-and-sandbox` is never used |
+
+### No `--max-turns` / `--timeout` exist
+
+codex exec has neither `--max-turns` nor `--timeout`. Consequently `AgentCliConfig.max_turns` is **ignored for codex**. The only time bound is the existing `exec_timeout_s` + process-group `SIGKILL`.
+
+### JSONL output and usage normalization
+
+`--json` output is JSONL (one event per line); progress goes to stderr, and the event stream (including the final answer) goes to stdout (confirmed by both the official docs and the real CLI). A verified one-shot run:
+
+```
+$ codex exec --json --skip-git-repo-check "What's 1+1? Answer with just the digit"
+{"type":"thread.started","thread_id":"019f4e74-08fd-77b2-9cc6-9afa744df130"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"2"}}
+{"type":"turn.completed","usage":{"input_tokens":13810,"cached_input_tokens":9984,"output_tokens":5,"reasoning_output_tokens":0}}
+```
+
+- Final answer: the **last** `item.completed` whose `item.type=="agent_message"`, taking `item.text`.
+- Usage normalization: `turn.completed.usage`'s `input_tokens` → `prompt_tokens`, `output_tokens` → `completion_tokens`, and their sum → `total_tokens`. `cached_input_tokens` is a **subset** of `input_tokens` (measured: input 13810 ⊃ cached 9984), so it is not added on top — it's kept as `prompt_tokens_details.cached_tokens`. When `reasoning_output_tokens` is greater than 0, it's kept as `completion_tokens_details.reasoning_tokens` (defensive). Multiple `turn.completed` events, if they occur, are summed.
+- `thread_id` (from `thread.started`) is surfaced as the `coderouter_session_id` response metadata.
+- If an `error` event or `turn.failed` is seen, or no agent_message is ever produced / stdout is empty / every line is non-JSON, this raises a retryable `AdapterError` and the fallback chain advances to the next provider. Individual non-JSON lines in the JSONL stream don't stop processing of the remaining lines (defense against stray stderr-like output mixed in).
+
+### Authentication (ChatGPT-plan subscription OAuth / API key)
+
+The codex CLI supports ChatGPT-plan OAuth login. Credentials are stored at `~/.codex/auth.json` (or the OS keyring), and the adapter's `HOME` inheritance makes it work with `passthrough_env: []`.
+
+1. Run `codex login` to complete login. `codex login status` exiting 0 confirms you're logged in.
+2. The OAuth token goes **stale after about 8 days**. It auto-refreshes on use, but a setup that doesn't call codex for a long stretch can fail while stale — running codex occasionally, or re-logging in, is recommended.
+
+For CI or metered API-key billing, list `CODEX_API_KEY` (**exec-only**) or `OPENAI_API_KEY` (general) in `passthrough_env`. `CODEX_HOME` can also override the config/credentials directory itself.
+
+### Error reporting
+
+The codex CLI exits 0 on success, and on failure exits non-zero with the error text on stderr (e.g. the git-repo-check message). JSONL may also carry an `error` event or `turn.failed`; both of those also become a retryable `AdapterError` and the fallback chain advances to the next provider.
+
+### Pre-1.0 caveat
+
+The codex CLI is pre-1.0 and releases nearly daily. `--json`'s alias is still `--experimental-json`, and the JSONL schema is not frozen. **Version pinning is recommended** (you can point `command` at a pinned binary's full path). If the schema does change, defensive parsing turns it into a retryable `AdapterError` and the fallback chain demotes to the next provider.
 
 ---
 
@@ -222,7 +320,9 @@ The grok CLI is early beta (v0.2.93 [stable] channel as of 2026-07-10). Its JSON
 | Requests are rejected / not routed, effectively "paid gate blocked" | The `agent_cli` provider has `paid: true` but `ALLOW_PAID` isn't set | For subscription usage, set `paid: false`. For metered API-key billing, set `ALLOW_PAID=true` when starting CodeRouter |
 | `claude exited 1: ...` shows a specific reason | The claude CLI sometimes reports auth/API errors as an `is_error: true` JSON document on **stdout** (with stderr left empty) and exits with code 1 | v2.7.7's `_error_detail()` now prefers the `result` field of that stdout `is_error` JSON (the actual error text, e.g. `Not logged in · Please run /login`) even when stderr is empty, and includes it in the raised error message — use the message shown as your lead |
 | Fails with `grok exited 1: ...` | The grok CLI exits with code 1 on auth/network/runtime errors, with the error text on stderr | The adapter includes a tail of stderr in the `AdapterError`, so use the message shown as your lead. For auth errors, re-run `grok login` and smoke-check that `grok models` works |
-| CLI fails to launch (`failed to launch ...`) | `command` (defaults to the same name as `agent`) isn't on `PATH` | Confirm `claude --version` / `grok --version` works. You can also point `command` at a full path |
+| Fails with `codex exited 1: ...` (suspect stale OAuth) | codex's OAuth token goes stale after about 8 days. It auto-refreshes on use, but a long gap between calls can leave it stale and failing | Check login state with `codex login status` and re-run `codex login` if needed. Running codex occasionally helps avoid staleness |
+| `Not inside a trusted directory and --skip-git-repo-check was not specified.` appears | This should never happen — the adapter always passes `--skip-git-repo-check` | If you see this, it likely indicates a bug in CodeRouter's argv construction. Check your version and file an issue if it reproduces |
+| CLI fails to launch (`failed to launch ...`) | `command` (defaults to the same name as `agent`) isn't on `PATH` | Confirm `claude --version` / `codex --version` / `grok --version` works. You can also point `command` at a full path |
 
 ---
 

--- a/docs/backends/external-agents.md
+++ b/docs/backends/external-agents.md
@@ -2,7 +2,7 @@
 
 > English: [`external-agents.en.md`](./external-agents.en.md)
 
-`kind: "agent_cli"` は、Claude Code CLI のような外部コーディングエージェントを CodeRouter の 1 プロバイダとして登録するアダプタである。v2.7.7 で新規追加され(Phase 1a: claude)、v2.7.8 で grok が追加された(Phase 1d)。詳細設計は [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) を参照。
+`kind: "agent_cli"` は、Claude Code CLI のような外部コーディングエージェントを CodeRouter の 1 プロバイダとして登録するアダプタである。v2.7.7 で新規追加され(Phase 1a: claude)、v2.7.8 で grok が追加され(Phase 1d)、v2.7.9 で codex が追加された(Phase 1b)。詳細設計は [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) を参照。
 
 ---
 
@@ -11,16 +11,16 @@
 コーディングエージェント CLI は本来、ファイルを書き換えながら何ターンも自律的に動くステートフルな制御ループであり、CodeRouter の「1リクエスト = 1変換」という思想とは相性が悪い。`agent_cli` はこれを **ワンショット `exec`**(プロンプト in → 最終回答テキスト out)に押し込めることで両立させている。オーケストレーション(マルチターン制御・ツール実行)はエージェント CLI 内部で完結し、CodeRouter 側からは「1回の対話で答えを返すだけの1つのプロバイダ」として見える。
 
 - **対象 CLI**: `agent` フィールドで `claude` / `codex` / `gemini` / `grok` の4種を宣言できる。
-- **実装状況(v2.7.8 時点)**: **`claude`(Claude Code CLI・Phase 1a)と `grok`(Grok CLI・Phase 1d)が実装済み**。`codex` / `gemini` は `providers.yaml` のスキーマ上は書けるが、アダプタ構築時に必ず AdapterError で拒否される(Phase 1b/1c は未実装)。エラーメッセージは概ね次の形である(正確な文言はバージョンにより変わりうる):
+- **実装状況(v2.7.9 時点)**: **`claude`(Claude Code CLI・Phase 1a)・`codex`(OpenAI Codex CLI・Phase 1b)・`grok`(Grok CLI・Phase 1d)が実装済み**。`gemini` のみ `providers.yaml` のスキーマ上は書けるが、アダプタ構築時に必ず AdapterError で拒否される(Phase 1c は未実装)。エラーメッセージは概ね次の形である(正確な文言はバージョンにより変わりうる):
 
   ```
-  AdapterError: agent 'codex' is not implemented yet (implemented: claude, grok).
-  Wait for the agent's phase (1b/1c).
+  AdapterError: agent 'gemini' is not implemented yet (implemented: claude, codex, grok).
+  Wait for the agent's phase (1c).
   ```
 
   この拒否は `retryable=False` — フォールバックチェーンに他プロバイダがあっても、設定ミスとして即座に停止する。
 
-- 本ドキュメントの共通部分(認証設計・設定リファレンス・制限事項)は claude ターゲットを軸に記述し、grok 固有の挙動は [grok(Grok CLI)](#grokgrok-cli) セクションにまとめる。codex / gemini の設定例は `examples/providers-agent-cli.yaml` 末尾にコメントアウトされたプレビューとして置かれているが、動作しない。
+- 本ドキュメントの共通部分(認証設計・設定リファレンス・制限事項)は claude ターゲットを軸に記述し、codex / grok 固有の挙動はそれぞれ [codex(OpenAI Codex CLI)](#codexopenai-codex-cli) / [grok(Grok CLI)](#grokgrok-cli) セクションにまとめる。gemini の設定例は `examples/providers-agent-cli.yaml` 末尾にコメントアウトされたプレビューとして置かれているが、動作しない。
 
 ---
 
@@ -96,14 +96,14 @@ Claude Code CLI は Keychain からトークンを解決する際に `USER` 環�
 
 | フィールド | 型 | 既定値 | 説明 |
 |---|---|---|---|
-| `agent` | `"claude" \| "codex" \| "gemini" \| "grok"` | (必須) | 呼び出す CLI。**v2.7.8 で実装済みなのは `claude` と `grok`。`codex` / `gemini` はアダプタ構築時に拒否される** |
+| `agent` | `"claude" \| "codex" \| "gemini" \| "grok"` | (必須) | 呼び出す CLI。**v2.7.9 で実装済みなのは `claude`・`codex`・`grok`。`gemini` はアダプタ構築時に拒否される** |
 | `command` | `str \| null` | `null`(未設定時は `agent` と同名) | CLI 実行ファイル名 or 絶対パス。`PATH` から解決 |
 | `workdir` | `str \| null` | `null`(未設定時は `~/.coderouter/agents/<プロバイダ名>`) | ワンショット exec の作業ディレクトリ。`~` / 環境変数展開あり。`..` を含むパスは拒否される |
 | `exec_timeout_s` | `float` | `600.0`(範囲 `1.0`–`1800.0`) | exec 全体の強制タイムアウト(秒)。`ProviderConfig.timeout_s` とは**別系統**(後者は agent_cli では使われない) |
 | `allow_file_writes` | `bool` | `false` | ファイル書き込みを許可するか。`false` のときは `sandbox_mode` の値に関わらず read-only にクランプされる |
-| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | 各 CLI のサンドボックス/承認フラグへマッピングされる(claude は[下表](#sandbox_mode--permission-mode-マッピングclaude)、grok は [grok セクション](#sandbox_mode--grok-フラグのマッピング)参照) |
-| `model` | `str \| null` | `null`(未設定時は `ProviderConfig.model` を使用) | CLI の `--model` / `-m` に渡すモデル名(claude: `opus` / `sonnet` / `haiku` / `fable` 等、grok: `grok-4.5` 等) |
-| `max_turns` | `int \| null` | `8`(範囲 `1`–`50`) | CLI 内部のターン上限。`--max-turns` として渡る |
+| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | 各 CLI のサンドボックス/承認フラグへマッピングされる(claude は[下表](#sandbox_mode--permission-mode-マッピングclaude)、codex は [codex セクション](#sandbox_mode--codex-フラグのマッピング)、grok は [grok セクション](#sandbox_mode--grok-フラグのマッピング)参照) |
+| `model` | `str \| null` | `null`(未設定時は `ProviderConfig.model` を使用) | CLI の `--model` / `-m` に渡すモデル名(claude: `opus` / `sonnet` / `haiku` / `fable` 等、codex: `gpt-5.5` 等、grok: `grok-4.5` 等) |
+| `max_turns` | `int \| null` | `8`(範囲 `1`–`50`) | CLI 内部のターン上限。`--max-turns` として渡る。**codex には対応する CLI フラグが無いため常に無視される**(codex では `exec_timeout_s` + プロセスグループ kill のみが時間上限になる) |
 | `passthrough_env` | `list[str]` | `[]` | 親環境から子プロセスへ転送する環境変数名のallowlist。`ANTHROPIC_API_KEY` はここに書かない限り渡らない |
 | `agent_depth_limit` | `int` | `2`(範囲 `1`–`4`) | 再帰ネストの上限。`CODEROUTER_AGENT_DEPTH` が上限以上なら `AdapterError(retryable=False)` で即停止 |
 
@@ -120,6 +120,104 @@ Claude Code CLI は Keychain からトークンを解決する際に `USER` 環�
 ### `paid: false` の理由
 
 サンプル設定 `examples/providers-agent-cli.yaml` の `agent-claude` プロバイダは `paid: false` になっている。これはサブスクリプション OAuth で運用する限り**従量課金が一切発生しない**(消費するのは後述の5時間窓/週次クォータのみ)ためである。API キー従量課金で運用したい場合は `paid: true` に変更し、CodeRouter 起動時に `ALLOW_PAID=true` を環境変数として渡す必要がある。`ALLOW_PAID` 環境変数は `providers.yaml` に書いた値(`allow_paid`)を**起動時に上書きする**ため、`paid: true` のプロバイダは `ALLOW_PAID` 未設定時にはルーティングから除外される点に注意する。
+
+---
+
+## codex(OpenAI Codex CLI)
+
+v2.7.9(Phase 1b)で `agent: codex` が実装された。claude と同じくプロンプトを **stdin 経由**で渡す方式である(grok のようなファイル経由ではない)。JSONL 出力・`--ephemeral`・git 外ディレクトリ対応など codex 固有の挙動がある。以下は codex CLI **0.144.1**(作者の Mac、2026-07-11 実機検証)を基準とする。
+
+### 設定例
+
+```yaml
+providers:
+  - name: agent-codex
+    kind: agent_cli
+    model: gpt-5.5                # 現行フロンティアモデルの例。既定モデルは環境/プラン依存なので明示推奨
+    paid: false                   # ChatGPT プランサブスクリプション OAuth 運用 = 従量課金ゼロ
+    capabilities:
+      streaming: false
+      tools: false
+    agent_cli:
+      agent: codex
+      command: codex
+      workdir: ~/.coderouter/agents/codex
+      exec_timeout_s: 600
+      allow_file_writes: false
+      sandbox_mode: read_only
+      max_turns: 8                 # codex には対応フラグが無く無視される(下記参照)
+      passthrough_env: []          # OAuth は ~/.codex/auth.json を HOME 継承で読むため空でよい。
+                                    # CI で API キーを使う場合のみ CODEX_API_KEY(exec専用)
+                                    # または OPENAI_API_KEY を列挙する
+```
+
+### アダプタが構築する argv
+
+`sandbox_mode: read_only`(既定)の場合、アダプタは次の argv を構築する。
+
+```
+codex exec --json --skip-git-repo-check --ephemeral -m <model> -C <workdir> -s read-only -
+```
+
+### プロンプトは stdin 経由(claude と同じ、grok とは異なる)
+
+codex の `exec` サブコマンドは PROMPT 引数を省略する(または明示的に `-` を指定する)と stdin からプロンプトを読む。アダプタは argv 末尾に明示の `-` を置いてこの経路を強制する。grok のように隔離 workdir 内の一時ファイル(`--prompt-file`)を経由する必要はなく、claude と同じ stdin 方式である。
+
+### `--skip-git-repo-check` を常時付与する理由
+
+CodeRouter の隔離 workdir は git リポジトリではない。codex はデフォルトで「信頼済みディレクトリ」チェックを行い、git リポジトリ外かつ未確認のディレクトリでは exit 1 + stderr `Not inside a trusted directory and --skip-git-repo-check was not specified.` で即座に失敗する(実機確認済み)。アダプタはこのフラグを常時付与するため、実運用でこのエラーメッセージが表示されることはない。
+
+### `--ephemeral` を常時付与する理由
+
+`--ephemeral` はセッションをディスクに保存しない。grok の `--no-memory` と同じ理由 — CodeRouter の「1リクエスト = 1ステートレス変換」思想との整合 — で、アダプタは常にこのフラグを付与する(設定で外すことはできない)。
+
+### `sandbox_mode` → codex フラグのマッピング
+
+claude/grok と同様、`allow_file_writes=false` のときは `sandbox_mode` の値に関わらず `read_only` にクランプされる。
+
+| `sandbox_mode` | codex フラグ | 備考 |
+|---|---|---|
+| `read_only`(既定) | `-s read-only` | ファイル変更なし。`allow_file_writes=false` のとき常にこのモードにクランプされる |
+| `edit` | `-s workspace-write` | workspace-write サンドボックス内でのファイル編集を許可 |
+| `full_auto` | `-s workspace-write` | **`codex exec` に承認フラグ(`-a` / `--ask-for-approval`)は存在しない**(0.144.1 の `exec --help` に無し。非対話実行のため承認プロンプト自体が無い)。そのため `edit` と同一マッピングになる。`--dangerously-bypass-approvals-and-sandbox` は使わない |
+
+### `--max-turns` / `--timeout` は存在しない
+
+codex exec には `--max-turns` も `--timeout` も存在しない。したがって `AgentCliConfig.max_turns` は **codex では無視される**。時間上限は既存の `exec_timeout_s` + プロセスグループ SIGKILL のみが担う。
+
+### JSONL 出力と usage 正規化
+
+`--json` の出力は JSONL(1行1イベント)であり、進捗は stderr、イベント列(最終応答を含む)は stdout に出る(公式ドキュメント・実機とも確認済み)。実機での one-shot 実行例:
+
+```
+$ codex exec --json --skip-git-repo-check "1+1は?数字だけ答えて"
+{"type":"thread.started","thread_id":"019f4e74-08fd-77b2-9cc6-9afa744df130"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"2"}}
+{"type":"turn.completed","usage":{"input_tokens":13810,"cached_input_tokens":9984,"output_tokens":5,"reasoning_output_tokens":0}}
+```
+
+- 最終回答: **最後の** `item.completed` かつ `item.type=="agent_message"` の `item.text`。
+- usage 正規化: `turn.completed.usage` の `input_tokens` → `prompt_tokens`、`output_tokens` → `completion_tokens`、両者の和を `total_tokens` とする。`cached_input_tokens` は `input_tokens` の**部分集合**であり(実測: input 13810 ⊃ cached 9984)、加算せず `prompt_tokens_details.cached_tokens` として保持する。`reasoning_output_tokens` が 0 より大きい場合は `completion_tokens_details.reasoning_tokens` として保持する(防御的)。複数の `turn.completed` が出た場合は合算する。
+- `thread_id`(`thread.started`)はレスポンスメタデータ `coderouter_session_id` に写す。
+- `error` イベントまたは `turn.failed` を検出した場合、あるいは agent_message が1つも得られない/stdout が空/全行が非JSON の場合は retryable `AdapterError` としてフォールバックチェーンを次のプロバイダへ進める。JSONL の個々の行が非JSON でも他の行の処理は続行する(stderr 混入等への防御)。
+
+### 認証(ChatGPT プランサブスクリプション OAuth / API キー)
+
+codex CLI は ChatGPT プランの OAuth ログインに対応している。資格情報は `~/.codex/auth.json`(または OS キーチェーン)に保存され、アダプタの `HOME` 継承によって `passthrough_env: []` のままで動作する。
+
+1. `codex login` を実行してログインを済ませる。`codex login status` が exit 0 を返せばログイン済みと確認できる。
+2. OAuth トークンは**約8日で stale** になる。使用時に自動リフレッシュされるが、長期間 codex を呼び出さない構成では stale のまま失敗することがあるため、定期的に codex を実行するか再ログインしておくことを推奨する。
+
+CI などで API キー従量課金を使う場合は、`CODEX_API_KEY`(**exec 専用**)または `OPENAI_API_KEY`(一般)を `passthrough_env` に列挙する。`CODEX_HOME` で config/資格情報ディレクトリ自体を上書きすることも可能。
+
+### エラー報告
+
+codex CLI は成功時に終了コード 0、失敗時は非ゼロ終了コード + stderr にエラーテキストを出力する(例: git 外チェック失敗時のメッセージ)。JSONL 内に `error` イベントや `turn.failed` が含まれる場合もあり、これらも retryable な `AdapterError` としてフォールバックチェーンを次のプロバイダへ進める。
+
+### pre-1.0 であることの注意
+
+codex CLI は pre-1.0 でほぼ毎日リリースされている。`--json` の別名は依然として `--experimental-json` のままであり、JSONL スキーマは未凍結である。**バージョンの pin を推奨する**(`command` に固定版バイナリのフルパスを指定できる)。スキーマ変化が起きても防御的パースにより retryable な `AdapterError` となり、フォールバックチェーンの次のプロバイダへ降格する。
 
 ---
 
@@ -222,7 +320,9 @@ grok CLI は early beta である(v0.2.93 [stable] チャネル、2026-07-10 時
 | リクエストが `paid gate blocked` 相当で弾かれる/ルーティングされない | `agent_cli` プロバイダが `paid: true` なのに `ALLOW_PAID` が立っていない | サブスク運用なら `paid: false` にする。API キー従量課金で使うなら CodeRouter 起動時に `ALLOW_PAID=true` を設定する |
 | `claude exited 1: ...` のエラーメッセージに具体的な理由が出る | claude CLI は認証エラー等を **stdout** に `is_error: true` の JSON として出力し(stderr は空のまま)終了コード1で終わることがある | v2.7.7 の `_error_detail()` は stderr が空でも stdout の `is_error` JSON から `result` フィールド(実際のエラー文言、例: `Not logged in · Please run /login`)を優先的に拾ってエラーメッセージに含めるようになっている。表示されたメッセージをそのまま手がかりにできる |
 | `grok exited 1: ...` で失敗する | grok CLI は認証・ネットワーク・実行時エラーを終了コード1で終わり、エラーテキストを stderr に出す | アダプタが stderr の末尾を `AdapterError` に含めるので、そのメッセージを手がかりにする。認証エラーなら `grok login` を再実行し、`grok models` が通ることをスモーク確認する |
-| CLI 起動に失敗する(`failed to launch ...`) | `command`(既定は `agent` と同名)が `PATH` 上に無い | `claude --version` / `grok --version` が通ることを確認する。フルパスを `command` に指定してもよい |
+| `codex exited 1: ...` で失敗する(OAuth の stale を疑う場合) | codex の OAuth トークンは約8日で stale になる。使用時自動リフレッシュされるが、長期間呼び出しが無いと stale のまま失敗することがある | `codex login status` でログイン状態を確認し、必要なら `codex login` を再実行する。定期的に codex を実行しておくと stale 化を避けやすい |
+| `Not inside a trusted directory and --skip-git-repo-check was not specified.` が表示される | 通常は発生しない — アダプタは `--skip-git-repo-check` を常時付与するため | もし表示された場合は CodeRouter 側の argv 構築にバグがある可能性が高い。バージョンを確認し、再現するなら issue を報告する |
+| CLI 起動に失敗する(`failed to launch ...`) | `command`(既定は `agent` と同名)が `PATH` 上に無い | `claude --version` / `codex --version` / `grok --version` が通ることを確認する。フルパスを `command` に指定してもよい |
 
 ---
 

--- a/docs/designs/external-agents-adapter.md
+++ b/docs/designs/external-agents-adapter.md
@@ -2,7 +2,7 @@
 
 > 対象バージョン: CodeRouter v2.x 系 / Phase 1（in-core adapter）
 > 関連: [`docs/future.md`](../future.md) §1.2・§5、[`docs/backends/launcher.md`](../backends/launcher.md)
-> ステータス: 設計確定 / Phase 1a (claude)・Phase 1d (grok) 実装済み
+> ステータス: 設計確定 / Phase 1a (claude)・Phase 1b (codex)・Phase 1d (grok) 実装済み
 
 本設計書は、OpenAI Codex CLI・Google Gemini CLI・xAI Grok・Anthropic Claude Code CLI の4つの外部コーディングエージェントを、CodeRouter の新しいアダプタ種別 `kind="agent_cli"` として本体に組み込む方式を定義するものである。CLI のフラグ・認証仕様はすべて調査レポート（`RESEARCH-cli.md`、2026-07 時点）を、コード上の拡張点はすべてコード解析報告書（`ANALYSIS-code.md`）を典拠とする。ユーザー確定事項（`DECISIONS.md`）は拘束条件であり、本書はそれを厳密に実装する。
 
@@ -621,3 +621,22 @@ Phase 1d（grok）実装時に、設計時点の調査（`RESEARCH-cli.md`、202
 | メモリ | （記載なし） | grok はクロスセッションメモリを持つ。ステートレス性維持のためアダプタは **`--no-memory` を常時付与** |
 
 あわせて、§5.2.1 の検証ルール #1（`agent=="grok"` かつ `passthrough_env` に `XAI_API_KEY` が無い場合の警告）は前提の消滅により**廃止**した（実装には含まれない）。§9.2 の「API 直（openai_compat）推奨」は引き続き有効な代替経路である。
+
+### 11.4 Phase 1b 実CLI検証結果（codex-cli 0.144.1, 2026-07-11）
+
+Phase 1b（codex）実装時に、設計時点の調査（`RESEARCH-cli.md`、2026-07 時点）と実 CLI（codex-cli 0.144.1、作者の Mac、2026-07-11）との差分を検証した。本設計書の本文（§3.1・§5.1.5・§5.1.6・§5.2.1・§5.3.3・§5.4・§9・§11.1）のうち codex に関する記述は以下の検証結果で読み替えること（歴史的記録として本文は改変しない）。
+
+| 項目 | 設計時の想定 | 実 CLI での検証結果（0.144.1） |
+|---|---|---|
+| 承認フラグ（edit/full_auto） | `-a/--ask-for-approval` が存在し、`edit` → `-s workspace-write -a on-request`、`full_auto` → `-s workspace-write -a never` とマッピング（§5.4） | **`-a`/`--ask-for-approval` は `exec` サブコマンドに存在しない**（0.144.1 の `exec --help` に無し。非対話実行なので承認プロンプト自体が無い）。設計の `edit`/`full_auto` マッピングは obsolete — 両方とも `-s workspace-write` のみで、`edit` と `full_auto` は区別されない |
+| `--full-auto` | 非推奨のため使わないと注記（§5.1.5 補足） | **確認済み・不使用のまま**。`--dangerously-bypass-approvals-and-sandbox` も同様に使わない |
+| `--skip-git-repo-check` | git 外ディレクトリで動かす場合に付与、と注記（§5.1.5 補足） | **実機で必須と確認**。CodeRouter の隔離 workdir は git リポジトリではないため、無いと exit 1 + stderr `Not inside a trusted directory and --skip-git-repo-check was not specified.` で即座に失敗する（実測）。アダプタは常時付与する |
+| `--ephemeral` | セッション不保存の位置付けで言及（§5.1.5 補足） | **採用を確定**。grok の `--no-memory` と同じ理由（ステートレス思想）で常時付与する |
+| プロンプト投入 | 「引数末尾 or `-`（stdin）」（§5.1.5 表） | **stdin 方式を確定採用**。PROMPT 省略時（または明示 `-`）は stdin から読む。argv 末尾に明示の `-` を置く。claude と同じ経路であり、grok のような `--prompt-file` は不要 |
+| JSON 出力スキーマ | JSONL・最終回答は最後の `item.completed`（`item.type=="agent_message"`）の `item.text`、usage は `turn.completed.usage` の `input_tokens`/`cached_input_tokens`/`output_tokens`（§5.1.6） | **実機で確認・スキーマに追加あり**: `turn.completed.usage` に**新フィールド `reasoning_output_tokens`**が含まれる（設計時点では未記載）。0 より大きい場合は `completion_tokens_details.reasoning_tokens` として保持する（防御的）。`cached_input_tokens` は `input_tokens` の部分集合であり加算しない（実測: input 13810 ⊃ cached 9984） |
+| `--max-turns` / `--timeout` | 「（フラグ無し→外部 timeout で囲む）」と設計時点から想定済み（§5.1.5 表、§10 リスク表） | **設計どおり確認**。`--max-turns` も `--timeout` も存在せず、`AgentCliConfig.max_turns` は codex では無視される。`exec_timeout_s` + PGID kill のみが時間上限 |
+| 認証 | ChatGPT プラン OAuth or API key、約8日失効に既に言及（§5.3.3・§11.1） | **概ね設計どおりで確認・詳細確定**。`~/.codex/auth.json`（または OS キーチェーン）、約8日で stale・使用時自動リフレッシュ。CI 用に**`CODEX_API_KEY`（exec 専用）**および `OPENAI_API_KEY`（一般）の両方を確認。`CODEX_HOME` で config/資格情報ディレクトリを上書き可能（設計時点で未記載の追加事項） |
+| モデル | `gpt-5.5`（§3.1 の providers.yaml 例） | **`gpt-5.5` は現行フロンティアモデルとして引き続き有効**。既定モデルは環境/プラン依存のため `providers.yaml` での明示を推奨する方針も変更なし |
+| 成熟度 / バージョン churn | pre-1.0・要 pin（§10 リスク表、§11.1） | **確認済み**。CLI は pre-1.0 でほぼ毎日リリース。`--json` の別名は依然 `--experimental-json` のままでスキーマ未凍結 → バージョン pin 推奨 + 防御的パース必須の方針を維持 |
+
+あわせて、§5.1.5 表の codex 行の「サンドボックス/承認」列は `-s read-only` のみが確定であり、`edit`/`full_auto` は上表のとおり `-s workspace-write` に統一されたことを付記する（本文は歴史的記録として改変しない）。

--- a/examples/providers-agent-cli.yaml
+++ b/examples/providers-agent-cli.yaml
@@ -1,26 +1,28 @@
 # ============================================================
 # CodeRouter providers.yaml — 外部コーディングエージェント CLI (agent_cli)
-# 【カテゴリ】 kind="agent_cli" アダプタ / Phase 1a (claude)・Phase 1d (grok) 実装済み
+# 【カテゴリ】 kind="agent_cli" アダプタ / Phase 1a (claude)・Phase 1b (codex)・
+#              Phase 1d (grok) 実装済み
 #
 # 出典: docs/designs/external-agents-adapter.md
-# 目的: Claude Code CLI (`claude -p --output-format json`) や Grok CLI を
-#       CodeRouter の1プロバイダとして登録し、他のオーケストレータ
+# 目的: Claude Code CLI (`claude -p --output-format json`)、Codex CLI、
+#       Grok CLI を CodeRouter の1プロバイダとして登録し、他のオーケストレータ
 #       (別の Claude Code / Cursor 等) から「1つのモデル」として透過的に
 #       呼び出せるようにする。
 #       CodeRouter はワンショット exec (プロンプト in → テキスト out) の
 #       1変換だけを担い、エージェントのマルチターン制御ループそのものは
 #       中で完結させる (future.md の「1リクエスト=1変換」思想を維持)。
 #
-# 実装スコープ (v2.7.8 時点):
-#   - agent: claude (Phase 1a) と grok (Phase 1d) が実装済み。いずれも
-#     サブスクリプション OAuth を優先し (claude: `~/.claude/.credentials.json`
-#     または `claude setup-token`、grok: `~/.grok/auth.json`)、子プロセスには
+# 実装スコープ (v2.7.9 時点):
+#   - agent: claude (Phase 1a)・codex (Phase 1b)・grok (Phase 1d) が実装済み。
+#     いずれもサブスクリプション OAuth を優先し (claude:
+#     `~/.claude/.credentials.json` または `claude setup-token`、codex:
+#     `~/.codex/auth.json`、grok: `~/.grok/auth.json`)、子プロセスには
 #     ANTHROPIC_API_KEY 等を含む親環境を継承させない
 #     (env allowlist、下記 passthrough_env 参照)。
-#   - agent: codex / gemini は config スキーマ上は宣言できるが、
+#   - agent: gemini のみ config スキーマ上は宣言できるが、
 #     アダプタ構築時に AdapterError ("not implemented yet" — 実装済み
 #     エージェントの列挙付き) で拒否される。末尾にコメントアウトした
-#     Phase 1b-1c のプレビューブロック (未実装) を参照。
+#     Phase 1c のプレビューブロック (未実装) を参照。
 #   - 既定は read_only (書き込み不可)。書き込みを許可するには
 #     allow_file_writes: true と sandbox_mode: edit|full_auto を両方
 #     明示する必要がある (片方だけだと config load 時に ValueError)。
@@ -41,6 +43,11 @@
 #          -H 'Content-Type: application/json' \
 #          -H 'X-CodeRouter-Profile: claude-agent' \
 #          -d '{"model":"opus","messages":[{"role":"user","content":"1行でこんにちはと言って"}]}'
+#      下記の codex ブロックを有効化した場合の動作確認 (要 `codex login` 済み):
+#        curl http://localhost:8088/v1/chat/completions \
+#          -H 'Content-Type: application/json' \
+#          -H 'X-CodeRouter-Profile: codex' \
+#          -d '{"model":"gpt-5.5","messages":[{"role":"user","content":"1行でこんにちはと言って"}]}'
 #      下記の grok ブロックを有効化した場合の動作確認 (要 `grok login` 済み):
 #        curl http://localhost:8088/v1/chat/completions \
 #          -H 'Content-Type: application/json' \
@@ -78,6 +85,49 @@ providers:
       max_turns: 8                # CLI 内部のターン上限 (--max-turns)
       passthrough_env: [CLAUDE_CODE_OAUTH_TOKEN]   # setup-token を使う場合のみ (任意)
       agent_depth_limit: 2         # ネスト再帰 (CODEROUTER_AGENT_DEPTH) の上限
+
+  # ---- OpenAI Codex CLI (Phase 1b・実装済み — v2.7.9) ----
+  # 実装済みだが既定ではコメントアウトしてある: このファイルをそのまま
+  # コピーしても codex CLI のインストールを要求しないようにするため。
+  # codex CLI (0.144.1 で検証) を導入し `codex login` を済ませてから
+  # 有効化すること (`codex login status` が exit 0 を返せば認証 OK)。
+  # pre-1.0・ほぼ毎日リリースのためバージョン pin 推奨 (command にフルパス指定可)。
+  #
+  # 認証: ChatGPT プランサブスクリプション OAuth (`~/.codex/auth.json` または
+  #   OS キーチェーン、約8日で stale・使用時自動リフレッシュ)。CI で API
+  #   キー従量課金を使う場合のみ CODEX_API_KEY (exec専用) または
+  #   OPENAI_API_KEY を passthrough_env に列挙する。CODEX_HOME で
+  #   config/資格情報ディレクトリを上書き可能。
+  # max_turns: codex には対応する CLI フラグが無いため常に無視される。
+  #   時間上限は exec_timeout_s (+ プロセスグループ kill) のみが担う。
+  # サンドボックス: codex exec には承認フラグ (-a/--ask-for-approval) が
+  #   存在しない (非対話実行のため)。edit/full_auto はいずれも
+  #   -s workspace-write に写る (claude の acceptEdits と同様、両者は
+  #   区別されない)。
+  #
+  # - name: agent-codex
+  #   kind: agent_cli
+  #   model: gpt-5.5                # 現行フロンティアモデルの例。既定モデルは
+  #                                  # 環境/プラン依存のため明示推奨
+  #   paid: false                   # ChatGPT プランサブスクリプション OAuth 運用 = 従量課金ゼロ
+  #   capabilities:
+  #     streaming: false
+  #     tools: false
+  #   agent_cli:
+  #     agent: codex
+  #     command: codex
+  #     workdir: ~/.coderouter/agents/codex
+  #     exec_timeout_s: 600
+  #     allow_file_writes: false
+  #     sandbox_mode: read_only     # -s read-only にマップ
+  #     max_turns: 8                # codex では無視される (上記コメント参照)
+  #     passthrough_env: []         # OAuth は ~/.codex/auth.json を HOME 継承で読むため空でよい。
+  #                                  # CI で API キーを使う場合のみ CODEX_API_KEY (exec専用)
+  #                                  # または OPENAI_API_KEY を列挙する
+  #
+  # 有効化する場合は profiles にも次を追加する:
+  #   - name: codex
+  #     providers: [agent-codex]
 
   # ---- xAI Grok CLI (Phase 1d・実装済み — v2.7.8) ----
   # 実装済みだが既定ではコメントアウトしてある: このファイルをそのまま
@@ -139,36 +189,20 @@ profiles:
 #       match: { model_pattern: "claude-agent.*" }
 
 # ============================================================
-# 以下はプレビュー (Phase 1b-1c・未実装) — コメントアウト
+# 以下はプレビュー (Phase 1c・未実装) — コメントアウト
 #
-# 下記の agent: codex / gemini は config スキーマとしては
+# 下記の agent: gemini は config スキーマとしては
 # 有効 (providers.yaml として読み込める) だが、AgentCliAdapter が
-# claude / grok 以外を拒否するため、実際にリクエストを投げると
+# claude / codex / grok 以外を拒否するため、実際にリクエストを投げると
 # 起動時におおよそ次の形の AdapterError (正確な文言は変わりうる)
-#   AdapterError: agent 'codex' is not implemented yet
-#   (implemented: claude, grok). Wait for the agent's phase (1b/1c).
+#   AdapterError: agent 'gemini' is not implemented yet
+#   (implemented: claude, codex, grok). Wait for the agent's phase (1c).
 # で失敗する (retryable=False)。将来のフェーズが実装されるまでの
 # forward-compatible なプレースホルダとして参照用に残してある。
 # 詳細: docs/designs/external-agents-adapter.md §3, §9
 # ============================================================
 
 # providers:
-#   # ---- OpenAI Codex CLI (Phase 1b・未実装) ----
-#   - name: agent-codex
-#     kind: agent_cli
-#     model: gpt-5.5
-#     paid: false               # サブスク OAuth 運用なら false
-#     capabilities:
-#       streaming: false
-#     agent_cli:
-#       agent: codex
-#       command: codex
-#       workdir: ~/.coderouter/agents/codex
-#       exec_timeout_s: 600
-#       allow_file_writes: false
-#       sandbox_mode: read_only
-#       passthrough_env: []        # サブスク OAuth は ~/.codex から読む
-#
 #   # ---- Google Gemini CLI (Phase 1c・未実装) ----
 #   - name: agent-gemini
 #     kind: agent_cli
@@ -187,7 +221,5 @@ profiles:
 #       passthrough_env: [GEMINI_API_KEY]   # OAuth キャッシュが無い場合の保険
 #
 # profiles:
-#   - name: codex
-#     providers: [agent-codex]
 #   - name: gemini
 #     providers: [agent-gemini]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 # in plan.md §11.B; once granted, this name will become an alias and
 # `coderouter` will become the canonical distribution name.
 name = "coderouter-cli"
-version = "2.7.8"
+version = "2.7.9"
 description = "Local-first, free-first, fallback-built-in LLM router. Claude Code / OpenAI compatible."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,20 +1,25 @@
-"""Tests for the agent_cli adapter (Phase 1a claude + Phase 1d grok).
+"""Tests for the agent_cli adapter (Phase 1a claude + Phase 1b codex +
+Phase 1d grok).
 
-Implements the design's §8 test plan for the Phase 1a/1d scope:
+Implements the design's §8 test plan for the Phase 1a/1b/1d scope:
 
 * T1  argv construction (model / max-turns / permission-mode mapping,
-      allow_file_writes clamp) — for both claude and grok (grok adds the
-      --prompt-file / --no-memory / --sandbox shape).
-* T2  claude / grok JSON parsing (success / is_error / malformed / missing
-      fields; grok's zero-usage + sessionId meta).
+      allow_file_writes clamp) — for claude, codex and grok (codex adds the
+      exec/--json/--skip-git-repo-check/--ephemeral/-s/trailing "-" shape;
+      grok adds the --prompt-file / --no-memory / --sandbox shape).
+* T2  claude / codex / grok output parsing (success / is_error / malformed /
+      missing fields; codex's JSONL + cached-tokens-as-subset usage +
+      thread_id meta; grok's zero-usage + sessionId meta).
 * T3  stubbed subprocess via ``asyncio.create_subprocess_exec`` monkeypatch
-      (grok additionally checks the prompt-file lifecycle: 0600 file exists
+      (codex checks the stdin prompt-delivery path with no prompt file;
+      grok additionally checks the prompt-file lifecycle: 0600 file exists
       and contains the prompt DURING the exec, deleted afterwards, also on
       failure / timeout paths).
 * T4  TestClient E2E through ``POST /v1/chat/completions``.
 * T6  timeout → process-group kill + retryable AdapterError.
 * T7  child-env isolation (no ANTHROPIC_API_KEY leak, NO_COLOR present,
-      passthrough allowlist incl. GROK_CODE_XAI_API_KEY, depth +1).
+      passthrough allowlist incl. GROK_CODE_XAI_API_KEY / CODEX_API_KEY,
+      depth +1).
 * T8  recursion depth limit → non-retryable AdapterError.
 
 Plus config-schema validation (agent_cli required, base_url optionality,
@@ -86,6 +91,37 @@ GROK_RESULT = {
 }
 GROK_JSON = json.dumps(GROK_RESULT).encode("utf-8")
 
+# ---------------------------------------------------------------------------
+# Canned codex `exec --json` JSONL output (verified on codex-cli 0.144.1 —
+# see _codex/facts-codex.md; one JSON object per line, newline-delimited)
+# ---------------------------------------------------------------------------
+
+CODEX_JSONL = b"\n".join(
+    [
+        json.dumps(
+            {"type": "thread.started", "thread_id": "019f4e74-08fd-77b2-9cc6-9afa744df130"}
+        ).encode("utf-8"),
+        json.dumps({"type": "turn.started"}).encode("utf-8"),
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"id": "item_0", "type": "agent_message", "text": "2"},
+            }
+        ).encode("utf-8"),
+        json.dumps(
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 13810,
+                    "cached_input_tokens": 9984,
+                    "output_tokens": 5,
+                    "reasoning_output_tokens": 0,
+                },
+            }
+        ).encode("utf-8"),
+    ]
+)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -115,6 +151,21 @@ def _make_grok_adapter(**agent_cli_overrides: object) -> AgentCliAdapter:
         name="agent-grok",
         kind="agent_cli",
         model="grok-4.5",
+        paid=True,
+        capabilities=Capabilities(streaming=False),
+        agent_cli=AgentCliConfig(**acfg),  # type: ignore[arg-type]
+    )
+    return AgentCliAdapter(provider)
+
+
+def _make_codex_adapter(**agent_cli_overrides: object) -> AgentCliAdapter:
+    """Build an AgentCliAdapter with a codex sub-config + overrides."""
+    acfg: dict[str, object] = {"agent": "codex"}
+    acfg.update(agent_cli_overrides)
+    provider = ProviderConfig(
+        name="agent-codex",
+        kind="agent_cli",
+        model="gpt-5.5",
         paid=True,
         capabilities=Capabilities(streaming=False),
         agent_cli=AgentCliConfig(**acfg),  # type: ignore[arg-type]
@@ -331,6 +382,79 @@ def test_grok_argv_no_memory_and_no_prompt_in_argv() -> None:
 
 
 # ---------------------------------------------------------------------------
+# T1 (codex) — argv construction
+# ---------------------------------------------------------------------------
+
+
+def test_codex_argv_read_only_default_full_snapshot() -> None:
+    adapter = _make_codex_adapter(workdir="/tmp/wd")
+    argv = adapter._build_codex_argv("/tmp/wd")
+    assert argv == [
+        "codex",
+        "exec",
+        "--json",
+        "--skip-git-repo-check",
+        "--ephemeral",
+        "-m",
+        "gpt-5.5",
+        "-C",
+        "/tmp/wd",
+        "-s",
+        "read-only",
+        "-",
+    ]
+
+
+def test_codex_argv_edit_maps_workspace_write() -> None:
+    adapter = _make_codex_adapter(sandbox_mode="edit", allow_file_writes=True)
+    argv = adapter._build_codex_argv("/w")
+    assert argv[argv.index("-s") + 1] == "workspace-write"
+
+
+def test_codex_argv_full_auto_maps_workspace_write() -> None:
+    # exec has no approval flag in 0.144.1, so full_auto collapses onto the
+    # same workspace-write value as edit.
+    adapter = _make_codex_adapter(sandbox_mode="full_auto", allow_file_writes=True)
+    argv = adapter._build_codex_argv("/w")
+    assert argv[argv.index("-s") + 1] == "workspace-write"
+    assert "--dangerously-bypass-approvals-and-sandbox" not in argv
+
+
+def test_codex_argv_read_only_clamp_when_writes_disabled() -> None:
+    adapter = _make_codex_adapter(sandbox_mode="edit", allow_file_writes=False)
+    argv = adapter._build_codex_argv("/w")
+    assert argv[argv.index("-s") + 1] == "read-only"
+
+
+def test_codex_argv_omits_max_turns_even_when_set() -> None:
+    # codex has no --max-turns equivalent; the flag must never appear, even
+    # when the config sets max_turns explicitly.
+    adapter = _make_codex_adapter(max_turns=5)
+    argv = adapter._build_codex_argv("/w")
+    assert "--max-turns" not in argv
+
+
+def test_codex_argv_model_override() -> None:
+    adapter = _make_codex_adapter(model="gpt-5.5-mini")
+    argv = adapter._build_codex_argv("/w")
+    assert argv[argv.index("-m") + 1] == "gpt-5.5-mini"
+
+
+def test_codex_argv_always_skips_git_check_and_ephemeral() -> None:
+    adapter = _make_codex_adapter()
+    argv = adapter._build_codex_argv("/w")
+    assert "--skip-git-repo-check" in argv
+    assert "--ephemeral" in argv
+
+
+def test_codex_argv_trailing_stdin_sentinel_and_no_prompt() -> None:
+    adapter = _make_codex_adapter()
+    argv = adapter._build_codex_argv("/w")
+    assert argv[-1] == "-"
+    assert all("hi there" not in arg for arg in argv)
+
+
+# ---------------------------------------------------------------------------
 # T7 — child-env isolation
 # ---------------------------------------------------------------------------
 
@@ -396,6 +520,17 @@ def test_env_grok_api_key_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
     env = adapter._build_child_env()
     assert env["GROK_CODE_XAI_API_KEY"] == "xai-tok-123"
     assert "XAI_API_KEY" not in env
+
+
+def test_env_codex_api_key_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CODEX_API_KEY (codex's exec-only CI key env) is forwarded only when
+    allowlisted; ChatGPT-plan OAuth under ~/.codex rides on HOME."""
+    monkeypatch.setenv("CODEX_API_KEY", "codex-tok-123")
+    monkeypatch.setenv("OPENAI_API_KEY", "wrong-var-should-not-leak")
+    adapter = _make_codex_adapter(passthrough_env=["CODEX_API_KEY"])
+    env = adapter._build_child_env()
+    assert env["CODEX_API_KEY"] == "codex-tok-123"
+    assert "OPENAI_API_KEY" not in env
 
 
 def test_env_depth_incremented(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -519,6 +654,144 @@ def test_grok_parse_thought_field_ignored() -> None:
 
 
 # ---------------------------------------------------------------------------
+# T2 (codex) — codex JSONL parsing
+# ---------------------------------------------------------------------------
+
+
+def test_codex_parse_success() -> None:
+    adapter = _make_codex_adapter()
+    text, usage, meta = adapter._parse_codex(CODEX_JSONL, b"")
+    assert text == "2"
+    # cached_input_tokens (9984) is a SUBSET of input_tokens (13810), not
+    # additive — prompt_tokens stays 13810, NOT 13810 + 9984.
+    assert usage["prompt_tokens"] == 13810
+    assert usage["completion_tokens"] == 5
+    assert usage["total_tokens"] == 13815
+    assert usage["prompt_tokens_details"]["cached_tokens"] == 9984
+    # reasoning_output_tokens was 0 → no completion_tokens_details emitted.
+    assert "completion_tokens_details" not in usage
+    assert meta["coderouter_session_id"] == "019f4e74-08fd-77b2-9cc6-9afa744df130"
+
+
+def test_codex_parse_reasoning_tokens_surfaced_when_nonzero() -> None:
+    adapter = _make_codex_adapter()
+    lines = [
+        json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "ok"}}),
+        json.dumps(
+            {
+                "type": "turn.completed",
+                "usage": {
+                    "input_tokens": 10,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 20,
+                    "reasoning_output_tokens": 7,
+                },
+            }
+        ),
+    ]
+    payload = "\n".join(lines).encode("utf-8")
+    _text, usage, _meta = adapter._parse_codex(payload, b"")
+    assert usage["completion_tokens_details"]["reasoning_tokens"] == 7
+    assert "prompt_tokens_details" not in usage
+
+
+def test_codex_parse_multiple_turn_completed_summed() -> None:
+    adapter = _make_codex_adapter()
+    lines = [
+        json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "x"}}),
+        json.dumps(
+            {
+                "type": "turn.completed",
+                "usage": {"input_tokens": 10, "output_tokens": 1, "cached_input_tokens": 2},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "turn.completed",
+                "usage": {"input_tokens": 20, "output_tokens": 3, "cached_input_tokens": 4},
+            }
+        ),
+    ]
+    payload = "\n".join(lines).encode("utf-8")
+    _text, usage, _meta = adapter._parse_codex(payload, b"")
+    assert usage["prompt_tokens"] == 30
+    assert usage["completion_tokens"] == 4
+    assert usage["prompt_tokens_details"]["cached_tokens"] == 6
+
+
+def test_codex_parse_garbage_lines_skipped_answer_still_parsed() -> None:
+    adapter = _make_codex_adapter()
+    lines = [
+        "not json at all {",
+        json.dumps(["also", "not", "a", "dict"]),
+        json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "ok"}}),
+        "",
+        "   ",
+        json.dumps({"type": "turn.completed", "usage": {"input_tokens": 1, "output_tokens": 1}}),
+    ]
+    payload = "\n".join(lines).encode("utf-8")
+    text, usage, _meta = adapter._parse_codex(payload, b"")
+    assert text == "ok"
+    assert usage["prompt_tokens"] == 1
+
+
+def test_codex_parse_last_agent_message_wins() -> None:
+    adapter = _make_codex_adapter()
+    lines = [
+        json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "first"}}),
+        json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "last"}}),
+    ]
+    payload = "\n".join(lines).encode("utf-8")
+    text, _usage, _meta = adapter._parse_codex(payload, b"")
+    assert text == "last"
+
+
+def test_codex_parse_error_event_without_agent_message_raises_retryable() -> None:
+    adapter = _make_codex_adapter()
+    payload = json.dumps({"type": "error", "message": "boom"}).encode("utf-8")
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_codex(payload, b"")
+    assert info.value.retryable is True
+    assert "boom" in str(info.value) or "error" in str(info.value)
+
+
+def test_codex_parse_turn_failed_without_agent_message_raises_retryable() -> None:
+    adapter = _make_codex_adapter()
+    payload = json.dumps({"type": "turn.failed", "reason": "context_overflow"}).encode("utf-8")
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_codex(payload, b"")
+    assert info.value.retryable is True
+
+
+def test_codex_parse_error_after_valid_agent_message_answer_wins() -> None:
+    # A completed answer beats a trailing error event.
+    adapter = _make_codex_adapter()
+    lines = [
+        json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "done"}}),
+        json.dumps({"type": "error", "message": "late failure"}),
+    ]
+    payload = "\n".join(lines).encode("utf-8")
+    text, _usage, _meta = adapter._parse_codex(payload, b"")
+    assert text == "done"
+
+
+def test_codex_parse_no_agent_message_raises_retryable() -> None:
+    adapter = _make_codex_adapter()
+    payload = json.dumps({"type": "turn.started"}).encode("utf-8")
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_codex(payload, b"")
+    assert info.value.retryable is True
+    assert "no agent_message" in str(info.value)
+
+
+def test_codex_parse_empty_stdout_raises_retryable() -> None:
+    adapter = _make_codex_adapter()
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_codex(b"   \n", b"")
+    assert info.value.retryable is True
+
+
+# ---------------------------------------------------------------------------
 # T3 — generate() with a stubbed subprocess
 # ---------------------------------------------------------------------------
 
@@ -609,6 +882,44 @@ async def test_grok_generate_nonzero_exit_cleans_prompt_file(
     path = argv[argv.index("--prompt-file") + 1]
     assert not os.path.exists(path)
     assert list(tmp_path.glob(".coderouter-prompt-*")) == []
+
+
+# ---------------------------------------------------------------------------
+# T3 (codex) — generate() with a stubbed subprocess (stdin prompt delivery)
+# ---------------------------------------------------------------------------
+
+
+async def test_codex_generate_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    proc = _FakeProc(stdout=CODEX_JSONL, returncode=0)
+    captured = _patch_exec(monkeypatch, proc)
+    adapter = _make_codex_adapter(workdir=str(tmp_path))
+
+    resp = await adapter.generate(_request())
+
+    assert resp.choices[0]["message"]["content"] == "2"
+    assert resp.coderouter_provider == "agent-codex"
+    assert resp.model == "gpt-5.5"
+    assert resp.coderouter_session_id == "019f4e74-08fd-77b2-9cc6-9afa744df130"
+    # Prompt was fed on stdin, not argv — codex is a stdin-delivery agent
+    # like claude, not a --prompt-file agent like grok.
+    assert proc.stdin_received is not None
+    assert b"hi there" in proc.stdin_received
+    argv = captured[0]
+    assert all("hi there" not in arg for arg in argv)
+    assert "--prompt-file" not in argv
+    # No private prompt file was ever created in the workdir.
+    assert list(tmp_path.glob(".coderouter-prompt-*")) == []
+
+
+async def test_codex_generate_nonzero_exit_is_retryable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    proc = _FakeProc(stdout=b"", stderr=b"not inside a trusted directory", returncode=1)
+    _patch_exec(monkeypatch, proc)
+    adapter = _make_codex_adapter(workdir=str(tmp_path))
+    with pytest.raises(AdapterError) as info:
+        await adapter.generate(_request())
+    assert info.value.retryable is True
 
 
 # ---------------------------------------------------------------------------
@@ -704,17 +1015,17 @@ async def test_healthcheck_present_binary(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_unsupported_agent_raises_non_retryable() -> None:
     provider = ProviderConfig(
-        name="agent-codex",
+        name="agent-gemini",
         kind="agent_cli",
-        model="gpt-5.5",
+        model="gemini-pro",
         paid=True,
-        agent_cli=AgentCliConfig(agent="codex"),
+        agent_cli=AgentCliConfig(agent="gemini"),
     )
     with pytest.raises(AdapterError) as info:
         AgentCliAdapter(provider)
     assert info.value.retryable is False
     assert "not implemented yet" in str(info.value)
-    assert "implemented: claude, grok" in str(info.value)
+    assert "implemented: claude, codex, grok" in str(info.value)
 
 
 # ---------------------------------------------------------------------------
@@ -866,3 +1177,62 @@ def test_e2e_grok_chat_completions(grok_e2e_client: TestClient) -> None:
     assert body["coderouter_provider"] == "agent-grok"
     # grok emits no token counts — usage is reported as zeros end-to-end.
     assert body["usage"]["total_tokens"] == 0
+
+
+# ---------------------------------------------------------------------------
+# T4 (codex) — TestClient E2E through /v1/chat/completions
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def codex_e2e_config(tmp_path: Path) -> CodeRouterConfig:
+    return CodeRouterConfig(
+        allow_paid=True,
+        default_profile="codex-agent",
+        providers=[
+            ProviderConfig(
+                name="agent-codex",
+                kind="agent_cli",
+                model="gpt-5.5",
+                paid=True,
+                capabilities=Capabilities(streaming=False),
+                agent_cli=AgentCliConfig(agent="codex", workdir=str(tmp_path)),
+            ),
+        ],
+        profiles=[FallbackChain(name="codex-agent", providers=["agent-codex"])],
+    )
+
+
+@pytest.fixture
+def codex_e2e_client(
+    codex_e2e_config: CodeRouterConfig, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[TestClient]:
+    proc = _FakeProc(stdout=CODEX_JSONL, returncode=0)
+
+    async def fake_exec(*argv: str, **kwargs: object) -> _FakeProc:
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr("coderouter.ingress.app.load_config", lambda path=None: codex_e2e_config)
+    uninstall_collector()
+    app = create_app()
+    try:
+        with TestClient(app) as tc:
+            yield tc
+    finally:
+        uninstall_collector()
+
+
+def test_e2e_codex_chat_completions(codex_e2e_client: TestClient) -> None:
+    resp = codex_e2e_client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"X-CodeRouter-Profile": "codex-agent"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["choices"][0]["message"]["content"] == "2"
+    assert body["coderouter_provider"] == "agent-codex"
+    assert body["usage"]["prompt_tokens"] == 13810
+    assert body["usage"]["total_tokens"] == 13815
+    assert body["coderouter_session_id"] == "019f4e74-08fd-77b2-9cc6-9afa744df130"

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "coderouter-cli"
-version = "2.7.8"
+version = "2.7.9"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Adds the **codex (OpenAI Codex CLI)** target to the `agent_cli` adapter
(Phase 1b of docs/designs/external-agents-adapter.md). Implemented agents
are now **claude (1a) + codex (1b) + grok (1d)**; gemini remains
schema-declared and rejected until Phase 1c.

All flags and the JSONL schema were verified against the **real CLI
(codex-cli 0.144.1)** before implementation, per the design's
verify-on-real-CLI process (recorded in design doc §11.4). Design-time
assumptions that changed:

- **`codex exec` has no approval flag** in 0.144.1 — the design's
  `-a on-request` / `-a never` mappings are obsolete; `edit` and
  `full_auto` both map to `-s workspace-write`
  (`--dangerously-bypass-approvals-and-sandbox` is never used).
- usage now includes a **`reasoning_output_tokens`** field (surfaced as
  `completion_tokens_details.reasoning_tokens`).

Confirmed as designed: JSONL on stdout / progress on stderr; final answer
in the last `item.completed` `agent_message`; usage in `turn.completed`;
**no `--max-turns` / `--timeout`** (external `exec_timeout_s` + PGID kill
remains the only time bound); `--skip-git-repo-check` required outside a
git repo (field-verified exit 1).

## Implementation

- argv (read_only default):
  `codex exec --json --skip-git-repo-check --ephemeral -m <model>
  -C <workdir> -s read-only -`
- Prompt on **stdin** via the trailing `-` sentinel (same as claude,
  unlike grok's `--prompt-file`); no prompt file is created.
- `--ephemeral` always passed — no session persistence, preserving the
  "1 request = 1 stateless transformation" ethos (grok's `--no-memory`
  analogue).
- Defensive JSONL parser (pre-1.0 CLI; `--json` still aliases
  `--experimental-json`): per-line parse with skip-on-garbage, last
  agent_message wins, completed answer beats a trailing `error` event,
  usage summed across `turn.completed` events with cached tokens kept as
  a subset (`prompt_tokens_details.cached_tokens`), `thread_id` →
  `coderouter_session_id`.
- Auth: ChatGPT-plan OAuth (`~/.codex/auth.json`, ~8-day staleness with
  auto-refresh) via HOME inheritance, `passthrough_env: []`; CI path is
  `CODEX_API_KEY` (exec-only) / `OPENAI_API_KEY`.

## Verification

- Unit: `tests/test_agent_cli.py` **50 → 72 passed** (ruff clean); claude
  and grok argv snapshots unchanged byte-for-byte.
- Adversarial review (separate agent): **APPROVE** — 15 crafted parser
  inputs (garbage lines, non-dict items, float/None usage, error-event
  orderings, 100k-line stream) with zero unexpected exceptions; security
  requirements (argv allowlist, env allowlist, PGID kill, clamp,
  recursion cap) verified intact.
- Real-CLI dress rehearsal: production-identical argv returned
  `{"text":"5"}` for 2+3 on codex-cli 0.144.1 / macOS.
- E2E (T9): `coderouter serve` → `POST /v1/chat/completions` with
  `X-CodeRouter-Profile: codex`.

## Docs

- `docs/backends/external-agents.md` / `.en.md`: codex section (config,
  argv, sandbox table incl. the no-approval-flag note, OAuth + 8-day
  staleness, JSONL/usage normalization, version-pin caveat,
  troubleshooting rows).
- `docs/designs/external-agents-adapter.md`: status header + §11.4
  real-CLI verification record.
- `examples/providers-agent-cli.yaml`: codex block promoted to 実装済み
  (kept commented); preview section now Phase 1c (gemini) only.
- CHANGELOG: v2.7.9 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NM473z8MscgHUsGDkiuDTq
