### PR TITLE
feat(adapters): agent_cli Phase 1c — antigravity backend, Phase 1 complete (v2.7.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,104 @@ are kept verbatim where the Japanese text itself is the subject).
 
 ---
 
+## [v2.7.10] — 2026-07-11 (agent_cli Phase 1c: antigravity — Phase 1 complete)
+
+Completes agent_cli Phase 1: `agent: antigravity` (the Google Antigravity
+CLI, command `agy`) is now implemented, joining `claude` (1a), `codex`
+(1b), and `grok` (1d) — all four Phase 1 backends are now in place. This
+target replaces the originally-planned `gemini`: on the author's Mac, the
+legacy Gemini CLI (`@google/gemini-cli` 0.50.x) now fails individual-account
+OAuth outright with a verified `IneligibleTierError: This client is no
+longer supported for Gemini Code Assist for individuals. To continue using
+Gemini, please migrate to the Antigravity suite of products:
+https://antigravity.google` (`reasonCode: UNSUPPORTED_CLIENT`,
+`tierId: free-tier`) — Google discontinued Gemini CLI for individual
+accounts on 2026-06-18. The same legacy CLI also still hits the
+trusted-directory gate with exit 55 (`--skip-trust` /
+`GEMINI_CLI_TRUST_WORKSPACE=true`), a pre-existing constraint unrelated to
+the discontinuation. Google's stated successor is the Antigravity CLI
+(`agy`) — a separate Go rewrite, not a fork of gemini-cli — which keeps
+individual Google-account OAuth alive, including the free tier. Verified
+against agy **1.1.1** (author's Mac, 2026-07-11), its flag surface differs
+meaningfully from gemini-cli's: no `--output-format json` (plain-text
+output only), `--mode plan|accept-edits` instead of an approval-mode flag,
+a `--dangerously-skip-permissions` full-bypass flag, a CLI-side
+`--print-timeout` (the first agent_cli target with its own timeout), no
+`--max-turns`, and no stdin channel for the prompt at all — piping stdin to
+`agy` hangs (field-verified). `agent: gemini` remains schema-declared but
+is now rejected with a migration-pointer message instead of a generic
+not-implemented one.
+
+### Added
+
+- **`agent: antigravity` builder/parser in `AgentCliAdapter`**
+  (`coderouter/adapters/agent_cli.py`) — invokes the Antigravity CLI
+  one-shot as `agy -p <prompt> --model <model> --mode plan --print-timeout
+  <exec_timeout_s>s` (read_only default). The prompt rides on argv as the
+  value of `-p` — agy has no `--prompt-file` equivalent and hangs if stdin
+  is piped (field-verified), so this is the fourth prompt-delivery pattern
+  among the four backends (claude/codex use stdin, grok uses
+  `--prompt-file`, antigravity uses argv). Documented limitation: Linux's
+  `MAX_ARG_STRLEN` (~128KiB) caps prompt size, and the prompt is visible in
+  `ps` output — there is no way around this with agy's current flag
+  surface. Output is plain text: stdout is decoded UTF-8, defensively
+  stripped of ANSI escapes, and trimmed; an empty result raises a
+  retryable `AdapterError`. There is no `--output-format json`, so token
+  usage, session id, and structured errors are all unavailable — usage is
+  reported as all zeros (same treatment as grok), and
+  `coderouter_session_id` is never populated.
+- **`sandbox_mode` → antigravity flag mapping** — `read_only` →
+  `--mode plan`; `edit` → `--mode accept-edits`; `full_auto` →
+  `--mode accept-edits --dangerously-skip-permissions`. As with the other
+  three backends, the effective mode is clamped to read-only whenever
+  `allow_file_writes=false`.
+- **`--print-timeout` as a CLI-side first wall** — generated from
+  `AgentCliConfig.exec_timeout_s` (e.g. `exec_timeout_s=600` →
+  `--print-timeout 600s`), letting agy self-terminate before the outer
+  `asyncio.wait_for` + process-group `SIGKILL` fires. antigravity is the
+  only agent_cli target with a double timeout wall.
+- **`max_turns` ignored for antigravity** — agy has no
+  `--max-turns`-equivalent flag; `AgentCliConfig.max_turns` has no effect
+  when `agent: antigravity`, same as codex.
+- **`command` defaults to `"agy"`** — the only agent_cli target whose
+  default executable name differs from the `agent` field value (the binary
+  is named for the CLI, not the product).
+- **5th `Literal` value on `AgentCliConfig.agent`** — `"antigravity"` joins
+  `claude`/`codex`/`gemini`/`grok`.
+
+### Changed
+
+- **`agent: gemini` now rejected with a migration message** instead of the
+  generic "not implemented yet" wording — constructing the adapter with
+  `agent: gemini` now raises `AdapterError: Google discontinued Gemini CLI
+  for individual accounts (June 2026). Use agent='antigravity' instead.`
+  (`retryable=False`).
+- **Schema docstrings** (`coderouter/config/schemas.py`) — `AgentCliConfig`
+  field descriptions updated for the four-backend reality
+  (claude/codex/antigravity/grok implemented, gemini rejected), including
+  the `command` and `max_turns` docstrings noting antigravity's `agy`
+  default and ignored `max_turns`.
+- **Docs & examples** — `docs/backends/external-agents.md`/`.en.md` gain a
+  full antigravity section (config example, adapter argv, the
+  argv-vs-stdin-vs-`--prompt-file` prompt-delivery comparison across all
+  four backends, mode mapping table, plain-text parsing and zero usage,
+  the `--print-timeout` double wall, OAuth setup with the `agy models`
+  smoke check, the display-string model-name caveat including that Claude
+  models are reachable through agy, the stdin-pipe-hang warning, and the
+  version-pin caveat) and lead with the gemini-discontinuation story
+  (updated implementation-status wording: Phase 1 complete, all four
+  backends). The design doc `docs/designs/external-agents-adapter.md` gets
+  a new appendix §11.5 recording the gemini-to-antigravity delta (body
+  text left as the historical record); its header status line now reads
+  Phase 1 (1a/1b/1c/1d) complete. `examples/providers-agent-cli.yaml`
+  replaces the Phase 1c gemini preview block with a documented (still
+  commented-out) antigravity block, with the now-empty
+  "unimplemented preview" framing removed since nothing remains
+  unimplemented.
+
 ## [v2.7.9] — 2026-07-11 (agent_cli Phase 1b: codex)
 
-**PR #69**. Adds the third target to the `agent_cli` adapter: `agent: codex` (the OpenAI
+Adds the third target to the `agent_cli` adapter: `agent: codex` (the OpenAI
 Codex CLI) is now implemented alongside `claude` (Phase 1a) and `grok`
 (Phase 1d). The implementation was verified against the real CLI (codex-cli
 0.144.1, 2026-07-11), and one design-time assumption from the 2026-07

--- a/coderouter/adapters/agent_cli.py
+++ b/coderouter/adapters/agent_cli.py
@@ -1,9 +1,9 @@
 """External coding-agent CLI adapter (``kind="agent_cli"``).
 
 This adapter invokes an external coding-agent CLI (Claude Code / Codex /
-Gemini / Grok) as a single one-shot ``exec`` and returns the agent's final
-answer as one ``prompt in → text out`` transformation. It is the in-core
-implementation of the external-agents-adapter design
+Antigravity / Grok) as a single one-shot ``exec`` and returns the agent's
+final answer as one ``prompt in → text out`` transformation. It is the
+in-core implementation of the external-agents-adapter design
 (``docs/designs/external-agents-adapter.md``).
 
 Design in one paragraph
@@ -18,10 +18,10 @@ CodeRouter merely performs the one conversion. Following the
 ``openai_compat`` precedent, a *single* adapter class fronts *multiple*
 target agents, dispatched on the ``agent`` field.
 
-Implemented agents (Phase 1a + 1b + 1d)
-========================================
+Implemented agents (Phase 1 complete: 1a + 1b + 1c + 1d)
+==========================================================
 
-Three targets are implemented here:
+Four targets are implemented here:
 
 * ``claude`` (Claude Code CLI, Phase 1a) — the most stable CLI, the most
   fine-grained safety controls, and the only one that emits
@@ -42,22 +42,44 @@ Three targets are implemented here:
   ``ProviderConfig.cost``, design §5.1.6). ``--no-memory`` is always passed
   so a user-level cross-session memory setting cannot leak state between
   requests.
+* ``antigravity`` (Antigravity CLI, command ``agy``, Phase 1c, in lieu of
+  ``gemini``) — headless one-shot via ``agy -p <prompt> --mode ...``.
+  Google discontinued the legacy Gemini CLI's OAuth for individual
+  accounts in June 2026 (field-verified ``IneligibleTierError`` /
+  ``UNSUPPORTED_CLIENT``); its successor, the Antigravity CLI, is a
+  separate Go implementation (not a gemini-cli fork) fulfilling the design's
+  "gemini" slot. It has no stdin or ``--prompt-file`` channel — piped stdin
+  hangs the CLI (field-verified on agy 1.1.1) — so the prompt rides argv
+  (see the security note below). Output is plain text with no
+  ``--output-format`` flag, no token/cost figures, and no session id, so
+  usage is reported as zeros and meta is empty, mirroring grok's rationale.
+  It is also the only agent with a CLI-side self-termination flag
+  (``--print-timeout``), layered *underneath* the adapter's own
+  ``asyncio.wait_for`` + PGID SIGKILL rather than replacing it.
 
-The remaining agent (gemini) is declared in the config schema so
-providers.yaml is forward-compatible, but constructing an adapter for it
-raises a clear ``AdapterError`` until its phase (1c) lands.
+``gemini`` itself is declared in the config schema for backward-compatible
+config parsing, but constructing an adapter for it raises a clear
+``AdapterError`` with a migration pointer to ``agent="antigravity"``.
 
 Security (design §6, non-negotiable)
 ====================================
 
 * **allowlist argv only** — the child is launched with
   :func:`asyncio.create_subprocess_exec` and a list argv. ``shell=True`` is
-  never used; the prompt is never subject to shell interpretation (claude
-  and codex read it from stdin — codex's argv carries a trailing ``-``
-  sentinel making that explicit; grok reads it from a private ``0600``
-  prompt file inside the resolved workdir — its ``-p`` requires the prompt
-  as an argv value, and argv would both hit Linux's ~128KiB
-  ``MAX_ARG_STRLEN`` on huge prompts and leak the text into ``ps`` output).
+  never used. Prompt delivery is one of three mechanisms depending on the
+  agent: claude and codex read it from stdin (codex's argv carries a
+  trailing ``-`` sentinel making that explicit); grok reads it from a
+  private ``0600`` prompt file inside the resolved workdir (its ``-p``
+  requires the prompt as an argv value, and argv would both hit Linux's
+  ~128KiB ``MAX_ARG_STRLEN`` on huge prompts and leak the text into ``ps``
+  output); antigravity has neither a stdin nor a ``--prompt-file`` channel
+  (piped stdin hangs the CLI, field-verified), so its prompt is carried on
+  argv — accepting the same ``MAX_ARG_STRLEN`` cap and local ``ps``
+  visibility that grok's file delivery was specifically designed to avoid.
+  No shell is involved in any case (list argv, never shell text), and the
+  documented threat model (an isolated, single-operator workstation) treats
+  local ``ps`` visibility as an accepted, documented limitation for
+  antigravity rather than a defect.
 * **default read-only** — ``allow_file_writes=False`` /
   ``sandbox_mode="read_only"`` are the defaults, mapped to claude's
   ``--permission-mode plan``. Writes require explicit opt-in and the sandbox
@@ -82,6 +104,7 @@ import asyncio
 import contextlib
 import json
 import os
+import re
 import shutil
 import signal
 import time
@@ -148,6 +171,29 @@ _CODEX_SANDBOX_ARGS = {
     "full_auto": ["-s", "workspace-write"],
 }
 
+# sandbox_mode → antigravity ``--mode`` flags (design §5.4, Antigravity CLI
+# 1.1.1, verified via facts-antigravity.md). ``agy --help`` only enumerates
+# two ``--mode`` values (``plan`` / ``accept-edits``), so ``full_auto`` maps
+# onto ``accept-edits`` plus the separate ``--dangerously-skip-permissions``
+# flag (auto-approves all tool executions) rather than a third ``--mode``
+# value. ``--sandbox`` is deliberately never used here: it has a known bypass
+# bug when combined with ``--dangerously-skip-permissions`` (agy issue #36).
+_ANTIGRAVITY_MODE_ARGS = {
+    "read_only": ["--mode", "plan"],
+    "edit": ["--mode", "accept-edits"],
+    "full_auto": ["--mode", "accept-edits", "--dangerously-skip-permissions"],
+}
+
+# Compiled ANSI escape sequence stripper for antigravity's plain-text output
+# (design §5.1.6). Covers CSI sequences (``ESC [ ... final-byte``) plus bare
+# OSC-style ``ESC ]`` sequences terminated by BEL or ``ESC \`` (kept simple —
+# antigravity's TUI chrome is not fully specified, so this is a defensive
+# best-effort strip, not a full ANSI parser).
+_ANSI_RE = re.compile(
+    r"\x1b\[[0-9;?]*[ -/]*[@-~]"  # CSI ... final byte
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC ... BEL or ST
+)
+
 
 def _chunk_text(text: str, size: int = _STREAM_CHUNK_CHARS) -> Iterator[str]:
     """Split ``text`` into ``size``-char pieces for the pseudo-stream."""
@@ -156,20 +202,26 @@ def _chunk_text(text: str, size: int = _STREAM_CHUNK_CHARS) -> Iterator[str]:
 
 
 class AgentCliAdapter(BaseAdapter):
-    """Invoke an external coding-agent CLI one-shot (claude + codex + grok).
+    """Invoke an external coding-agent CLI one-shot (claude + codex + grok +
+    antigravity).
 
     The ``agent`` field selects the argv builder / output parser via the
     dispatch tables built in :meth:`__init__`, mirroring how
     ``openai_compat`` fronts many HTTP backends from one class.
     """
 
+    _IMPLEMENTED_AGENTS = ("claude", "codex", "grok", "antigravity")
+
     def __init__(self, config: ProviderConfig) -> None:
         """Bind to a ``ProviderConfig`` and reject unsupported agents.
 
-        Constructing an adapter for an agent other than ``claude`` /
-        ``codex`` / ``grok`` raises a non-retryable :class:`AdapterError` —
-        the remaining target (gemini) is declared in the schema but not
-        implemented until its phase (design §9).
+        ``gemini`` gets its own rejection message (non-retryable): Google
+        discontinued the Gemini CLI's OAuth for individual accounts in June
+        2026, so this adapter points the operator at ``antigravity``
+        instead of a generic "not implemented" message. Any other
+        unimplemented value (future-proofing; currently none, since the
+        schema's ``Literal`` only allows the five known agents) falls back
+        to a generic message listing what IS implemented.
         """
         super().__init__(config)
         if config.agent_cli is None:  # pragma: no cover - schema enforces this
@@ -179,34 +231,50 @@ class AgentCliAdapter(BaseAdapter):
                 retryable=False,
             )
         self.acfg: AgentCliConfig = config.agent_cli
-        if self.acfg.agent not in ("claude", "codex", "grok"):
+        if self.acfg.agent not in self._IMPLEMENTED_AGENTS:
+            if self.acfg.agent == "gemini":
+                raise AdapterError(
+                    "agent 'gemini' is not supported: Google discontinued "
+                    "the Gemini CLI for individual accounts (June 2026; "
+                    "IneligibleTierError). Use agent='antigravity' "
+                    "(Antigravity CLI, command 'agy') instead.",
+                    provider=config.name,
+                    retryable=False,
+                )
             raise AdapterError(
-                f"agent {self.acfg.agent!r} is not implemented yet "
-                f"(implemented: claude, codex, grok). Wait for Phase 1c.",
+                f"agent {self.acfg.agent!r} is not implemented "
+                f"(implemented: {', '.join(self._IMPLEMENTED_AGENTS)}).",
                 provider=config.name,
                 retryable=False,
             )
         # agent → argv builder / output parser dispatch tables. claude landed
-        # in Phase 1a, codex in Phase 1b, grok in Phase 1d; Phase 1c adds
-        # gemini.
+        # in Phase 1a, codex in Phase 1b, grok in Phase 1d, antigravity in
+        # Phase 1c — all four (design §9) are now implemented.
         self._builders = {
             "claude": self._build_claude_argv,
             "codex": self._build_codex_argv,
             "grok": self._build_grok_argv,
+            "antigravity": self._build_antigravity_argv,
         }
         self._parsers = {
             "claude": self._parse_claude,
             "codex": self._parse_codex,
             "grok": self._parse_grok,
+            "antigravity": self._parse_antigravity,
         }
-        # Prompt delivery is per-agent: claude and codex read their prompt
-        # from stdin (10MB cap; codex's argv carries a trailing "-" sentinel
-        # making that explicit), which keeps argv free of the (potentially
-        # huge) prompt text. grok's ``-p`` REQUIRES the prompt as its argv
-        # value (piped stdin is only appended as extra context, verified on
-        # v0.2.93), so grok gets the prompt via ``--prompt-file`` instead —
-        # see ``_write_prompt_file`` for the rationale.
+        # Prompt delivery is per-agent, one of three mechanisms: claude and
+        # codex read their prompt from stdin (10MB cap; codex's argv carries
+        # a trailing "-" sentinel making that explicit), which keeps argv
+        # free of the (potentially huge) prompt text. grok's ``-p``
+        # REQUIRES the prompt as its argv value (piped stdin is only
+        # appended as extra context, verified on v0.2.93), so grok gets the
+        # prompt via ``--prompt-file`` instead — see ``_write_prompt_file``
+        # for the rationale. antigravity has NEITHER a stdin nor a
+        # ``--prompt-file`` channel — piped stdin hangs the CLI outright
+        # (field-verified on agy 1.1.1) — so its prompt rides argv instead;
+        # see ``_build_antigravity_argv`` for the tradeoff this accepts.
         self._uses_stdin = self.acfg.agent in ("claude", "codex")
+        self._uses_argv = self.acfg.agent == "antigravity"
 
     # ------------------------------------------------------------------
     # BaseAdapter contract
@@ -255,10 +323,16 @@ class AgentCliAdapter(BaseAdapter):
 
         # Agents that cannot take the prompt on stdin (grok) get it through a
         # private temp file inside the workdir; it is ALWAYS removed in the
-        # ``finally`` below, including on timeout / exception paths.
-        prompt_file = None if self._uses_stdin else self._write_prompt_file(prompt, workdir)
+        # ``finally`` below, including on timeout / exception paths. Argv
+        # agents (antigravity) get neither a file nor stdin bytes — the
+        # prompt text is handed straight to the builder instead.
+        prompt_file = (
+            None
+            if self._uses_stdin or self._uses_argv
+            else self._write_prompt_file(prompt, workdir)
+        )
         try:
-            argv = self._builders[self.acfg.agent](workdir, prompt_file)
+            argv = self._builders[self.acfg.agent](workdir, prompt_file, prompt)
             # Resolve the executable to an absolute path so argv[0] is a
             # concrete binary independent of the child's minimal PATH
             # (design §6 allowlist).
@@ -297,6 +371,10 @@ class AgentCliAdapter(BaseAdapter):
                     retryable=False,
                 ) from exc
 
+            # Non-stdin agents (grok's file delivery, antigravity's argv
+            # delivery) get None here, so ``communicate()`` closes stdin
+            # immediately without writing to it — verified required for
+            # antigravity, whose CLI hangs if anything is piped to stdin.
             stdin_bytes = prompt.encode("utf-8") if self._uses_stdin else None
             try:
                 stdout, stderr = await asyncio.wait_for(
@@ -366,7 +444,9 @@ class AgentCliAdapter(BaseAdapter):
     # claude argv builder + output parser
     # ------------------------------------------------------------------
 
-    def _build_claude_argv(self, workdir: str, prompt_file: str | None = None) -> list[str]:
+    def _build_claude_argv(
+        self, workdir: str, prompt_file: str | None = None, prompt: str | None = None
+    ) -> list[str]:
         """Assemble the ``claude -p`` argv (design §5.1.5 / §5.4).
 
         Shape::
@@ -375,12 +455,13 @@ class AgentCliAdapter(BaseAdapter):
                    --permission-mode <plan|acceptEdits> --add-dir <workdir>
 
         The prompt is fed on stdin (not argv), so it never appears here and
-        ``prompt_file`` is ignored (it exists only to keep the builder
-        signature uniform across agents). ``--bare`` is deliberately NOT
-        added — it would skip OAuth/keychain reads and break subscription
-        auth (design §5.3.4).
+        both ``prompt_file`` and ``prompt`` are ignored (they exist only to
+        keep the builder signature uniform across agents — see
+        ``_build_antigravity_argv`` for the one agent that needs ``prompt``).
+        ``--bare`` is deliberately NOT added — it would skip OAuth/keychain
+        reads and break subscription auth (design §5.3.4).
         """
-        del prompt_file  # claude takes the prompt on stdin, not from a file.
+        del prompt_file, prompt  # claude takes the prompt on stdin.
         model = self.acfg.model or self.config.model
         argv = [self.acfg.command, "-p", "--output-format", "json", "--model", model]
         if self.acfg.max_turns is not None:
@@ -494,7 +575,9 @@ class AgentCliAdapter(BaseAdapter):
     # codex argv builder + output parser (Phase 1b)
     # ------------------------------------------------------------------
 
-    def _build_codex_argv(self, workdir: str, prompt_file: str | None = None) -> list[str]:
+    def _build_codex_argv(
+        self, workdir: str, prompt_file: str | None = None, prompt: str | None = None
+    ) -> list[str]:
         """Assemble the ``codex exec`` argv (design §5.1.5 / §5.4, verified
         against codex-cli 0.144.1 — see ``_codex/facts-codex.md``).
 
@@ -504,19 +587,20 @@ class AgentCliAdapter(BaseAdapter):
                        -m <model> -C <workdir> -s <read-only|workspace-write> -
 
         The prompt is fed on stdin (not argv), so it never appears here and
-        ``prompt_file`` is ignored (it exists only to keep the builder
-        signature uniform across agents) — the trailing ``-`` makes the
-        stdin intent explicit to ``codex exec``, which otherwise treats a
-        bare invocation with no PROMPT arg the same way but reads more
-        ambiguously in a fixed argv list. ``--skip-git-repo-check`` is
-        ALWAYS passed because the isolated workdir is not a git repository
-        (without it the CLI exits 1). ``--ephemeral`` is ALWAYS passed so no
-        session state persists to disk, matching the adapter's stateless
-        one-shot ethos (the same rationale as grok's ``--no-memory``). codex
-        has no ``--max-turns`` equivalent, so ``AgentCliConfig.max_turns`` is
-        silently ignored here (documented in the schema).
+        both ``prompt_file`` and ``prompt`` are ignored (they exist only to
+        keep the builder signature uniform across agents) — the trailing
+        ``-`` makes the stdin intent explicit to ``codex exec``, which
+        otherwise treats a bare invocation with no PROMPT arg the same way
+        but reads more ambiguously in a fixed argv list. ``--skip-git-repo-
+        check`` is ALWAYS passed because the isolated workdir is not a git
+        repository (without it the CLI exits 1). ``--ephemeral`` is ALWAYS
+        passed so no session state persists to disk, matching the adapter's
+        stateless one-shot ethos (the same rationale as grok's
+        ``--no-memory``). codex has no ``--max-turns`` equivalent, so
+        ``AgentCliConfig.max_turns`` is silently ignored here (documented in
+        the schema).
         """
-        del prompt_file  # codex takes the prompt on stdin, not from a file.
+        del prompt_file, prompt  # codex takes the prompt on stdin.
         model = self.acfg.model or self.config.model
         argv = [
             self.acfg.command,
@@ -666,7 +750,9 @@ class AgentCliAdapter(BaseAdapter):
     # grok argv builder + output parser (Phase 1d)
     # ------------------------------------------------------------------
 
-    def _build_grok_argv(self, workdir: str, prompt_file: str | None = None) -> list[str]:
+    def _build_grok_argv(
+        self, workdir: str, prompt_file: str | None = None, prompt: str | None = None
+    ) -> list[str]:
         """Assemble the grok headless argv (design §5, grok CLI v0.2.93).
 
         Shape::
@@ -680,8 +766,11 @@ class AgentCliAdapter(BaseAdapter):
         would hit Linux's ~128KiB ``MAX_ARG_STRLEN`` on large prompts and
         leak the text into ``ps`` output. ``--no-memory`` is deliberate: it
         enforces the one-request-one-transformation statelessness even if
-        the user's grok config enables cross-session memory.
+        the user's grok config enables cross-session memory. ``prompt`` is
+        ignored (it exists only to keep the builder signature uniform across
+        agents — grok never takes it on argv).
         """
+        del prompt
         if prompt_file is None:  # pragma: no cover - generate() always supplies it
             raise AdapterError(
                 "grok argv requires a prompt file",
@@ -773,6 +862,108 @@ class AgentCliAdapter(BaseAdapter):
         if isinstance(session_id, str):
             meta["coderouter_session_id"] = session_id
         return result, usage, meta
+
+    # ------------------------------------------------------------------
+    # antigravity argv builder + output parser (Phase 1c, in lieu of gemini)
+    # ------------------------------------------------------------------
+
+    def _build_antigravity_argv(
+        self, workdir: str, prompt_file: str | None = None, prompt: str | None = None
+    ) -> list[str]:
+        """Assemble the ``agy -p`` argv (design §5.1.5 / §5.4, verified
+        against Antigravity CLI 1.1.1 — see ``_codex/facts-antigravity.md``).
+
+        Shape::
+
+            agy -p <prompt> --model <m> --mode <plan|accept-edits>
+                [--dangerously-skip-permissions] --print-timeout <n>s
+
+        ``workdir`` is unused here — antigravity picks up its working
+        directory from the child process's ``cwd`` (set by ``generate()``),
+        and this adapter deliberately never passes ``--add-dir`` (design
+        keeps the argv minimal; only claude's multi-root model needs it).
+        ``prompt_file`` is unused (antigravity has no such flag).
+
+        Prompt-delivery tradeoff (read this before touching the ``-p``
+        line): agy has no stdin channel — piping content to stdin makes the
+        real CLI hang waiting for a response that never comes (field-
+        verified on 1.1.1) — and no ``--prompt-file`` equivalent either. The
+        prompt therefore rides argv as the ``-p`` value, which is the *only*
+        delivery mechanism the CLI offers. This caps practical prompt size
+        at Linux's ~128KiB ``MAX_ARG_STRLEN`` and exposes the prompt text to
+        ``ps`` on the local host — exactly the two costs grok's
+        ``--prompt-file`` delivery was built to avoid (see the module
+        docstring's security section). No shell is involved (list argv, not
+        shell text), and the adapter's threat model — an isolated,
+        single-operator workstation — accepts local ``ps`` visibility as a
+        documented limitation rather than a defect; there is no safer
+        channel to fall back to.
+
+        ``--print-timeout`` is antigravity's own self-termination clock,
+        derived from ``exec_timeout_s`` — it is the CLI's *first* wall
+        against a hung call; the adapter's outer ``asyncio.wait_for`` +
+        process-group ``SIGKILL`` remains the second, unconditional wall
+        (design §6). ``max_turns`` is never emitted: agy has no ``--max-
+        turns``-equivalent flag (like codex), so ``AgentCliConfig.max_turns``
+        is silently ignored here (documented in the schema). No ``--sandbox``
+        (known bypass bug alongside ``--dangerously-skip-permissions``,
+        agy issue #36) and no ``--add-dir`` are ever passed.
+        """
+        del prompt_file  # antigravity has no prompt-file flag.
+        if prompt is None:  # pragma: no cover - generate() always supplies it
+            raise AdapterError(
+                "antigravity argv requires the prompt text",
+                provider=self.name,
+                retryable=False,
+            )
+        model = self.acfg.model or self.config.model
+        argv = [self.acfg.command, "-p", prompt, "--model", model]
+        argv += self._antigravity_mode_args()
+        argv += ["--print-timeout", f"{int(self.acfg.exec_timeout_s)}s"]
+        return argv
+
+    def _antigravity_mode_args(self) -> list[str]:
+        """Map ``sandbox_mode`` → antigravity ``--mode`` flags, clamped.
+
+        Same clamp as claude/codex/grok (design §5.4): when
+        ``allow_file_writes`` is False the effective mode is forced to
+        ``read_only`` regardless of ``sandbox_mode``, so writes always
+        require the explicit opt-in.
+        """
+        mode = self.acfg.sandbox_mode if self.acfg.allow_file_writes else "read_only"
+        return list(_ANTIGRAVITY_MODE_ARGS[mode])
+
+    def _parse_antigravity(
+        self, stdout: bytes, stderr: bytes
+    ) -> tuple[str, dict[str, Any], dict[str, Any]]:
+        """Parse antigravity's plain-text ``-p`` output (verified agy 1.1.1).
+
+        There is no ``--output-format`` flag at all (agy's ``--help`` does
+        not list one) — output is whatever the model printed, decorated
+        with whatever terminal styling the CLI applied even in non-TTY runs.
+        Parsing is therefore: UTF-8 decode (defensively, replacing invalid
+        bytes) → strip ANSI escape sequences (``_ANSI_RE``, best-effort, see
+        its definition) → ``.strip()`` surrounding whitespace. Empty output
+        raises a retryable :class:`AdapterError` so the chain can fall
+        through. There is no token/cost figure and no session id anywhere
+        in agy's output, so ``usage`` is all-zeros (cost stays 0 unless the
+        operator sets ``ProviderConfig.cost``, same rationale as grok,
+        design §5.1.6) and ``meta`` is empty.
+        """
+        text = _ANSI_RE.sub("", stdout.decode("utf-8", "replace")).strip()
+        if not text:
+            raise AdapterError(
+                "antigravity produced no stdout",
+                provider=self.name,
+                retryable=True,
+            )
+        usage: dict[str, Any] = {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        }
+        meta: dict[str, Any] = {}
+        return text, usage, meta
 
     # ------------------------------------------------------------------
     # helpers: prompt rendering, response shaping, env, workdir, kill

--- a/coderouter/config/schemas.py
+++ b/coderouter/config/schemas.py
@@ -168,13 +168,18 @@ class AgentCliConfig(BaseModel):
 
     Introduced by the external-agents-adapter design (Phase 1). One
     ``agent_cli`` sub-config drives the :class:`AgentCliAdapter`, which
-    invokes an external coding-agent CLI (codex / gemini / grok / claude)
-    in a single one-shot ``exec`` and returns the final answer as one
-    ``prompt in → text out`` transformation. ``claude`` (Claude Code CLI,
-    Phase 1a), ``codex`` (codex CLI, Phase 1b) and ``grok`` (grok CLI,
-    Phase 1d) are implemented; ``gemini`` is declared at the schema level
-    so configs are forward-compatible, but the adapter rejects it until its
-    phase (1c) lands.
+    invokes an external coding-agent CLI (codex / gemini / grok / claude /
+    antigravity) in a single one-shot ``exec`` and returns the final answer
+    as one ``prompt in → text out`` transformation. ``claude`` (Claude Code
+    CLI, Phase 1a), ``codex`` (codex CLI, Phase 1b), ``grok`` (grok CLI,
+    Phase 1d) and ``antigravity`` (Antigravity CLI, Phase 1c, in lieu of
+    ``gemini``) are implemented. ``gemini`` is declared at the schema level
+    for backward-compatible config parsing, but the adapter rejects it with
+    a migration pointer: Google discontinued the (legacy) Gemini CLI's
+    OAuth for individual accounts in June 2026 (``IneligibleTierError`` /
+    ``UNSUPPORTED_CLIENT`` on the real client) and its successor is the
+    Antigravity CLI (command ``agy``, a separate Go implementation, not a
+    gemini-cli fork) — set ``agent: "antigravity"`` instead.
 
     Auth note (grok): the grok CLI uses OAuth credentials stored under
     ``~/.grok`` (``grok login``), which the adapter's HOME inheritance
@@ -190,25 +195,41 @@ class AgentCliConfig(BaseModel):
     ``CODEX_API_KEY`` (exec-only) or ``OPENAI_API_KEY`` (general) in
     ``passthrough_env``.
 
+    Auth note (antigravity): the Antigravity CLI uses a Google-account OAuth
+    login (free tier included), with credentials preferentially stored in
+    the OS keyring and mirrored under ``~/.gemini/antigravity-cli/``
+    (``credentials.enc`` / ``settings.json``) — the adapter's HOME (and, on
+    macOS, USER) inheritance already covers this, no extra config needed.
+    Any API-key environment variable for CI / non-interactive setups is
+    UNCONFIRMED (field reports disagree on the variable name) — this
+    docstring deliberately does not name one as authoritative; if you find
+    one that works, list it in ``passthrough_env``.
+
     Follows the ``extra="forbid"`` convention used across this module so a
     typo'd key fails at config-load rather than being silently ignored.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    agent: Literal["codex", "gemini", "grok", "claude"] = Field(
+    agent: Literal["codex", "gemini", "grok", "claude", "antigravity"] = Field(
         ...,
         description=(
             "External coding-agent CLI to invoke. 'claude' (Phase 1a), "
-            "'codex' (Phase 1b) and 'grok' (Phase 1d) are implemented; "
-            "'gemini' (Phase 1c) pending."
+            "'codex' (Phase 1b), 'grok' (Phase 1d) and 'antigravity' "
+            "(Phase 1c, Google's Antigravity CLI, command 'agy') are "
+            "implemented. 'gemini' is rejected by the adapter — Google "
+            "discontinued the Gemini CLI for individual accounts in June "
+            "2026; use 'antigravity' instead."
         ),
     )
     command: str | None = Field(
         default=None,
         description=(
             "CLI executable name or absolute path (resolved via PATH). "
-            "When unset, defaults to the ``agent`` name."
+            "When unset, defaults to the ``agent`` name — EXCEPT "
+            "'antigravity', whose binary is named ``agy`` (the product is "
+            "'Antigravity CLI' but the executable keeps the short, "
+            "pre-rename command name)."
         ),
     )
     workdir: str | None = Field(
@@ -291,9 +312,14 @@ class AgentCliConfig(BaseModel):
         ``sandbox_mode="read_only"`` is contradictory — the operator asked
         for writes while pinning a read-only sandbox. Fail fast at load,
         matching the module's other cross-field validators.
+
+        ``command`` defaults to the ``agent`` name for every agent EXCEPT
+        ``antigravity``, whose binary is ``agy`` — the product renamed from
+        Gemini CLI to Antigravity CLI, but the executable kept its short
+        pre-rename name.
         """
         if self.command is None:
-            self.command = self.agent
+            self.command = "agy" if self.agent == "antigravity" else self.agent
         if self.allow_file_writes and self.sandbox_mode == "read_only":
             raise ValueError(
                 "agent_cli: allow_file_writes=True conflicts with "

--- a/docs/backends/external-agents.en.md
+++ b/docs/backends/external-agents.en.md
@@ -2,7 +2,7 @@
 
 > 日本語版: [`external-agents.md`](./external-agents.md)
 
-`kind: "agent_cli"` is an adapter that registers an external coding-agent CLI, such as the Claude Code CLI, as a single CodeRouter provider. It was newly added in v2.7.7 (Phase 1a: claude), v2.7.8 added grok (Phase 1d), and v2.7.9 added codex (Phase 1b). See [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) for the full design.
+`kind: "agent_cli"` is an adapter that registers an external coding-agent CLI, such as the Claude Code CLI, as a single CodeRouter provider. It was newly added in v2.7.7 (Phase 1a: claude), v2.7.8 added grok (Phase 1d), v2.7.9 added codex (Phase 1b), and v2.7.10 added antigravity (Phase 1c). **Phase 1 (all four backends) is now complete.** See [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) for the full design.
 
 ---
 
@@ -10,17 +10,34 @@
 
 A coding-agent CLI is normally a stateful control loop that runs many turns autonomously while editing files — a poor fit for CodeRouter's "one request = one transformation" ethos. `agent_cli` reconciles the two by collapsing the CLI into a **one-shot `exec`** (prompt in → final answer text out). Orchestration (multi-turn control, tool execution) stays entirely inside the agent CLI process; from CodeRouter's side it looks like just another provider that answers a single exchange.
 
-- **Supported CLIs**: the `agent` field can declare `claude` / `codex` / `gemini` / `grok`.
-- **Implementation status (as of v2.7.9)**: **`claude` (Claude Code CLI, Phase 1a), `codex` (OpenAI Codex CLI, Phase 1b), and `grok` (Grok CLI, Phase 1d) are implemented**. Only `gemini` can be written into `providers.yaml` at the schema level, but constructing the adapter always rejects it (Phase 1c is not yet implemented). The error message looks roughly like the following (the exact wording may differ between versions):
+- **Supported CLIs**: the `agent` field can declare `claude` / `codex` / `antigravity` / `grok`. `gemini` also remains in the schema's `Literal`, but it is always rejected (see below).
+- **Implementation status (as of v2.7.10)**: **Phase 1 is complete — `claude` (Claude Code CLI, Phase 1a), `codex` (OpenAI Codex CLI, Phase 1b), `antigravity` (Google Antigravity CLI, Phase 1c), and `grok` (Grok CLI, Phase 1d) are all implemented**. `gemini` fell out of scope because Google discontinued the Gemini CLI for individual accounts in June 2026; constructing the adapter with it always raises a dedicated migration error:
 
   ```
-  AdapterError: agent 'gemini' is not implemented yet (implemented: claude, codex, grok).
-  Wait for the agent's phase (1c).
+  AdapterError: Google discontinued Gemini CLI for individual accounts (June 2026).
+  Use agent='antigravity' instead.
   ```
 
-  This rejection is `retryable=False` — even if other providers exist in the fallback chain, it stops immediately as a configuration error.
+  This rejection is `retryable=False` — even if other providers exist in the fallback chain, it stops immediately as a configuration error. See [Gemini's discontinuation and the move to antigravity](#geminis-discontinuation-and-the-move-to-antigravity) for the full story.
 
-- The shared parts of this document (authentication design, configuration reference, limitations) are written against the `claude` target; codex- and grok-specific behavior are collected in the [codex (OpenAI Codex CLI)](#codex-openai-codex-cli) and [grok (Grok CLI)](#grok-grok-cli) sections, respectively. Example configs for `gemini` exist only as a commented-out preview at the bottom of `examples/providers-agent-cli.yaml` and do not work.
+- The shared parts of this document (authentication design, configuration reference, limitations) are written against the `claude` target; codex-, antigravity-, and grok-specific behavior are collected in the [codex (OpenAI Codex CLI)](#codex-openai-codex-cli), [antigravity (Google Antigravity CLI)](#antigravity-google-antigravity-cli), and [grok (Grok CLI)](#grok-grok-cli) sections, respectively.
+
+### Gemini's discontinuation and the move to antigravity
+
+The legacy Gemini CLI (`@google/gemini-cli` 0.50.x) has had individual-account OAuth **discontinued as of 2026-06-18** (per Google's official blog). On real hardware this now fails with:
+
+```
+IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals.
+To continue using Gemini, please migrate to the Antigravity suite of products: https://antigravity.google
+```
+
+(`reasonCode: UNSUPPORTED_CLIENT`, `tierId: free-tier`)
+
+The legacy gemini CLI was also hit during this adapter's field verification by its trusted-directory gate returning **exit 55** (requiring `--skip-trust` or `GEMINI_CLI_TRUST_WORKSPACE=true`) — a pre-existing constraint unrelated to the individual-account discontinuation.
+
+Google's stated successor is the **Antigravity CLI** (command name `agy`). It is not a fork of gemini-cli but a separate Go rewrite, and it is where individual Google-account OAuth (including the free tier) lives on. In response, CodeRouter implemented the originally-planned Phase 1c (`agent: "gemini"`) as **`agent: "antigravity"`** instead (v2.7.10).
+
+`agent: "gemini"` remains in the schema's `Literal`, but constructing the adapter rejects it with the migration message shown above. Configs that used `gemini` should switch to `agent: antigravity` — see the [antigravity (Google Antigravity CLI)](#antigravity-google-antigravity-cli) section for a working example.
 
 ---
 
@@ -96,14 +113,14 @@ All fields of the `agent_cli:` sub-config (`AgentCliConfig`) in `providers.yaml`
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `agent` | `"claude" \| "codex" \| "gemini" \| "grok"` | (required) | Which CLI to invoke. **As of v2.7.9, `claude`, `codex`, and `grok` are implemented; `gemini` is rejected when the adapter is constructed** |
-| `command` | `str \| null` | `null` (defaults to the same name as `agent`) | CLI executable name or absolute path, resolved via `PATH` |
+| `agent` | `"claude" \| "codex" \| "antigravity" \| "gemini" \| "grok"` | (required) | Which CLI to invoke. **As of v2.7.10, `claude`, `codex`, `antigravity`, and `grok` are all implemented (Phase 1 complete); `gemini` remains in the schema but is rejected when the adapter is constructed** |
+| `command` | `str \| null` | `null` (defaults to the same name as `agent`) | CLI executable name or absolute path, resolved via `PATH`. **`agent: antigravity` is the sole exception, defaulting to `agy`** (the binary name differs from the product name) |
 | `workdir` | `str \| null` | `null` (defaults to `~/.coderouter/agents/<provider name>`) | Working directory for the one-shot exec. `~` / env-var expansion is applied; a path containing `..` is rejected |
-| `exec_timeout_s` | `float` | `600.0` (range `1.0`–`1800.0`) | Forced timeout (seconds) for the whole exec. **Separate** from `ProviderConfig.timeout_s` (the latter is not used by agent_cli) |
+| `exec_timeout_s` | `float` | `600.0` (range `1.0`–`1800.0`) | Forced timeout (seconds) for the whole exec. **Separate** from `ProviderConfig.timeout_s` (the latter is not used by agent_cli). For antigravity this value also generates `--print-timeout` (see below) |
 | `allow_file_writes` | `bool` | `false` | Whether to allow file writes. When `false`, the effective mode is clamped to read-only regardless of `sandbox_mode` |
-| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | Maps to each CLI's sandbox/approval flags (claude: [table below](#sandbox_mode--permission-mode-mapping-claude); codex: [codex section](#sandbox_mode--codex-flag-mapping); grok: [grok section](#sandbox_mode--grok-flag-mapping)) |
-| `model` | `str \| null` | `null` (defaults to `ProviderConfig.model`) | Model name passed to the CLI's `--model` / `-m` (claude: `opus` / `sonnet` / `haiku` / `fable` etc.; codex: `gpt-5.5` etc.; grok: `grok-4.5` etc.) |
-| `max_turns` | `int \| null` | `8` (range `1`–`50`) | Turn cap inside the CLI. Passed as `--max-turns`. **codex has no corresponding CLI flag, so this is always ignored** (for codex, `exec_timeout_s` + process-group kill is the only time bound) |
+| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | Maps to each CLI's sandbox/approval flags (claude: [table below](#sandbox_mode--permission-mode-mapping-claude); codex: [codex section](#sandbox_mode--codex-flag-mapping); antigravity: [antigravity section](#sandbox_mode--antigravity-flag-mapping); grok: [grok section](#sandbox_mode--grok-flag-mapping)) |
+| `model` | `str \| null` | `null` (defaults to `ProviderConfig.model`) | Model name passed to the CLI's `--model` / `-m` (claude: `opus` / `sonnet` / `haiku` / `fable` etc.; codex: `gpt-5.5` etc.; antigravity: a **display-string** like `"Gemini 3.5 Flash (Low)"`; grok: `grok-4.5` etc.) |
+| `max_turns` | `int \| null` | `8` (range `1`–`50`) | Turn cap inside the CLI. Passed as `--max-turns`. **codex and antigravity have no corresponding CLI flag, so this is always ignored for both** (for those two, `exec_timeout_s` + process-group kill is the only time bound; antigravity additionally has its own `--print-timeout`) |
 | `passthrough_env` | `list[str]` | `[]` | Allowlist of environment variable names forwarded from the parent process into the child. `ANTHROPIC_API_KEY` is not forwarded unless listed here |
 | `agent_depth_limit` | `int` | `2` (range `1`–`4`) | Recursion nesting cap. When `CODEROUTER_AGENT_DEPTH` reaches or exceeds this, the call stops immediately with `AdapterError(retryable=False)` |
 
@@ -221,6 +238,109 @@ The codex CLI is pre-1.0 and releases nearly daily. `--json`'s alias is still `-
 
 ---
 
+## antigravity (Google Antigravity CLI)
+
+v2.7.10 (Phase 1c) implements `agent: antigravity`, which completes **Phase 1 (claude, codex, antigravity, and grok — all four backends)**. This target replaces the originally-planned `gemini`, since Google discontinued that CLI for individual accounts — see [Gemini's discontinuation and the move to antigravity](#geminis-discontinuation-and-the-move-to-antigravity) for the story. Its distinguishing behaviors: the prompt rides on **argv** (unlike claude/codex's stdin or grok's `--prompt-file`), output is plain text (usage is always zero), and it's the only agent_cli target with its own CLI-side timeout. Everything below is based on agy **1.1.1** (field-verified on the author's Mac, 2026-07-11).
+
+### Example configuration
+
+```yaml
+providers:
+  - name: agent-antigravity
+    kind: agent_cli
+    model: "Gemini 3.5 Flash (Low)"   # a display string, not an API ID (see below)
+    paid: false                       # Google-account OAuth (including free tier) = zero metered cost
+    capabilities:
+      streaming: false
+      tools: false
+    agent_cli:
+      agent: antigravity
+      # command may be omitted (defaults to "agy" — the binary name differs from the product name)
+      workdir: ~/.coderouter/agents/antigravity
+      exec_timeout_s: 600
+      allow_file_writes: false
+      sandbox_mode: read_only
+      passthrough_env: []             # OAuth reads the OS keyring + ~/.gemini/antigravity-cli/ via
+                                       # inherited HOME (and USER on macOS), so empty is fine.
+                                       # API-key env is UNCONFIRMED (see below)
+```
+
+### The argv the adapter builds
+
+With `sandbox_mode: read_only` (the default), the adapter builds the following argv.
+
+```
+agy -p <prompt> --model "Gemini 3.5 Flash (Low)" --mode plan --print-timeout 600s
+```
+
+### The prompt is delivered via argv (unlike claude/codex's stdin or grok's `--prompt-file`)
+
+Prompt delivery splits into three patterns across the four backends.
+
+| agent | Delivery mechanism | Notes |
+|---|---|---|
+| claude | stdin | `-p` reads stdin when the argument is omitted |
+| codex | stdin (with an explicit trailing `-` on argv) | Same channel as claude |
+| grok | `--prompt-file` (a mode-`0600` temp file inside the isolated workdir) | Neither argv nor stdin is accepted |
+| antigravity | argv value (`-p <prompt>`) | stdin is not accepted; there's no `--prompt-file` equivalent either |
+
+agy's `-p` / `--print` / `--prompt` requires a value on argv — there is no stdin channel for the prompt, and no `--prompt-file`-equivalent flag either. So the prompt has to ride on argv, which carries Linux's `MAX_ARG_STRLEN` (~128KiB) size cap and exposes the full prompt text to `ps` as known limitations (documented here since there's no alternative with agy's current flag surface). The argv is passed as a list (never `shell=True`), so it doesn't go through shell interpretation.
+
+### Piping stdin causes a hang — a caveat for anyone scripting `agy` directly
+
+The adapter itself never writes to stdin and closes it immediately (`communicate(input=None)`, field-verified to work correctly via `</dev/null`), so this is a non-issue through CodeRouter. However, **piping anything into agy's stdin makes it hang** (field-verified: `printf '...' | agy -p "..."` sits waiting and eventually reports `Error: timeout waiting for response`). agy has no facility for reading stdin as context. If you script `agy` directly, always leave stdin empty (e.g. `</dev/null`).
+
+### `sandbox_mode` → antigravity flag mapping
+
+As with claude/codex/grok, when `allow_file_writes=false` the effective mode is clamped to `read_only` regardless of `sandbox_mode`.
+
+| `sandbox_mode` | agy flags | Notes |
+|---|---|---|
+| `read_only` (default) | `--mode plan` | No file changes. Always clamped to this mode when `allow_file_writes=false` |
+| `edit` | `--mode accept-edits` | Auto-approves file edits |
+| `full_auto` | `--mode accept-edits --dangerously-skip-permissions` | Auto-approves all tool execution (agy's `--help` only enumerates `accept-edits`/`plan` as mode values; full_auto is expressed by adding `--dangerously-skip-permissions`) |
+
+### Plain-text output and always-zero usage
+
+agy has **no `--output-format`-style flag at all** — output is plain text only. The adapter decodes stdout as UTF-8, defensively strips ANSI escapes (regex), and trims whitespace to produce the final answer; an empty result raises a retryable `AdapterError`. With no JSON output, token usage, session id, and structured errors are all unavailable — usage is reported as **always zero**, same as grok (`coderouter_cost_usd` stays 0 unless the operator sets unit prices in `ProviderConfig.cost`). No session id is ever surfaced in response metadata.
+
+### `--print-timeout` — the first agent with its own CLI-side timeout
+
+agy has a `--print-timeout <Go duration>` flag (default `5m0s`) that bounds how long print mode itself will wait. claude/codex/grok have no CLI-side timeout of this kind. The adapter generates `--print-timeout` from `AgentCliConfig.exec_timeout_s` (e.g. `exec_timeout_s=600` → `--print-timeout 600s`), giving the CLI a first wall to self-terminate against. This is on top of the existing outer `asyncio.wait_for` + process-group `SIGKILL` second wall, making antigravity the only agent with a **double timeout wall**.
+
+### `max_turns` is ignored
+
+agy has no `--max-turns`-equivalent flag. `AgentCliConfig.max_turns` always has no effect for antigravity (same as codex), and the time bound is carried entirely by the `--print-timeout` + `exec_timeout_s` double wall.
+
+### Authentication (Google-account OAuth, free tier included)
+
+agy supports Google-account OAuth, including the free tier. Credentials are stored primarily in the OS keyring, with `~/.gemini/antigravity-cli/` (`credentials.enc` / `settings.json`) as well. The adapter's `HOME` inheritance (plus `USER` on macOS) lets it run headless with `passthrough_env: []` (handled by the existing `_build_child_env()`). Setup steps:
+
+1. Run `agy` for the first time; it opens a browser for Google-account login. Complete it.
+2. Run `agy models` and smoke-check that the model list comes back.
+
+API-key-based authentication (the environment variable name) has conflicting reports (`ANTIGRAVITY_API_KEY` is claimed by some, and others claim `GEMINI_API_KEY` is ignored) and is **UNCONFIRMED**. This document does not assert either way.
+
+### Model names are display strings — Claude models are reachable through agy
+
+The value passed to `--model` isn't an API ID — it's a **display string** returned by `agy models`. Verified output from a real install (agy 1.1.1):
+
+```
+Gemini 3.5 Flash (Medium/High/Low)
+Gemini 3.1 Pro (Low/High)
+Claude Sonnet 4.6 (Thinking)
+Claude Opus 4.6 (Thinking)
+GPT-OSS 120B (Medium)
+```
+
+Interestingly, agy can reach non-Google models this way — including Claude Opus 4.6. Write one of these display strings verbatim (spaces, parentheses and all) into `providers.yaml`'s `model` field.
+
+### Early-days-product caveat
+
+The Antigravity CLI is a brand-new product. Its flag surface and model list are likely to keep changing, so **version pinning is recommended** (point `command` at a pinned binary's full path). Because output is plain text, JSON-schema-churn-style parsing accidents are less likely, but unexpected empty responses or nonzero exit codes are handled defensively and become a retryable `AdapterError`, demoting to the next provider in the fallback chain.
+
+---
+
 ## grok (Grok CLI)
 
 v2.7.8 (Phase 1d) implements `agent: grok`. It uses the same one-shot exec scheme as claude, but grok has its own behavior around prompt delivery, cross-session memory disabling, and usage reporting. Everything below is based on grok CLI **v0.2.93** ([stable] channel, field-verified on 2026-07-10).
@@ -322,7 +442,9 @@ The grok CLI is early beta (v0.2.93 [stable] channel as of 2026-07-10). Its JSON
 | Fails with `grok exited 1: ...` | The grok CLI exits with code 1 on auth/network/runtime errors, with the error text on stderr | The adapter includes a tail of stderr in the `AdapterError`, so use the message shown as your lead. For auth errors, re-run `grok login` and smoke-check that `grok models` works |
 | Fails with `codex exited 1: ...` (suspect stale OAuth) | codex's OAuth token goes stale after about 8 days. It auto-refreshes on use, but a long gap between calls can leave it stale and failing | Check login state with `codex login status` and re-run `codex login` if needed. Running codex occasionally helps avoid staleness |
 | `Not inside a trusted directory and --skip-git-repo-check was not specified.` appears | This should never happen — the adapter always passes `--skip-git-repo-check` | If you see this, it likely indicates a bug in CodeRouter's argv construction. Check your version and file an issue if it reproduces |
-| CLI fails to launch (`failed to launch ...`) | `command` (defaults to the same name as `agent`) isn't on `PATH` | Confirm `claude --version` / `codex --version` / `grok --version` works. You can also point `command` at a full path |
+| `agent: gemini` raises an `AdapterError` / you see `IneligibleTierError` | Google discontinued the Gemini CLI for individual accounts in June 2026 (field-verified: `IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals...`) | Switch to `agent: antigravity`. See the [antigravity (Google Antigravity CLI)](#antigravity-google-antigravity-cli) section for a working example |
+| `agy` hangs and never responds | Something is being piped into agy's stdin (e.g. `printf '...' \| agy -p "..."`) | Don't pipe stdin — write nothing and redirect from `</dev/null`. Calls made through CodeRouter already do this (the adapter closes stdin immediately) |
+| CLI fails to launch (`failed to launch ...`) | `command` (defaults to the same name as `agent`, except antigravity which defaults to `agy`) isn't on `PATH` | Confirm `claude --version` / `codex --version` / `agy --version` / `grok --version` works. You can also point `command` at a full path |
 
 ---
 

--- a/docs/backends/external-agents.md
+++ b/docs/backends/external-agents.md
@@ -2,7 +2,7 @@
 
 > English: [`external-agents.en.md`](./external-agents.en.md)
 
-`kind: "agent_cli"` は、Claude Code CLI のような外部コーディングエージェントを CodeRouter の 1 プロバイダとして登録するアダプタである。v2.7.7 で新規追加され(Phase 1a: claude)、v2.7.8 で grok が追加され(Phase 1d)、v2.7.9 で codex が追加された(Phase 1b)。詳細設計は [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) を参照。
+`kind: "agent_cli"` は、Claude Code CLI のような外部コーディングエージェントを CodeRouter の 1 プロバイダとして登録するアダプタである。v2.7.7 で新規追加され(Phase 1a: claude)、v2.7.8 で grok が追加され(Phase 1d)、v2.7.9 で codex が追加され(Phase 1b)、v2.7.10 で antigravity が追加された(Phase 1c)。これにより **Phase 1(4バックエンド)は完了**した。詳細設計は [`docs/designs/external-agents-adapter.md`](../designs/external-agents-adapter.md) を参照。
 
 ---
 
@@ -10,17 +10,34 @@
 
 コーディングエージェント CLI は本来、ファイルを書き換えながら何ターンも自律的に動くステートフルな制御ループであり、CodeRouter の「1リクエスト = 1変換」という思想とは相性が悪い。`agent_cli` はこれを **ワンショット `exec`**(プロンプト in → 最終回答テキスト out)に押し込めることで両立させている。オーケストレーション(マルチターン制御・ツール実行)はエージェント CLI 内部で完結し、CodeRouter 側からは「1回の対話で答えを返すだけの1つのプロバイダ」として見える。
 
-- **対象 CLI**: `agent` フィールドで `claude` / `codex` / `gemini` / `grok` の4種を宣言できる。
-- **実装状況(v2.7.9 時点)**: **`claude`(Claude Code CLI・Phase 1a)・`codex`(OpenAI Codex CLI・Phase 1b)・`grok`(Grok CLI・Phase 1d)が実装済み**。`gemini` のみ `providers.yaml` のスキーマ上は書けるが、アダプタ構築時に必ず AdapterError で拒否される(Phase 1c は未実装)。エラーメッセージは概ね次の形である(正確な文言はバージョンにより変わりうる):
+- **対象 CLI**: `agent` フィールドで `claude` / `codex` / `antigravity` / `grok` の4種を宣言できる。`gemini` もスキーマの `Literal` には残っているが、常に拒否される(下記参照)。
+- **実装状況(v2.7.10 時点)**: **Phase 1 が完了し、`claude`(Claude Code CLI・Phase 1a)・`codex`(OpenAI Codex CLI・Phase 1b)・`antigravity`(Google Antigravity CLI・Phase 1c)・`grok`(Grok CLI・Phase 1d)の4バックエンドすべてが実装済み**。`gemini` は Google が2026年6月に個人アカウント向け Gemini CLI の提供を終了したため実装対象から外れ、アダプタ構築時に必ず次のような専用メッセージ付きの AdapterError で拒否される:
 
   ```
-  AdapterError: agent 'gemini' is not implemented yet (implemented: claude, codex, grok).
-  Wait for the agent's phase (1c).
+  AdapterError: Google discontinued Gemini CLI for individual accounts (June 2026).
+  Use agent='antigravity' instead.
   ```
 
-  この拒否は `retryable=False` — フォールバックチェーンに他プロバイダがあっても、設定ミスとして即座に停止する。
+  この拒否は `retryable=False` — フォールバックチェーンに他プロバイダがあっても、設定ミスとして即座に停止する。経緯の詳細は [gemini の廃止と antigravity への移行](#gemini-の廃止と-antigravity-への移行) を参照。
 
-- 本ドキュメントの共通部分(認証設計・設定リファレンス・制限事項)は claude ターゲットを軸に記述し、codex / grok 固有の挙動はそれぞれ [codex(OpenAI Codex CLI)](#codexopenai-codex-cli) / [grok(Grok CLI)](#grokgrok-cli) セクションにまとめる。gemini の設定例は `examples/providers-agent-cli.yaml` 末尾にコメントアウトされたプレビューとして置かれているが、動作しない。
+- 本ドキュメントの共通部分(認証設計・設定リファレンス・制限事項)は claude ターゲットを軸に記述し、codex / antigravity / grok 固有の挙動はそれぞれ [codex(OpenAI Codex CLI)](#codexopenai-codex-cli) / [antigravity(Google Antigravity CLI)](#antigravitygoogle-antigravity-cli) / [grok(Grok CLI)](#grokgrok-cli) セクションにまとめる。
+
+### gemini の廃止と antigravity への移行
+
+旧 Gemini CLI(`@google/gemini-cli` 0.50.0 系)は、個人アカウントの OAuth が **2026-06-18 をもって廃止済み**である(公式ブログ)。実機で以下のエラーが確認されている。
+
+```
+IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals.
+To continue using Gemini, please migrate to the Antigravity suite of products: https://antigravity.google
+```
+
+(`reasonCode: UNSUPPORTED_CLIENT`, `tierId: free-tier`)
+
+さらに旧 gemini CLI は trusted-directory ゲートで **exit 55**(`--skip-trust` または `GEMINI_CLI_TRUST_WORKSPACE=true` が必要)にも本アダプタの実機検証中に遭遇している — こちらは個人アカウント終了とは別に以前から存在する制約である。
+
+Google が後継として案内しているのは **Antigravity CLI**(コマンド名 `agy`)である。gemini-cli のフォークではなく Go 製の別実装であり、個人の Google アカウント OAuth(無料枠含む)はこちらで存続する。CodeRouter はこの移行を受けて、当初計画していた Phase 1c(`agent: "gemini"`)を **`agent: "antigravity"`** として実装した(v2.7.10)。
+
+`agent: "gemini"` はスキーマの `Literal` には残すが、アダプタ構築時に上記の専用メッセージで拒否される。`gemini` を使っていた設定は `agent: antigravity` に切り替え、[antigravity(Google Antigravity CLI)](#antigravitygoogle-antigravity-cli) セクションの設定例を参照すること。
 
 ---
 
@@ -96,14 +113,14 @@ Claude Code CLI は Keychain からトークンを解決する際に `USER` 環�
 
 | フィールド | 型 | 既定値 | 説明 |
 |---|---|---|---|
-| `agent` | `"claude" \| "codex" \| "gemini" \| "grok"` | (必須) | 呼び出す CLI。**v2.7.9 で実装済みなのは `claude`・`codex`・`grok`。`gemini` はアダプタ構築時に拒否される** |
-| `command` | `str \| null` | `null`(未設定時は `agent` と同名) | CLI 実行ファイル名 or 絶対パス。`PATH` から解決 |
+| `agent` | `"claude" \| "codex" \| "antigravity" \| "gemini" \| "grok"` | (必須) | 呼び出す CLI。**v2.7.10 で `claude`・`codex`・`antigravity`・`grok` の4つすべてが実装済み(Phase 1 完了)。`gemini` はスキーマに残るがアダプタ構築時に拒否される** |
+| `command` | `str \| null` | `null`(未設定時は `agent` と同名) | CLI 実行ファイル名 or 絶対パス。`PATH` から解決。**`agent: antigravity` のみ既定値は `agy`**(バイナリ名が製品名と異なるため) |
 | `workdir` | `str \| null` | `null`(未設定時は `~/.coderouter/agents/<プロバイダ名>`) | ワンショット exec の作業ディレクトリ。`~` / 環境変数展開あり。`..` を含むパスは拒否される |
-| `exec_timeout_s` | `float` | `600.0`(範囲 `1.0`–`1800.0`) | exec 全体の強制タイムアウト(秒)。`ProviderConfig.timeout_s` とは**別系統**(後者は agent_cli では使われない) |
+| `exec_timeout_s` | `float` | `600.0`(範囲 `1.0`–`1800.0`) | exec 全体の強制タイムアウト(秒)。`ProviderConfig.timeout_s` とは**別系統**(後者は agent_cli では使われない)。antigravity ではこの値から `--print-timeout` も生成される(下記参照) |
 | `allow_file_writes` | `bool` | `false` | ファイル書き込みを許可するか。`false` のときは `sandbox_mode` の値に関わらず read-only にクランプされる |
-| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | 各 CLI のサンドボックス/承認フラグへマッピングされる(claude は[下表](#sandbox_mode--permission-mode-マッピングclaude)、codex は [codex セクション](#sandbox_mode--codex-フラグのマッピング)、grok は [grok セクション](#sandbox_mode--grok-フラグのマッピング)参照) |
-| `model` | `str \| null` | `null`(未設定時は `ProviderConfig.model` を使用) | CLI の `--model` / `-m` に渡すモデル名(claude: `opus` / `sonnet` / `haiku` / `fable` 等、codex: `gpt-5.5` 等、grok: `grok-4.5` 等) |
-| `max_turns` | `int \| null` | `8`(範囲 `1`–`50`) | CLI 内部のターン上限。`--max-turns` として渡る。**codex には対応する CLI フラグが無いため常に無視される**(codex では `exec_timeout_s` + プロセスグループ kill のみが時間上限になる) |
+| `sandbox_mode` | `"read_only" \| "edit" \| "full_auto"` | `"read_only"` | 各 CLI のサンドボックス/承認フラグへマッピングされる(claude は[下表](#sandbox_mode--permission-mode-マッピングclaude)、codex は [codex セクション](#sandbox_mode--codex-フラグのマッピング)、antigravity は [antigravity セクション](#sandbox_mode--antigravity-フラグのマッピング)、grok は [grok セクション](#sandbox_mode--grok-フラグのマッピング)参照) |
+| `model` | `str \| null` | `null`(未設定時は `ProviderConfig.model` を使用) | CLI の `--model` / `-m` に渡すモデル名(claude: `opus` / `sonnet` / `haiku` / `fable` 等、codex: `gpt-5.5` 等、antigravity: `"Gemini 3.5 Flash (Low)"` 等の**表示名文字列**、grok: `grok-4.5` 等) |
+| `max_turns` | `int \| null` | `8`(範囲 `1`–`50`) | CLI 内部のターン上限。`--max-turns` として渡る。**codex・antigravity には対応する CLI フラグが無いため常に無視される**(この2つでは `exec_timeout_s` + プロセスグループ kill のみが時間上限になる。antigravity はこれに加えて CLI 自身の `--print-timeout` も持つ) |
 | `passthrough_env` | `list[str]` | `[]` | 親環境から子プロセスへ転送する環境変数名のallowlist。`ANTHROPIC_API_KEY` はここに書かない限り渡らない |
 | `agent_depth_limit` | `int` | `2`(範囲 `1`–`4`) | 再帰ネストの上限。`CODEROUTER_AGENT_DEPTH` が上限以上なら `AdapterError(retryable=False)` で即停止 |
 
@@ -221,6 +238,109 @@ codex CLI は pre-1.0 でほぼ毎日リリースされている。`--json` の�
 
 ---
 
+## antigravity(Google Antigravity CLI)
+
+v2.7.10(Phase 1c)で `agent: antigravity` が実装され、これで **Phase 1(claude・codex・antigravity・grok の4バックエンド)は完了**した。当初計画されていた `gemini` は Google が個人アカウント向け提供を終了したため、後継の Antigravity CLI(コマンド `agy`)を対象に実装している。詳しい経緯は [gemini の廃止と antigravity への移行](#gemini-の廃止と-antigravity-への移行) を参照。プロンプトを **argv 値として**渡す点(claude/codex の stdin、grok の `--prompt-file` とはいずれも異なる)、プレーンテキスト出力(usage は常にゼロ)、そして CLI 自身がタイムアウトを持つ唯一のエージェントである点が固有の挙動である。以下は agy **1.1.1**(作者の Mac、2026-07-11 実機検証)を基準とする。
+
+### 設定例
+
+```yaml
+providers:
+  - name: agent-antigravity
+    kind: agent_cli
+    model: "Gemini 3.5 Flash (Low)"   # 表示名文字列(API IDではない。下記参照)
+    paid: false                       # Google アカウント OAuth 運用(無料枠含む) = 従量課金ゼロ
+    capabilities:
+      streaming: false
+      tools: false
+    agent_cli:
+      agent: antigravity
+      # command は省略可(既定 "agy" — バイナリ名が製品名と異なる点に注意)
+      workdir: ~/.coderouter/agents/antigravity
+      exec_timeout_s: 600
+      allow_file_writes: false
+      sandbox_mode: read_only
+      passthrough_env: []             # OAuth は OS キーリング + ~/.gemini/antigravity-cli/ を
+                                       # HOME(macOS では USER も)継承で読むため空でよい。
+                                       # API キー env は UNCONFIRMED(下記参照)
+```
+
+### アダプタが構築する argv
+
+`sandbox_mode: read_only`(既定)の場合、アダプタは次の argv を構築する。
+
+```
+agy -p <prompt> --model "Gemini 3.5 Flash (Low)" --mode plan --print-timeout 600s
+```
+
+### プロンプトは argv 値経由(claude/codex の stdin・grok の `--prompt-file` のいずれとも異なる)
+
+4エージェントのプロンプト配送方式は3パターンに分かれる。
+
+| agent | 配送方式 | 備考 |
+|---|---|---|
+| claude | stdin | `-p` は引数省略時に stdin を読む |
+| codex | stdin(argv 末尾に明示 `-`) | claude と同じ経路 |
+| grok | `--prompt-file`(隔離 workdir 内 0600 一時ファイル) | argv 値・stdin いずれも不可なため |
+| antigravity | argv 値(`-p <prompt>`) | stdin 不可・`--prompt-file` 相当のフラグも無い |
+
+agy の `-p` / `--print` / `--prompt` は値必須のフラグであり、stdin からプロンプトを読む経路も、grok のような `--prompt-file` 相当のフラグも存在しない。したがってプロンプトは argv の値として渡すほかなく、Linux の `MAX_ARG_STRLEN`(約128KiB)というサイズ上限と、`ps` からプロンプト全文が見えてしまう既知の制限が残る(他に選択肢が無いためドキュメント化するのみ)。argv はリスト形式で渡され(`shell=True` は使わない)、シェル解釈は経由しない。
+
+### stdin にパイプするとハングする — agy を直接叩く場合の注意
+
+アダプタ自身は stdin に何も書き込まず即座にクローズする(`communicate(input=None)`、実機で `</dev/null` により正常動作することを確認済み)ため CodeRouter 経由では問題にならない。しかし **agy に stdin から何かをパイプすると応答が返らずハングする**ことが実機で確認されている(`printf '...' | agy -p "..."` は応答待ちのまま `Error: timeout waiting for response` になる)。agy は stdin をコンテキストとして読む機能を持たない。CLI を直接スクリプトで叩く場合は、必ず stdin を空にする(`</dev/null` 等)こと。
+
+### `sandbox_mode` → antigravity フラグのマッピング
+
+claude/codex/grok と同様、`allow_file_writes=false` のときは `sandbox_mode` の値に関わらず `read_only` にクランプされる。
+
+| `sandbox_mode` | agy フラグ | 備考 |
+|---|---|---|
+| `read_only`(既定) | `--mode plan` | ファイル変更なし。`allow_file_writes=false` のとき常にこのモードにクランプされる |
+| `edit` | `--mode accept-edits` | ファイル編集を自動承認 |
+| `full_auto` | `--mode accept-edits --dangerously-skip-permissions` | 全ツール実行を自動承認(agy の `--help` に列挙されているモード値は `accept-edits`/`plan` の2値のみ。full_auto は `--dangerously-skip-permissions` の追加で表現する) |
+
+### プレーンテキスト出力と usage 常時ゼロ
+
+agy には `--output-format` 系のフラグが**存在しない**。出力はプレーンテキストのみである。アダプタは stdout を UTF-8 デコードした上で ANSI エスケープを防御的に除去(regex)し、前後の空白を strip して最終回答とする。空文字列になった場合は retryable な `AdapterError` を送出する。JSON 出力が無いためトークン usage・セッション ID・構造化エラーはいずれも取得不能であり、grok と同様に usage は**常にゼロ**で報告される(`coderouter_cost_usd` も `ProviderConfig.cost` に単価を設定しない限り 0 のまま)。レスポンスメタデータにセッション ID は入らない。
+
+### `--print-timeout` — CLI 側タイムアウトを持つ初めてのエージェント
+
+agy は `--print-timeout <Go duration>`(既定 5m0s)という print モード自身の待ち時間上限フラグを持つ。claude/codex/grok にはこの種の CLI 側タイムアウトが無い。アダプタは `AgentCliConfig.exec_timeout_s` から `--print-timeout` を生成し(例: `exec_timeout_s=600` → `--print-timeout 600s`)、CLI 自身に自己終了させる一次防壁とする。これに加えて、従来どおり外側の `asyncio.wait_for` + プロセスグループ SIGKILL による二次防壁も維持しており、antigravity は**二重のタイムアウト**を持つ唯一のエージェントになる。
+
+### `max_turns` は無視される
+
+agy には `--max-turns` に相当するフラグが無い。`AgentCliConfig.max_turns` は antigravity では常に無視され(codex と同様)、時間上限は `--print-timeout` と `exec_timeout_s` の二重防壁のみが担う。
+
+### 認証(Google アカウント OAuth・無料枠可)
+
+agy は Google アカウント OAuth に対応しており、無料枠でも動作する。資格情報は OS キーリングを優先し、`~/.gemini/antigravity-cli/`(`credentials.enc` / `settings.json`)にも保管される。アダプタの `HOME` 継承(macOS では `USER` も)によって `passthrough_env: []` のまま headless 動作する(既存の `_build_child_env()` で対応済み)。セットアップ手順:
+
+1. `agy` を初回実行するとブラウザでの Google アカウントログインが始まる。ログインを済ませておく。
+2. `agy models` を実行し、モデル一覧が返ることをスモーク確認する。
+
+API キー経由の認証(環境変数名)は情報が錯綜しており(`ANTIGRAVITY_API_KEY` 説あり・`GEMINI_API_KEY` は無視されるという説もあり)**未確認(UNCONFIRMED)**。本ドキュメントでは断定しない。
+
+### モデル名は表示名文字列 — Claude モデルまで届く
+
+`--model` に渡す値は API ID ではなく、`agy models` が返す**表示名文字列**である。実機(agy 1.1.1)で確認された一覧の例:
+
+```
+Gemini 3.5 Flash (Medium/High/Low)
+Gemini 3.1 Pro (Low/High)
+Claude Sonnet 4.6 (Thinking)
+Claude Opus 4.6 (Thinking)
+GPT-OSS 120B (Medium)
+```
+
+面白いことに、agy 経由では Google 以外のモデル、たとえば Claude Opus 4.6 まで呼び出せる。`providers.yaml` の `model` フィールドには、このいずれかの表示名文字列をそのまま(空白・括弧を含めて)書くこと。
+
+### early-days プロダクトであることの注意
+
+Antigravity CLI は登場したばかりのプロダクトである。フラグ体系・モデル一覧は今後変わる可能性が高いため、**バージョンの pin を推奨する**(`command` に固定版バイナリのフルパスを指定できる)。プレーンテキスト出力の性質上 JSON スキーマ変化のようなパース事故は起きにくいが、想定外の空応答・非零終了コードは防御的に扱われ、retryable な `AdapterError` としてフォールバックチェーンの次のプロバイダへ降格する。
+
+---
+
 ## grok(Grok CLI)
 
 v2.7.8(Phase 1d)で `agent: grok` が実装された。claude と同じワンショット exec 方式だが、プロンプトの渡し方・クロスセッションメモリの無効化・usage 報告の各点で grok 固有の挙動がある。以下は grok CLI **v0.2.93**([stable] チャネル、2026-07-10 実機検証)を基準とする。
@@ -322,7 +442,9 @@ grok CLI は early beta である(v0.2.93 [stable] チャネル、2026-07-10 時
 | `grok exited 1: ...` で失敗する | grok CLI は認証・ネットワーク・実行時エラーを終了コード1で終わり、エラーテキストを stderr に出す | アダプタが stderr の末尾を `AdapterError` に含めるので、そのメッセージを手がかりにする。認証エラーなら `grok login` を再実行し、`grok models` が通ることをスモーク確認する |
 | `codex exited 1: ...` で失敗する(OAuth の stale を疑う場合) | codex の OAuth トークンは約8日で stale になる。使用時自動リフレッシュされるが、長期間呼び出しが無いと stale のまま失敗することがある | `codex login status` でログイン状態を確認し、必要なら `codex login` を再実行する。定期的に codex を実行しておくと stale 化を避けやすい |
 | `Not inside a trusted directory and --skip-git-repo-check was not specified.` が表示される | 通常は発生しない — アダプタは `--skip-git-repo-check` を常時付与するため | もし表示された場合は CodeRouter 側の argv 構築にバグがある可能性が高い。バージョンを確認し、再現するなら issue を報告する |
-| CLI 起動に失敗する(`failed to launch ...`) | `command`(既定は `agent` と同名)が `PATH` 上に無い | `claude --version` / `codex --version` / `grok --version` が通ることを確認する。フルパスを `command` に指定してもよい |
+| `agent: gemini` を指定すると `AdapterError` になる/`IneligibleTierError` が出る | Google が2026年6月に個人アカウント向け Gemini CLI 提供を終了したため(実機で `IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals...` を確認) | `agent: antigravity` に切り替える。設定例は [antigravity(Google Antigravity CLI)](#antigravitygoogle-antigravity-cli) セクションを参照 |
+| `agy` が応答を返さずハングする | agy に stdin をパイプしている(例: `printf '...' \| agy -p "..."`) | stdin をパイプしない。何も書かず `</dev/null` にリダイレクトする。CodeRouter 経由の呼び出しではアダプタが既にこの対策(stdin 即クローズ)を取っている |
+| CLI 起動に失敗する(`failed to launch ...`) | `command`(既定は `agent` と同名。ただし antigravity のみ既定 `agy`)が `PATH` 上に無い | `claude --version` / `codex --version` / `agy --version` / `grok --version` が通ることを確認する。フルパスを `command` に指定してもよい |
 
 ---
 

--- a/docs/designs/external-agents-adapter.md
+++ b/docs/designs/external-agents-adapter.md
@@ -2,7 +2,7 @@
 
 > 対象バージョン: CodeRouter v2.x 系 / Phase 1（in-core adapter）
 > 関連: [`docs/future.md`](../future.md) §1.2・§5、[`docs/backends/launcher.md`](../backends/launcher.md)
-> ステータス: 設計確定 / Phase 1a (claude)・Phase 1b (codex)・Phase 1d (grok) 実装済み
+> ステータス: 設計確定 / Phase 1(1a claude・1b codex・1c antigravity・1d grok)実装済み・1c は antigravity として実装
 
 本設計書は、OpenAI Codex CLI・Google Gemini CLI・xAI Grok・Anthropic Claude Code CLI の4つの外部コーディングエージェントを、CodeRouter の新しいアダプタ種別 `kind="agent_cli"` として本体に組み込む方式を定義するものである。CLI のフラグ・認証仕様はすべて調査レポート（`RESEARCH-cli.md`、2026-07 時点）を、コード上の拡張点はすべてコード解析報告書（`ANALYSIS-code.md`）を典拠とする。ユーザー確定事項（`DECISIONS.md`）は拘束条件であり、本書はそれを厳密に実装する。
 
@@ -640,3 +640,26 @@ Phase 1b（codex）実装時に、設計時点の調査（`RESEARCH-cli.md`、20
 | 成熟度 / バージョン churn | pre-1.0・要 pin（§10 リスク表、§11.1） | **確認済み**。CLI は pre-1.0 でほぼ毎日リリース。`--json` の別名は依然 `--experimental-json` のままでスキーマ未凍結 → バージョン pin 推奨 + 防御的パース必須の方針を維持 |
 
 あわせて、§5.1.5 表の codex 行の「サンドボックス/承認」列は `-s read-only` のみが確定であり、`edit`/`full_auto` は上表のとおり `-s workspace-write` に統一されたことを付記する（本文は歴史的記録として改変しない）。
+
+### 11.5 Phase 1c 実CLI検証結果（gemini 廃止と Antigravity CLI `agy` 1.1.1, 2026-07-11）
+
+Phase 1c 着手時点で、本設計書の本文（§1.1・§3.1・§5.1.5・§5.2.1・§5.3.3・§5.4・§9・§11.1）が前提としていた対象 CLI そのもの（Google Gemini CLI、コマンド `gemini`）が実装対象から外れた。Google が個人アカウント向け Gemini CLI の提供を終了したためであり、以下は検証結果である（歴史的記録として本文は改変しない。本文中の `gemini` に関する記述は下表で読み替えること）。
+
+| 項目 | 設計時の想定（gemini） | 実機での検証結果（agy 1.1.1、作者の Mac、2026-07-11） |
+|---|---|---|
+| 対象 CLI そのもの | Google Gemini CLI（コマンド `gemini`）を想定（§1.1・§3.1・§4.1 構成図など） | 個人アカウント向け Gemini CLI（`@google/gemini-cli` 0.50.0 系）の OAuth は **2026-06-18 で提供終了**（公式ブログ）。実機で次の verbatim エラーを確認: `IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals. To continue using Gemini, please migrate to the Antigravity suite of products: https://antigravity.google`（`reasonCode: UNSUPPORTED_CLIENT`, `tierId: free-tier`） |
+| trusted-directory ゲート | （設計時点で gemini については未記載） | 旧 gemini CLI は trusted-directory ゲートで **exit 55**（`--skip-trust` または `GEMINI_CLI_TRUST_WORKSPACE=true` が必要）にも遭遇。個人アカウント終了とは別に以前から存在する制約 |
+| 後継 CLI との関係 | （未検討） | 後継の **Antigravity CLI**（コマンド `agy`）は gemini-cli の**フォークではなく Go 製の別実装**。個人の Google アカウント OAuth（無料枠含む）はこちらで存続する |
+| 出力形式 | `--output-format json`（§5.1.5 表・§5.1.6 表） | agy には `--output-format` 系のフラグが**存在しない**。出力はプレーンテキストのみで、トークン usage・セッション ID・構造化エラーはいずれも取得不能 |
+| 承認/モード制御 | `--approval-mode default/auto_edit/--yolo`（§5.4 表） | agy は `--mode plan\|accept-edits` を持つ（ヘルプに列挙されるのはこの2値のみ）。`--dangerously-skip-permissions` で全ツール実行を自動承認できる。read_only→`--mode plan`、edit→`--mode accept-edits`、full_auto→`--mode accept-edits --dangerously-skip-permissions` |
+| CLI 側タイムアウト | 「全体 `--timeout` フラグは無い」と記載（§5.1.5 補足） | agy は `--print-timeout <Go duration>`（既定 5m0s）という print モード自身のタイムアウトを持つ。**claude/codex/grok にはこの種のフラグが無く、agy が唯一**。`exec_timeout_s` から生成し、外側の `asyncio.wait_for` + PGID kill と合わせて二重防壁になる |
+| ターン上限 | `maxSessionTurns`（settings.json、CLI フラグ無し。exit 53 でハンドリング想定、§5.1.5・§9） | agy には `--max-turns` 相当のフラグが存在しない。`AgentCliConfig.max_turns` は antigravity では常に無視される（codex と同じ扱い） |
+| プロンプト投入 | `-p "<prompt>"`（§5.1.5 表） | `-p` / `--print` / `--prompt` は argv 値必須。**stdin 経由のプロンプト受け取りは無く、grok のような `--prompt-file` 相当のフラグも無い**。プロンプトは argv 値として渡すほかなく、`MAX_ARG_STRLEN`（約128KiB）と `ps` 可視性が既知の制限として残る |
+| stdin パイプ時の挙動 | （未検討） | **stdin に何かをパイプすると agy がハングする**ことを実機で確認（`printf '...' \| agy -p "..."` は応答なしのまま `Error: timeout waiting for response`）。アダプタは stdin に何も書かず即クローズする（`communicate(input=None)`）ため CodeRouter 経由では問題にならない（`</dev/null` での正常動作を実機確認済み） |
+| 非 TTY 出力バグ | （未検討） | v1.x 初期に「非 TTY だと出力空 + exit 0」の既知バグ報告があったが、**agy 1.1.1 では再現せず**（TTY・非 TTY いずれも正常） |
+| モデル指定 | `gemini-2.5-pro` のような API ID 相当を想定（§3.1 の providers.yaml 例） | `--model` は **表示名文字列**（`Gemini 3.5 Flash (Low)` 等）。`agy models` で一覧確認できる。Google 以外のモデル（例: `Claude Opus 4.6 (Thinking)`）まで agy 経由で呼べる |
+| 認証 | Google OAuth キャッシュ（`~/.gemini/`）+ `GEMINI_API_KEY` を保険として `passthrough_env`（§5.3.3） | 資格情報は **OS キーリングを優先**し、`~/.gemini/antigravity-cli/`（`credentials.enc` / `settings.json`）にも保管。`HOME`（macOS では `USER` も）継承で headless 動作し `passthrough_env: []` でよい。API キー経由の環境変数名は情報が錯綜しており **UNCONFIRMED**（断定しない） |
+| エラー体系 | （未検討） | exit code の公開表は無い。非零 exit は既存どおり retryable 扱いとする |
+| スキーマ上の帰結 | （n/a） | `AgentCliConfig.agent` の `Literal` に **5番目の値 `"antigravity"`** を追加。`command` の既定値は agent 名と同じだが **antigravity のみ既定 `"agy"`**（バイナリ名が製品名と異なるため）。`gemini` は `Literal` に残すが、アダプタ `__init__` で「Google discontinued Gemini CLI for individual accounts (June 2026) → use agent='antigravity'」という専用メッセージ付きで拒否する（`retryable=False`） |
+
+以上により Phase 1（1a claude・1b codex・1c antigravity・1d grok）が完了した。§9 の実装フェーズ表・§11.1 の比較表にある「gemini」列は、上表の読み替えを前提とした歴史的記録として残す（本文は改変しない）。

--- a/examples/providers-agent-cli.yaml
+++ b/examples/providers-agent-cli.yaml
@@ -1,28 +1,31 @@
 # ============================================================
 # CodeRouter providers.yaml — 外部コーディングエージェント CLI (agent_cli)
-# 【カテゴリ】 kind="agent_cli" アダプタ / Phase 1a (claude)・Phase 1b (codex)・
-#              Phase 1d (grok) 実装済み
+# 【カテゴリ】 kind="agent_cli" アダプタ / Phase 1 完了 — claude (1a)・codex (1b)・
+#              antigravity (1c)・grok (1d) の4バックエンドすべて実装済み
 #
 # 出典: docs/designs/external-agents-adapter.md
 # 目的: Claude Code CLI (`claude -p --output-format json`)、Codex CLI、
-#       Grok CLI を CodeRouter の1プロバイダとして登録し、他のオーケストレータ
-#       (別の Claude Code / Cursor 等) から「1つのモデル」として透過的に
-#       呼び出せるようにする。
+#       Antigravity CLI (`agy`)、Grok CLI を CodeRouter の1プロバイダとして
+#       登録し、他のオーケストレータ (別の Claude Code / Cursor 等) から
+#       「1つのモデル」として透過的に呼び出せるようにする。
 #       CodeRouter はワンショット exec (プロンプト in → テキスト out) の
 #       1変換だけを担い、エージェントのマルチターン制御ループそのものは
 #       中で完結させる (future.md の「1リクエスト=1変換」思想を維持)。
 #
-# 実装スコープ (v2.7.9 時点):
-#   - agent: claude (Phase 1a)・codex (Phase 1b)・grok (Phase 1d) が実装済み。
-#     いずれもサブスクリプション OAuth を優先し (claude:
-#     `~/.claude/.credentials.json` または `claude setup-token`、codex:
-#     `~/.codex/auth.json`、grok: `~/.grok/auth.json`)、子プロセスには
-#     ANTHROPIC_API_KEY 等を含む親環境を継承させない
-#     (env allowlist、下記 passthrough_env 参照)。
-#   - agent: gemini のみ config スキーマ上は宣言できるが、
-#     アダプタ構築時に AdapterError ("not implemented yet" — 実装済み
-#     エージェントの列挙付き) で拒否される。末尾にコメントアウトした
-#     Phase 1c のプレビューブロック (未実装) を参照。
+# 実装スコープ (v2.7.10 時点 — Phase 1 完了):
+#   - agent: claude (Phase 1a)・codex (Phase 1b)・antigravity (Phase 1c)・
+#     grok (Phase 1d) の4つすべてが実装済み。いずれもサブスクリプション
+#     OAuth を優先し (claude: `~/.claude/.credentials.json` または
+#     `claude setup-token`、codex: `~/.codex/auth.json`、antigravity:
+#     OS キーリング + `~/.gemini/antigravity-cli/`、grok:
+#     `~/.grok/auth.json`)、子プロセスには ANTHROPIC_API_KEY 等を含む
+#     親環境を継承させない (env allowlist、下記 passthrough_env 参照)。
+#   - agent: gemini は config スキーマ上は宣言できるが、Google が
+#     2026年6月に個人アカウント向け Gemini CLI 提供を終了したため、
+#     アダプタ構築時に必ず専用メッセージ付きの AdapterError で拒否される:
+#       AdapterError: Google discontinued Gemini CLI for individual
+#       accounts (June 2026). Use agent='antigravity' instead.
+#     後継の antigravity ブロックを下記に用意してある(末尾の参考節も参照)。
 #   - 既定は read_only (書き込み不可)。書き込みを許可するには
 #     allow_file_writes: true と sandbox_mode: edit|full_auto を両方
 #     明示する必要がある (片方だけだと config load 時に ValueError)。
@@ -48,6 +51,12 @@
 #          -H 'Content-Type: application/json' \
 #          -H 'X-CodeRouter-Profile: codex' \
 #          -d '{"model":"gpt-5.5","messages":[{"role":"user","content":"1行でこんにちはと言って"}]}'
+#      下記の antigravity ブロックを有効化した場合の動作確認 (要 `agy` の
+#      初回ログイン済み):
+#        curl http://localhost:8088/v1/chat/completions \
+#          -H 'Content-Type: application/json' \
+#          -H 'X-CodeRouter-Profile: antigravity' \
+#          -d '{"model":"Gemini 3.5 Flash (Low)","messages":[{"role":"user","content":"1行でこんにちはと言って"}]}'
 #      下記の grok ブロックを有効化した場合の動作確認 (要 `grok login` 済み):
 #        curl http://localhost:8088/v1/chat/completions \
 #          -H 'Content-Type: application/json' \
@@ -129,6 +138,69 @@ providers:
   #   - name: codex
   #     providers: [agent-codex]
 
+  # ---- Google Antigravity CLI (Phase 1c・実装済み — v2.7.10) ----
+  # 実装済みだが既定ではコメントアウトしてある: このファイルをそのまま
+  # コピーしても agy のインストールを要求しないようにするため。
+  # Antigravity CLI (コマンド名 `agy`。gemini-cli のフォークではない
+  # 別実装、agy 1.1.1 で検証) を導入し、初回 `agy` 実行でブラウザの
+  # Google アカウントログインを済ませてから有効化すること
+  # (`agy models` が一覧を返せば認証 OK)。
+  # 当初計画されていた agent: gemini は Google が2026年6月に個人
+  # アカウント向け提供を終了したため、後継の antigravity として
+  # Phase 1c を実装した。agent: gemini は config スキーマには残るが
+  # 実行すると専用メッセージ付きの AdapterError で拒否される
+  # (詳細はファイル冒頭のコメント、および docs/backends/external-agents.md
+  # を参照)。early-days プロダクトのためバージョン pin 推奨
+  # (command にフルパス指定可)。
+  #
+  # プロンプト投入: agy には stdin 経由のプロンプト受け取りも
+  #   --prompt-file 相当のフラグも無いため、プロンプトは argv の値
+  #   (`-p <prompt>`) として渡すほかない。Linux の MAX_ARG_STRLEN
+  #   (約128KiB) の上限と `ps` でのプロンプト可視性が既知の制限として
+  #   残る (claude/codex は stdin、grok は --prompt-file を使うため
+  #   この制限を受けない)。
+  # stdin 注意: agy に stdin をパイプすると応答がハングすることが
+  #   実機で確認されている。アダプタは stdin に何も書かず即クローズ
+  #   するため CodeRouter 経由では問題にならないが、agy を直接
+  #   スクリプトで叩く場合は stdin を空にする (</dev/null 等) こと。
+  # 出力: --output-format 系のフラグが無くプレーンテキストのみのため、
+  #   トークン usage・セッション ID は取得不能。usage は常にゼロ報告
+  #   (cost も ProviderConfig.cost に単価を設定しない限り 0 のまま)。
+  # max_turns: agy には対応する CLI フラグが無いため常に無視される
+  #   (codex と同様)。
+  # タイムアウト: agy は --print-timeout という CLI 側タイムアウトを
+  #   持つ唯一のエージェント。exec_timeout_s から生成し、外側の
+  #   asyncio.wait_for + プロセスグループ kill と合わせて二重防壁になる。
+  # モデル名: API ID ではなく表示名文字列 (`agy models` で一覧)。
+  #   Claude Opus 4.6 (Thinking) 等、Google 以外のモデルまで呼べる。
+  # 認証: Google アカウント OAuth (無料枠可)。資格情報は OS キーリング
+  #   優先 + ~/.gemini/antigravity-cli/ (credentials.enc / settings.json)。
+  #   HOME (macOS では USER も) 継承で headless 動作するため
+  #   passthrough_env: [] でよい。API キー経由の環境変数名は情報が
+  #   錯綜しており未確認 (UNCONFIRMED) — 断定しない。
+  #
+  # - name: agent-antigravity
+  #   kind: agent_cli
+  #   model: "Gemini 3.5 Flash (Low)"   # 表示名文字列。`agy models` で一覧確認
+  #   paid: false                        # Google アカウント OAuth 運用(無料枠含む) = 従量課金ゼロ
+  #   capabilities:
+  #     streaming: false
+  #     tools: false
+  #   agent_cli:
+  #     agent: antigravity
+  #     # command は省略可 (既定 "agy" — バイナリ名が製品名と異なる)
+  #     workdir: ~/.coderouter/agents/antigravity
+  #     exec_timeout_s: 600
+  #     allow_file_writes: false
+  #     sandbox_mode: read_only     # --mode plan にマップ
+  #     max_turns: 8                # antigravity では無視される (上記コメント参照)
+  #     passthrough_env: []         # OAuth は OS キーリング + ~/.gemini/antigravity-cli/ を
+  #                                  # HOME 継承で読むため空でよい。API キー env は UNCONFIRMED
+  #
+  # 有効化する場合は profiles にも次を追加する:
+  #   - name: antigravity
+  #     providers: [agent-antigravity]
+
   # ---- xAI Grok CLI (Phase 1d・実装済み — v2.7.8) ----
   # 実装済みだが既定ではコメントアウトしてある: このファイルをそのまま
   # コピーしても grok CLI のインストールを要求しないようにするため。
@@ -189,37 +261,27 @@ profiles:
 #       match: { model_pattern: "claude-agent.*" }
 
 # ============================================================
-# 以下はプレビュー (Phase 1c・未実装) — コメントアウト
+# 参考: agent: gemini は書けるが常に拒否される
 #
-# 下記の agent: gemini は config スキーマとしては
-# 有効 (providers.yaml として読み込める) だが、AgentCliAdapter が
-# claude / codex / grok 以外を拒否するため、実際にリクエストを投げると
-# 起動時におおよそ次の形の AdapterError (正確な文言は変わりうる)
-#   AdapterError: agent 'gemini' is not implemented yet
-#   (implemented: claude, codex, grok). Wait for the agent's phase (1c).
-# で失敗する (retryable=False)。将来のフェーズが実装されるまでの
-# forward-compatible なプレースホルダとして参照用に残してある。
-# 詳細: docs/designs/external-agents-adapter.md §3, §9
+# 当初計画されていた Phase 1c は Google Gemini CLI (コマンド `gemini`)
+# を対象としていたが、Google が2026年6月に個人アカウント向け提供を
+# 終了したため実装対象から外れ、後継の Antigravity CLI (`agy`) を
+# 対象に agent: antigravity として実装された (上記参照)。
+#
+# agent: gemini は config スキーマの Literal には残っているため
+# 次のような設定は providers.yaml として "読み込める" が、
+# AgentCliAdapter の構築時に必ず次の専用メッセージで拒否される
+# (retryable=False):
+#   AdapterError: Google discontinued Gemini CLI for individual
+#   accounts (June 2026). Use agent='antigravity' instead.
+#
+# 詳細: docs/backends/external-agents.md の「gemini の廃止と
+# antigravity への移行」節、docs/designs/external-agents-adapter.md §11.5
 # ============================================================
 
 # providers:
-#   # ---- Google Gemini CLI (Phase 1c・未実装) ----
 #   - name: agent-gemini
 #     kind: agent_cli
-#     model: gemini-2.5-pro
-#     paid: false               # サブスク OAuth 運用なら false
-#     capabilities:
-#       streaming: false
 #     agent_cli:
-#       agent: gemini
-#       command: gemini
-#       workdir: ~/.coderouter/agents/gemini
-#       exec_timeout_s: 600
-#       allow_file_writes: false
-#       max_turns: 8               # settings.json の maxSessionTurns 相当
-#       sandbox_mode: read_only
-#       passthrough_env: [GEMINI_API_KEY]   # OAuth キャッシュが無い場合の保険
-#
-# profiles:
-#   - name: gemini
-#     providers: [agent-gemini]
+#       agent: gemini   # → 上記 AdapterError で拒否される。
+#                        #   agent: antigravity に置き換えること。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 # in plan.md §11.B; once granted, this name will become an alias and
 # `coderouter` will become the canonical distribution name.
 name = "coderouter-cli"
-version = "2.7.9"
+version = "2.7.10"
 description = "Local-first, free-first, fallback-built-in LLM router. Claude Code / OpenAI compatible."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,20 +1,25 @@
 """Tests for the agent_cli adapter (Phase 1a claude + Phase 1b codex +
-Phase 1d grok).
+Phase 1d grok + Phase 1c antigravity — Phase 1 complete).
 
-Implements the design's §8 test plan for the Phase 1a/1b/1d scope:
+Implements the design's §8 test plan for the full Phase 1 scope:
 
 * T1  argv construction (model / max-turns / permission-mode mapping,
-      allow_file_writes clamp) — for claude, codex and grok (codex adds the
-      exec/--json/--skip-git-repo-check/--ephemeral/-s/trailing "-" shape;
-      grok adds the --prompt-file / --no-memory / --sandbox shape).
-* T2  claude / codex / grok output parsing (success / is_error / malformed /
-      missing fields; codex's JSONL + cached-tokens-as-subset usage +
-      thread_id meta; grok's zero-usage + sessionId meta).
+      allow_file_writes clamp) — for claude, codex, grok and antigravity
+      (codex adds the exec/--json/--skip-git-repo-check/--ephemeral/-s/
+      trailing "-" shape; grok adds the --prompt-file / --no-memory /
+      --sandbox shape; antigravity adds the argv-delivered -p prompt /
+      --mode / --print-timeout shape).
+* T2  claude / codex / grok / antigravity output parsing (success /
+      is_error / malformed / missing fields; codex's JSONL +
+      cached-tokens-as-subset usage + thread_id meta; grok's zero-usage +
+      sessionId meta; antigravity's ANSI-stripped plain text + zero-usage +
+      empty meta).
 * T3  stubbed subprocess via ``asyncio.create_subprocess_exec`` monkeypatch
       (codex checks the stdin prompt-delivery path with no prompt file;
       grok additionally checks the prompt-file lifecycle: 0600 file exists
       and contains the prompt DURING the exec, deleted afterwards, also on
-      failure / timeout paths).
+      failure / timeout paths; antigravity checks the argv-delivery path:
+      no prompt file, no stdin bytes, prompt present in captured argv).
 * T4  TestClient E2E through ``POST /v1/chat/completions``.
 * T6  timeout → process-group kill + retryable AdapterError.
 * T7  child-env isolation (no ANTHROPIC_API_KEY leak, NO_COLOR present,
@@ -23,7 +28,9 @@ Implements the design's §8 test plan for the Phase 1a/1b/1d scope:
 * T8  recursion depth limit → non-retryable AdapterError.
 
 Plus config-schema validation (agent_cli required, base_url optionality,
-sandbox / allow_file_writes conflict) and healthcheck / retryable semantics.
+sandbox / allow_file_writes conflict, antigravity's "agy" command default)
+and healthcheck / retryable semantics, including the dedicated gemini →
+antigravity migration rejection message.
 
 Subprocess stubbing follows the ``_FakeProc`` shape used in
 ``tests/test_launcher_mtp.py``; the TestClient scaffolding mirrors
@@ -124,6 +131,17 @@ CODEX_JSONL = b"\n".join(
 
 
 # ---------------------------------------------------------------------------
+# Canned antigravity (agy) plain-text output (verified agy 1.1.1 — no
+# --output-format flag exists; output is plain text, optionally ANSI-styled)
+# ---------------------------------------------------------------------------
+
+ANTIGRAVITY_PLAIN = b"9\n"
+# A representative ANSI-decorated variant: SGR color codes around the answer
+# plus a trailing OSC title-set sequence, both of which must be stripped.
+ANTIGRAVITY_ANSI = b"\x1b[32m9\x1b[0m\n\x1b]0;agy\x07"
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -167,6 +185,21 @@ def _make_codex_adapter(**agent_cli_overrides: object) -> AgentCliAdapter:
         kind="agent_cli",
         model="gpt-5.5",
         paid=True,
+        capabilities=Capabilities(streaming=False),
+        agent_cli=AgentCliConfig(**acfg),  # type: ignore[arg-type]
+    )
+    return AgentCliAdapter(provider)
+
+
+def _make_antigravity_adapter(**agent_cli_overrides: object) -> AgentCliAdapter:
+    """Build an AgentCliAdapter with an antigravity sub-config + overrides."""
+    acfg: dict[str, object] = {"agent": "antigravity"}
+    acfg.update(agent_cli_overrides)
+    provider = ProviderConfig(
+        name="agent-antigravity",
+        kind="agent_cli",
+        model="Gemini 3.5 Flash (Low)",
+        paid=False,
         capabilities=Capabilities(streaming=False),
         agent_cli=AgentCliConfig(**acfg),  # type: ignore[arg-type]
     )
@@ -452,6 +485,77 @@ def test_codex_argv_trailing_stdin_sentinel_and_no_prompt() -> None:
     argv = adapter._build_codex_argv("/w")
     assert argv[-1] == "-"
     assert all("hi there" not in arg for arg in argv)
+
+
+# ---------------------------------------------------------------------------
+# T1 (antigravity) — argv construction
+# ---------------------------------------------------------------------------
+
+
+def test_antigravity_argv_read_only_default_full_snapshot() -> None:
+    adapter = _make_antigravity_adapter(workdir="/tmp/wd")
+    argv = adapter._build_antigravity_argv("/tmp/wd", None, "solve 4+5")
+    assert argv == [
+        "agy",
+        "-p",
+        "solve 4+5",
+        "--model",
+        "Gemini 3.5 Flash (Low)",
+        "--mode",
+        "plan",
+        "--print-timeout",
+        "600s",
+    ]
+
+
+def test_antigravity_argv_edit_maps_accept_edits() -> None:
+    adapter = _make_antigravity_adapter(sandbox_mode="edit", allow_file_writes=True)
+    argv = adapter._build_antigravity_argv("/w", None, "p")
+    assert argv[argv.index("--mode") + 1] == "accept-edits"
+    assert "--dangerously-skip-permissions" not in argv
+
+
+def test_antigravity_argv_full_auto_maps_accept_edits_and_skip_permissions() -> None:
+    adapter = _make_antigravity_adapter(sandbox_mode="full_auto", allow_file_writes=True)
+    argv = adapter._build_antigravity_argv("/w", None, "p")
+    assert argv[argv.index("--mode") + 1] == "accept-edits"
+    assert "--dangerously-skip-permissions" in argv
+
+
+def test_antigravity_argv_read_only_clamp_when_writes_disabled() -> None:
+    # sandbox_mode=edit but allow_file_writes=False → clamp to plan, and
+    # --dangerously-skip-permissions must never appear either.
+    adapter = _make_antigravity_adapter(sandbox_mode="edit", allow_file_writes=False)
+    argv = adapter._build_antigravity_argv("/w", None, "p")
+    assert argv[argv.index("--mode") + 1] == "plan"
+    assert "--dangerously-skip-permissions" not in argv
+
+
+def test_antigravity_argv_omits_max_turns_even_when_set() -> None:
+    # agy has no --max-turns equivalent; the flag must never appear, even
+    # when the config sets max_turns explicitly.
+    adapter = _make_antigravity_adapter(max_turns=5)
+    argv = adapter._build_antigravity_argv("/w", None, "p")
+    assert "--max-turns" not in argv
+
+
+def test_antigravity_argv_model_override() -> None:
+    adapter = _make_antigravity_adapter(model="Gemini 3.1 Pro (High)")
+    argv = adapter._build_antigravity_argv("/w", None, "p")
+    assert argv[argv.index("--model") + 1] == "Gemini 3.1 Pro (High)"
+
+
+def test_antigravity_argv_print_timeout_from_exec_timeout_s() -> None:
+    adapter = _make_antigravity_adapter(exec_timeout_s=120)
+    argv = adapter._build_antigravity_argv("/w", None, "p")
+    assert argv[argv.index("--print-timeout") + 1] == "120s"
+
+
+def test_antigravity_argv_no_sandbox_no_add_dir() -> None:
+    adapter = _make_antigravity_adapter()
+    argv = adapter._build_antigravity_argv("/w", None, "p")
+    assert "--sandbox" not in argv
+    assert "--add-dir" not in argv
 
 
 # ---------------------------------------------------------------------------
@@ -792,6 +896,41 @@ def test_codex_parse_empty_stdout_raises_retryable() -> None:
 
 
 # ---------------------------------------------------------------------------
+# T2 (antigravity) — plain-text parsing
+# ---------------------------------------------------------------------------
+
+
+def test_antigravity_parse_plain_text_success() -> None:
+    adapter = _make_antigravity_adapter()
+    text, usage, meta = adapter._parse_antigravity(ANTIGRAVITY_PLAIN, b"")
+    assert text == "9"
+    assert usage == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    assert meta == {}
+
+
+def test_antigravity_parse_ansi_stripped() -> None:
+    adapter = _make_antigravity_adapter()
+    text, _usage, _meta = adapter._parse_antigravity(ANTIGRAVITY_ANSI, b"")
+    assert text == "9"
+    assert "\x1b" not in text
+
+
+def test_antigravity_parse_empty_stdout_raises_retryable() -> None:
+    adapter = _make_antigravity_adapter()
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_antigravity(b"   \n", b"")
+    assert info.value.retryable is True
+    assert "no stdout" in str(info.value)
+
+
+def test_antigravity_parse_whitespace_only_after_ansi_strip_raises_retryable() -> None:
+    adapter = _make_antigravity_adapter()
+    with pytest.raises(AdapterError) as info:
+        adapter._parse_antigravity(b"\x1b[32m\x1b[0m  \n", b"")
+    assert info.value.retryable is True
+
+
+# ---------------------------------------------------------------------------
 # T3 — generate() with a stubbed subprocess
 # ---------------------------------------------------------------------------
 
@@ -923,6 +1062,45 @@ async def test_codex_generate_nonzero_exit_is_retryable(
 
 
 # ---------------------------------------------------------------------------
+# T3 (antigravity) — generate() with a stubbed subprocess (argv delivery)
+# ---------------------------------------------------------------------------
+
+
+async def test_antigravity_generate_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    proc = _FakeProc(stdout=ANTIGRAVITY_PLAIN, returncode=0)
+    captured = _patch_exec(monkeypatch, proc)
+    adapter = _make_antigravity_adapter(workdir=str(tmp_path))
+
+    resp = await adapter.generate(_request())
+
+    assert resp.choices[0]["message"]["content"] == "9"
+    assert resp.coderouter_provider == "agent-antigravity"
+    assert resp.model == "Gemini 3.5 Flash (Low)"
+    assert resp.usage == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    # Nothing is written to stdin — verified required for agy, which hangs
+    # if anything is piped to it.
+    assert proc.stdin_received is None
+    # The prompt is carried on argv (the CLI's only delivery channel).
+    argv = captured[0]
+    assert any("hi there" in arg for arg in argv)
+    # No private prompt file is ever created in the workdir for antigravity.
+    assert list(tmp_path.glob(".coderouter-prompt-*")) == []
+
+
+async def test_antigravity_generate_nonzero_exit_is_retryable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    proc = _FakeProc(stdout=b"", stderr=b"auth failed", returncode=1)
+    _patch_exec(monkeypatch, proc)
+    adapter = _make_antigravity_adapter(workdir=str(tmp_path))
+    with pytest.raises(AdapterError) as info:
+        await adapter.generate(_request())
+    assert info.value.retryable is True
+
+
+# ---------------------------------------------------------------------------
 # T6 — timeout → process-group kill
 # ---------------------------------------------------------------------------
 
@@ -1013,7 +1191,7 @@ async def test_healthcheck_present_binary(monkeypatch: pytest.MonkeyPatch) -> No
     assert await adapter.healthcheck() is True
 
 
-def test_unsupported_agent_raises_non_retryable() -> None:
+def test_gemini_rejected_with_antigravity_migration_message() -> None:
     provider = ProviderConfig(
         name="agent-gemini",
         kind="agent_cli",
@@ -1024,8 +1202,12 @@ def test_unsupported_agent_raises_non_retryable() -> None:
     with pytest.raises(AdapterError) as info:
         AgentCliAdapter(provider)
     assert info.value.retryable is False
-    assert "not implemented yet" in str(info.value)
-    assert "implemented: claude, codex, grok" in str(info.value)
+    message = str(info.value)
+    assert "antigravity" in message
+    assert "discontinued" in message
+    # The OLD generic "not implemented yet" message must no longer fire for
+    # gemini — it now gets its own dedicated migration message instead.
+    assert "not implemented yet" not in message
 
 
 # ---------------------------------------------------------------------------
@@ -1056,6 +1238,29 @@ def test_schema_base_url_required_for_openai_compat() -> None:
 def test_schema_command_defaults_to_agent() -> None:
     cfg = AgentCliConfig(agent="claude")
     assert cfg.command == "claude"
+
+
+def test_schema_command_defaults_to_agy_for_antigravity() -> None:
+    # antigravity is the one agent whose binary name differs from the
+    # ``agent`` value (product "Antigravity CLI", command "agy").
+    cfg = AgentCliConfig(agent="antigravity")
+    assert cfg.command == "agy"
+
+
+def test_schema_command_still_defaults_to_agent_for_others() -> None:
+    for agent in ("claude", "codex", "grok"):
+        cfg = AgentCliConfig(agent=agent)  # type: ignore[arg-type]
+        assert cfg.command == agent
+
+
+def test_schema_antigravity_accepted_by_literal() -> None:
+    cfg = AgentCliConfig(agent="antigravity")
+    assert cfg.agent == "antigravity"
+
+
+def test_schema_antigravity_explicit_command_not_overridden() -> None:
+    cfg = AgentCliConfig(agent="antigravity", command="/opt/bin/agy")
+    assert cfg.command == "/opt/bin/agy"
 
 
 def test_schema_write_conflict_rejected() -> None:
@@ -1236,3 +1441,67 @@ def test_e2e_codex_chat_completions(codex_e2e_client: TestClient) -> None:
     assert body["usage"]["prompt_tokens"] == 13810
     assert body["usage"]["total_tokens"] == 13815
     assert body["coderouter_session_id"] == "019f4e74-08fd-77b2-9cc6-9afa744df130"
+
+
+# ---------------------------------------------------------------------------
+# T4 (antigravity) — TestClient E2E through /v1/chat/completions
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def antigravity_e2e_config(tmp_path: Path) -> CodeRouterConfig:
+    return CodeRouterConfig(
+        allow_paid=True,
+        default_profile="antigravity-agent",
+        providers=[
+            ProviderConfig(
+                name="agent-antigravity",
+                kind="agent_cli",
+                model="Gemini 3.5 Flash (Low)",
+                paid=False,
+                capabilities=Capabilities(streaming=False),
+                agent_cli=AgentCliConfig(agent="antigravity", workdir=str(tmp_path)),
+            ),
+        ],
+        profiles=[FallbackChain(name="antigravity-agent", providers=["agent-antigravity"])],
+    )
+
+
+@pytest.fixture
+def antigravity_e2e_client(
+    antigravity_e2e_config: CodeRouterConfig, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[TestClient]:
+    proc = _FakeProc(stdout=ANTIGRAVITY_PLAIN, returncode=0)
+
+    async def fake_exec(*argv: str, **kwargs: object) -> _FakeProc:
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(
+        "coderouter.ingress.app.load_config", lambda path=None: antigravity_e2e_config
+    )
+    uninstall_collector()
+    app = create_app()
+    try:
+        with TestClient(app) as tc:
+            yield tc
+    finally:
+        uninstall_collector()
+
+
+def test_e2e_antigravity_chat_completions(antigravity_e2e_client: TestClient) -> None:
+    resp = antigravity_e2e_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "Gemini 3.5 Flash (Low)",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+        headers={"X-CodeRouter-Profile": "antigravity-agent"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["choices"][0]["message"]["content"] == "9"
+    assert body["coderouter_provider"] == "agent-antigravity"
+    assert body["usage"]["total_tokens"] == 0
+    # antigravity emits no session id — meta is empty end-to-end.
+    assert "coderouter_session_id" not in body

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "coderouter-cli"
-version = "2.7.9"
+version = "2.7.10"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Completes **agent_cli Phase 1**: the fourth backend ships as
**`agent: antigravity`** (Google Antigravity CLI, command `agy`) — in lieu
of the originally-planned gemini. Implemented backends are now
**claude (1a) + codex (1b) + antigravity (1c) + grok (1d)**.

**Why not gemini:** field-verified on the legacy `@google/gemini-cli` —
individual-account OAuth now fails with
`IneligibleTierError: This client is no longer supported for Gemini Code
Assist for individuals. To continue using Gemini, please migrate to the
Antigravity suite of products` (discontinued June 2026), plus a
trusted-directory gate (exit 55). The successor `agy` (1.1.1, a Go
rewrite — not a fork; different flag surface) keeps individual OAuth
including the free tier. `agent: gemini` stays schema-valid but is
rejected with a migration pointer (recorded in design doc §11.5).

## Implementation (verified on agy 1.1.1, 2026-07-11)

- argv (read_only default):
  `agy -p <prompt> --model "Gemini 3.5 Flash (Low)" --mode plan
  --print-timeout 600s`
- **Prompt rides argv**: agy has no stdin channel (piping content to
  stdin hangs the CLI — field-verified) and no `--prompt-file`
  equivalent; nothing is written to stdin. Documented limitation:
  ~128KiB `MAX_ARG_STRLEN` / `ps` visibility. All three delivery
  mechanisms now coexist (claude/codex = stdin, grok = 0600 prompt file,
  antigravity = argv).
- Mode mapping with the usual clamp: read_only → `--mode plan`;
  edit → `--mode accept-edits`; full_auto → `--mode accept-edits
  --dangerously-skip-permissions`.
- `--print-timeout` (from `exec_timeout_s`) is the CLI-side first wall;
  asyncio + PGID SIGKILL remains the second.
- Plain-text output (no JSON flag exists): defensive ANSI-strip parsing;
  usage zeros; no session id.
- Schema: 5th `agent` Literal; `command` defaults to `agy` for
  antigravity; gemini-specific rejection message.
- Auth: Google-account OAuth (free tier OK) via OS keyring +
  `~/.gemini/antigravity-cli/`; HOME/USER inheritance,
  `passthrough_env: []`. API-key env var intentionally documented as
  unconfirmed.

## Verification

- Unit: `tests/test_agent_cli.py` **72 → 91 passed** (ruff clean);
  claude/codex/grok argv snapshots unchanged byte-for-byte.
- Adversarial review (separate agent): **APPROVE** — prompt-delivery
  matrix across all four agents, ANSI-regex ReDoS check (10MB in
  0.007s), mode-clamp and schema-default probes; zero defects.
- Real-CLI dress rehearsal: production-identical argv returned `9` for
  4+5 on agy 1.1.1 / macOS (stdin closed, non-TTY stdout).
- Legacy-gemini failure modes reproduced and recorded (IneligibleTierError,
  exit 55).

## Docs

- `docs/backends/external-agents.md` / `.en.md`: antigravity section +
  gemini-discontinuation migration note + 4-way prompt-delivery table +
  troubleshooting rows.
- `docs/designs/external-agents-adapter.md`: §11.5 verification record;
  status header → Phase 1 complete.
- `examples/providers-agent-cli.yaml`: antigravity block; gemini preview
  replaced with a rejection note.
- CHANGELOG: v2.7.10 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NM473z8MscgHUsGDkiuDTq
