### PR TITLE
feat(plugins): Adapter hook wiring — Phase 2a of agent_cli extraction (v2.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,56 @@ are kept verbatim where the Japanese text itself is the subject).
 
 ---
 
+## [v2.8.0] — 2026-07-11 (Plugin SDK: Adapter hook wired — Phase 2a of the agent_cli extraction)
+
+Opens the Plugin SDK's Adapter surface: the previously dead-end `Adapter`
+Protocol (name-only) is now a real engine-integrated hook, so an external
+plugin package can provide new `kind` values for providers.yaml without
+touching Core. This is Phase 2a of the agent_cli plugin-extraction design
+(`docs/designs/agent-cli-plugin-extraction.md`): hook wiring only — the
+in-core `agent_cli` adapter is unchanged and keeps working exactly as in
+v2.7.10; the actual move into `coderouter-plugin-agents` is Phase 2b/2c.
+
+### Added
+
+- **`Adapter` plugin Protocol** (`coderouter/plugins/base.py`) — `kind: str`
+  plus synchronous `build(config: ProviderConfig) -> BaseAdapter`. A factory
+  shape (kind → adapter), unlike the per-request hooks: construction happens
+  once at startup and does no I/O. The `adapter` entry-point group
+  (`coderouter.adapter`, singular — matching the loader's group mechanics)
+  moved from the future list into the active groups; the existing two-stage
+  gate (installed + listed in `plugins.enabled`) applies as-is.
+- **`build_adapter` plugin resolution** (`coderouter/adapters/registry.py`)
+  — resolution order is in-core kinds first (`openai_compat` / `anthropic` /
+  `agent_cli`; a plugin can never shadow them), then plugin-provided kinds,
+  then a `ValueError` listing every known kind plus an install/enable hint.
+  Both engine call sites (startup adapter cache + runtime
+  `register_provider`) pass the plugin registry.
+- **Tests** (`tests/test_plugin_adapter.py`, new, 10) — plugin-kind
+  resolution, in-core shadowing prevention, unknown-kind error contents,
+  two-stage gate via the real entry-point loader path, runtime
+  `register_provider` with a plugin kind, and an E2E request through
+  `POST /v1/chat/completions` served by a plugin-provided adapter.
+
+### Changed
+
+- **`ProviderConfig.kind`: `Literal[...]` → `str`** (`config/schemas.py`) —
+  plugin kinds cannot be known at config-load time (plugins are discovered
+  after the config is parsed), so the closed Literal had to open. Fail-fast
+  for a typo'd kind moves one step later but stays at startup: the engine
+  builds adapters for **all** providers eagerly in its constructor, so an
+  unknown kind still aborts `serve` at load with a message that now lists
+  in-core and plugin kinds (strictly more helpful than the old pydantic
+  error). Recorded as a design deviation in
+  `agent-cli-plugin-extraction.md` §8.1, including the residual limitation
+  that `doctor` (HTTP-probe based) does not surface typo'd kinds.
+- Plugin-group bookkeeping: `adapter` no longer warns as
+  "plugin-group-not-yet-active"; `PluginRegistry` gained an `adapters`
+  view alongside `input_filters` / `observers`.
+
 ## [v2.7.10] — 2026-07-11 (agent_cli Phase 1c: antigravity — Phase 1 complete)
 
-**PR #70**. Completes agent_cli Phase 1: `agent: antigravity` (the Google Antigravity
+Completes agent_cli Phase 1: `agent: antigravity` (the Google Antigravity
 CLI, command `agy`) is now implemented, joining `claude` (1a), `codex`
 (1b), and `grok` (1d) — all four Phase 1 backends are now in place. This
 target replaces the originally-planned `gemini`: on the author's Mac, the

--- a/coderouter/adapters/registry.py
+++ b/coderouter/adapters/registry.py
@@ -2,14 +2,41 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from coderouter.adapters.anthropic_native import AnthropicAdapter
 from coderouter.adapters.base import BaseAdapter
 from coderouter.adapters.openai_compat import OpenAICompatAdapter
 from coderouter.config.schemas import ProviderConfig
 
+if TYPE_CHECKING:
+    from coderouter.plugins.registry import PluginRegistry
 
-def build_adapter(provider: ProviderConfig) -> BaseAdapter:
-    """Construct an adapter from a ProviderConfig."""
+# in-core kinds, in resolution order. Kept as a tuple (not derived from
+# the if-chain below) so the "Unknown adapter kind" error message and
+# the plugin-shadow guard have a single source of truth.
+_IN_CORE_KINDS: tuple[str, ...] = ("openai_compat", "anthropic", "agent_cli")
+
+
+def _plugin_kinds(plugin_registry: PluginRegistry | None) -> list[str]:
+    """``kind`` values served by enabled adapter plugins, for error text."""
+    if plugin_registry is None:
+        return []
+    return [factory.kind for factory in plugin_registry.adapters]
+
+
+def build_adapter(
+    provider: ProviderConfig,
+    plugin_registry: PluginRegistry | None = None,
+) -> BaseAdapter:
+    """Construct an adapter from a ProviderConfig.
+
+    Resolution order (docs/designs/agent-cli-plugin-extraction.md §3.2):
+    in-core kinds first, then plugin-provided kinds, then a fail-fast
+    error. In-core kinds are checked first so a plugin can never shadow
+    a kind Core itself guarantees (``openai_compat`` / ``anthropic`` /,
+    during the Phase 2b migration window, ``agent_cli``).
+    """
     if provider.kind == "openai_compat":
         return OpenAICompatAdapter(provider)
     if provider.kind == "anthropic":
@@ -20,4 +47,14 @@ def build_adapter(provider: ProviderConfig) -> BaseAdapter:
         from coderouter.adapters.agent_cli import AgentCliAdapter
 
         return AgentCliAdapter(provider)
-    raise ValueError(f"Unknown adapter kind: {provider.kind!r}")
+    if plugin_registry is not None:
+        for factory in plugin_registry.adapters:
+            if factory.kind == provider.kind:
+                return factory.build(provider)
+    raise ValueError(
+        f"Unknown adapter kind {provider.kind!r}. "
+        f"in-core kinds: {', '.join(_IN_CORE_KINDS)}; "
+        f"plugin-provided kinds: {_plugin_kinds(plugin_registry)}. "
+        f"If a plugin should provide {provider.kind!r}, ensure it is "
+        f"installed AND listed in plugins.enabled."
+    )

--- a/coderouter/config/schemas.py
+++ b/coderouter/config/schemas.py
@@ -342,13 +342,23 @@ class ProviderConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str = Field(..., description="Unique identifier used in profiles.yaml")
-    kind: Literal["openai_compat", "anthropic", "agent_cli"] = Field(
+    # v2.8.0: widened from Literal["openai_compat", "anthropic", "agent_cli"]
+    # to str so a provider can name a kind served by an adapter plugin
+    # (docs/designs/agent-cli-plugin-extraction.md §3). Config loading
+    # happens before plugin discovery (coderouter/ingress/app.py
+    # ``load_config`` then ``discover_and_load``), so pydantic can't know
+    # the full set of valid kinds at this point — an unknown kind still
+    # fails fast, just one step later, in ``build_adapter`` when the
+    # engine builds its adapter cache at startup.
+    kind: str = Field(
         default="openai_compat",
         description=(
             "Adapter type. 'openai_compat' covers llama.cpp / Ollama / "
             "OpenRouter / LM Studio / Together / Groq. 'anthropic' is the "
             "native Anthropic Messages API passthrough (v0.3.x). 'agent_cli' "
-            "invokes an external coding-agent CLI one-shot (see AgentCliConfig)."
+            "invokes an external coding-agent CLI one-shot (see AgentCliConfig). "
+            "Other values must be served by an adapter plugin listed in "
+            "plugins.enabled."
         ),
     )
     # base_url is required for HTTP-backed adapters (openai_compat / anthropic)

--- a/coderouter/plugins/base.py
+++ b/coderouter/plugins/base.py
@@ -1,11 +1,13 @@
-"""Plugin SDK Protocol contracts (v2.3.0).
+"""Plugin SDK Protocol contracts (v2.3.0, Adapter wired in v2.8.0).
 
-Six extension points are defined here. Two are wired into the engine
-in v2.3.0 (:class:`InputFilter`, :class:`Observer`); four are
-Protocol-only (:class:`Frontend`, :class:`Guard`, :class:`OutputFilter`,
-:class:`Adapter`) and will get engine integration when a real plugin
-drives the requirement — see ``docs/inside/plugin-architecture-draft.md``
-§3 for the full design rationale.
+Six extension points are defined here. Three are wired into the engine
+(:class:`InputFilter`, :class:`Observer` since v2.3.0; :class:`Adapter`
+since v2.8.0 — see ``docs/designs/agent-cli-plugin-extraction.md`` §2);
+three remain Protocol-only (:class:`Frontend`, :class:`Guard`,
+:class:`OutputFilter`) and will get engine integration when a real
+plugin drives the requirement — see
+``docs/inside/plugin-architecture-draft.md`` §3 for the full design
+rationale.
 
 Why declare contracts ahead of integration? It lets a plugin author
 build against the SDK *now* (and ship a working ``coderouter.frontend``
@@ -14,9 +16,11 @@ backward-incompatible Protocol revision later. ``runtime_checkable``
 is used so :func:`isinstance` checks work in the loader for clearer
 error messages.
 
-All hooks are async. Failures must NEVER block the engine response —
-the engine wraps every hook call in try/except and degrades gracefully
-(see ``coderouter/routing/fallback.py`` integration site).
+InputFilter / Observer are async and run repeatedly on the hot path;
+failures must NEVER block the engine response, so the engine wraps
+every hook call in try/except and degrades gracefully (see
+``coderouter/routing/fallback.py`` integration site). Adapter is
+different in shape — see its docstring below.
 """
 from __future__ import annotations
 
@@ -25,7 +29,8 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 if TYPE_CHECKING:
     # Avoid circular imports at runtime — Protocol typing only needs
     # these for documentation and static analysis.
-    from coderouter.config.schemas import CodeRouterConfig
+    from coderouter.adapters.base import BaseAdapter
+    from coderouter.config.schemas import CodeRouterConfig, ProviderConfig
     from coderouter.translation.anthropic import (
         AnthropicRequest,
         AnthropicResponse,
@@ -94,6 +99,44 @@ class Observer(Protocol):
 
 
 # ====================================================================
+# Adapter hook (engine integration in v2.8.0)
+# ====================================================================
+
+
+@runtime_checkable
+class Adapter(Protocol):
+    """New ``kind`` value in providers.yaml, backed by a plugin.
+
+    The plugin declares the ``kind`` string it serves and a factory
+    that turns a matching :class:`~coderouter.config.schemas.ProviderConfig`
+    into a :class:`~coderouter.adapters.base.BaseAdapter` instance —
+    the same surface :func:`coderouter.adapters.registry.build_adapter`
+    uses for in-core kinds, so the engine treats plugin adapters
+    indistinguishably from built-ins once registered. See
+    ``docs/designs/agent-cli-plugin-extraction.md`` §2 for the design
+    rationale.
+
+    Shape-wise this hook differs from :class:`InputFilter` /
+    :class:`Observer`: those are instances the engine calls repeatedly
+    on the hot path, so they're async. An adapter provider is instead
+    a **factory** consulted once per provider at engine startup (and
+    again if the provider is re-registered at runtime) — construction
+    is I/O-free, so :meth:`build` is synchronous, matching
+    ``build_adapter``.
+    """
+
+    name: str
+    # The ``kind`` value this plugin serves in providers.yaml. Distinct
+    # from ``name`` (the plugin's own identifier, used in
+    # ``plugins.enabled`` / logs) — kept 1:1 for now; a future
+    # ``kinds: tuple[str, ...]`` can generalize this if a real plugin
+    # needs to serve more than one kind.
+    kind: str
+
+    def build(self, config: ProviderConfig) -> BaseAdapter: ...
+
+
+# ====================================================================
 # Future hooks (Protocol-only, engine integration in v2.4+)
 # ====================================================================
 
@@ -151,18 +194,3 @@ class OutputFilter(Protocol):
     async def transform(
         self, response: AnthropicResponse
     ) -> AnthropicResponse: ...
-
-
-@runtime_checkable
-class Adapter(Protocol):
-    """New ``kind`` value in providers.yaml (e.g. ``bedrock-native``).
-
-    Plugins implement the same async surface as
-    :class:`coderouter.adapters.base.BaseAdapter` so the engine can
-    treat them indistinguishably from built-in adapters once the
-    loader registers the new ``kind`` mapping.
-
-    Not yet integrated — Protocol contract only.
-    """
-
-    name: str

--- a/coderouter/plugins/loader.py
+++ b/coderouter/plugins/loader.py
@@ -38,10 +38,14 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# Active hook groups in v2.3.0. The engine wires these into the
-# request flow; plugins targeting them will see their methods called
-# at runtime.
-PLUGIN_GROUPS_V2_3: tuple[str, ...] = ("input_filter", "observer")
+# Active hook groups. The engine wires these into the request flow;
+# plugins targeting them will see their methods called at runtime.
+# ``input_filter`` / ``observer`` since v2.3.0; ``adapter`` joined in
+# v2.8.0 (docs/designs/agent-cli-plugin-extraction.md §2.4) — its
+# factories are consulted from ``build_adapter``, not iterated on the
+# hot path like the other two, but it goes through the same
+# discover-then-enable-gate machinery below.
+PLUGIN_GROUPS_V2_3: tuple[str, ...] = ("input_filter", "observer", "adapter")
 
 # Hook groups whose Protocol contracts are stable but whose engine
 # integration is deferred. Listing them here means a plugin author
@@ -51,7 +55,6 @@ PLUGIN_GROUPS_FUTURE: tuple[str, ...] = (
     "frontend",
     "guard",
     "output_filter",
-    "adapter",
 )
 
 

--- a/coderouter/plugins/registry.py
+++ b/coderouter/plugins/registry.py
@@ -20,8 +20,8 @@ from typing import Any
 class PluginRegistry:
     """In-memory registry of loaded plugin instances grouped by hook kind.
 
-    Use the typed ``input_filters`` / ``observers`` properties on the
-    hot path; plugin code should not iterate ``_by_group`` directly.
+    Use the typed ``input_filters`` / ``observers`` / ``adapters``
+    properties; plugin code should not iterate ``_by_group`` directly.
     """
 
     def __init__(self) -> None:
@@ -64,6 +64,17 @@ class PluginRegistry:
     def observers(self) -> list[Any]:
         """Plugins registered as ``coderouter.observer``."""
         return list(self._by_group.get("observer", ()))
+
+    @property
+    def adapters(self) -> list[Any]:
+        """Plugins registered as ``coderouter.adapter`` (kind factories).
+
+        Unlike ``input_filters`` / ``observers``, these aren't called
+        repeatedly on the hot path — :func:`coderouter.adapters.registry.build_adapter`
+        consults this list once per provider to resolve a plugin-served
+        ``kind`` (v2.8.0, docs/designs/agent-cli-plugin-extraction.md §2.4).
+        """
+        return list(self._by_group.get("adapter", ()))
 
     def is_empty(self) -> bool:
         """True iff no plugin instance has been registered, in any group.

--- a/coderouter/routing/fallback.py
+++ b/coderouter/routing/fallback.py
@@ -1104,9 +1104,13 @@ class FallbackEngine:
         # via ``add_done_callback(_observer_tasks.discard)`` in
         # :meth:`_fanout_observers`.
         self._observer_tasks: set[asyncio.Task[None]] = set()
-        # Cache adapters so we don't re-instantiate per request
+        # Cache adapters so we don't re-instantiate per request. v2.8.0:
+        # pass the plugin registry through so a provider whose ``kind``
+        # is served by an enabled adapter plugin resolves via
+        # ``build_adapter``'s plugin lookup (agent-cli-plugin-extraction
+        # §3.5) instead of raising "Unknown adapter kind".
         self._adapters: dict[str, BaseAdapter] = {
-            p.name: build_adapter(p) for p in config.providers
+            p.name: build_adapter(p, self._plugin_registry) for p in config.providers
         }
         # v1.9-C: per-process adaptive routing adjuster (rolling-window
         # latency + error-rate observations, debounced rank changes).
@@ -1217,7 +1221,7 @@ class FallbackEngine:
                 break
         if not replaced:
             self.config.providers.append(provider)
-        self._adapters[provider.name] = build_adapter(provider)
+        self._adapters[provider.name] = build_adapter(provider, self._plugin_registry)
 
         try:
             chain = self.config.profile_by_name(profile_name)

--- a/docs/designs/agent-cli-plugin-extraction.md
+++ b/docs/designs/agent-cli-plugin-extraction.md
@@ -1,0 +1,410 @@
+# agent_cli の plugin 切り出し設計書（Phase 2: `coderouter-plugin-agents`）
+
+> 対象バージョン: CodeRouter v2.8+ 系 / Phase 2（Adapter hook 配線 + 別リポ移設）
+> 関連: [`external-agents-adapter.md`](./external-agents-adapter.md) §9.3・§11.3〜§11.5、[`docs/inside/future.md`](../inside/future.md) §1.2・§2.5、[`plan.md`](../../plan.md)
+> ステータス: 設計中（レビュー前）
+
+本設計書は、現在 CodeRouter 本体に in-core 実装されている外部コーディングエージェント CLI アダプタ（`kind="agent_cli"`、`coderouter/adapters/agent_cli.py`、1168 行）を、別配布の plugin パッケージ `coderouter-plugin-agents` へ前方互換で切り出す方式を定義するものである。切り出しの前提として、現状デッドエンド（`name: str` のみ）である Adapter Protocol（`coderouter/plugins/base.py` L156-168）を engine に配線する設計を併せて確定する。CLI 固有仕様はすべて `external-agents-adapter.md` §11.3〜§11.5 の実 CLI 検証結果を、拡張点のコード上の根拠はすべて本体実装の該当行を典拠とする。
+
+---
+
+## 1. 目的と動機
+
+### 1.1 何を達成するか
+
+`AgentCliAdapter`（`coderouter/adapters/agent_cli.py` L204）を Core から分離し、`pip install coderouter-plugin-agents` + `plugins.enabled: [agents]` の二段ゲートで有効化される in-process plugin として再配布する。Core 側には Adapter Protocol の engine 配線（`build_adapter` の plugin 対応）だけを残し、churn の激しいアダプタ本体（argv 組み立て・出力パーサ・sandbox フラグ表）を Core のリリース周期から切り離す。
+
+### 1.2 なぜ切り出すか（churn 分離）
+
+`external-agents-adapter.md` §11.3〜§11.5 は、Phase 1 実装中に判明した実 CLI 仕様の破壊的変更を記録している。要点のみ再掲する。
+
+| CLI | 記録された churn（本文想定 → 実機） | 典拠 |
+|---|---|---|
+| grok v0.2.93 | `--sandbox` が値なしフラグ → プロファイル値必須、`XAI_API_KEY` → `GROK_CODE_XAI_API_KEY`、`-p` が stdin 非対応 → `--prompt-file` 採用、`grok-code-fast-1` は 2026-05-15 廃止 | §11.3 L612-624 |
+| codex-cli 0.144.1 | `-a/--ask-for-approval` が `exec` から消失 → `edit`/`full_auto` マッピング obsolete、`--skip-git-repo-check` が実機必須、`reasoning_output_tokens` 新フィールド追加 | §11.4 L631-643 |
+| gemini → agy 1.1.1 | 個人アカウント向け gemini CLI の OAuth が 2026-06-18 提供終了（`IneligibleTierError`）→ 対象 CLI そのものを Antigravity CLI に差し替え、`--output-format` なし・stdin パイプでハング | §11.5 L650-660 |
+
+これらの変更はいずれも**アダプタ本体（argv builder / parser / sandbox 表）に閉じており**、Core の他機能（ルーティング・信頼性層 L1-L6）とは無関係である。にもかかわらず、in-core にある限り 1 つの CLI のパッチ追従のたびに Core のリリースを回す必要が生じる。§9.3 L555 が明記するとおり、切り出しの動機は「**CLI churn（バージョン間の破壊的変更）に Core を追従させ続けるコストを Core のリリース周期から切り離す**」ことにある。
+
+### 1.3 三層モデルとの整合
+
+`future.md` §1.2（L187-253）の三層モデルは、機能を Core / Plugin / Ecosystem に振り分ける。判定基準（L225-234）に照らすと、agent_cli は次に該当する。
+
+- **Core ではない**: 信頼性層（L1-L6 guards・self-healing・fallback）ではなく、特定外部 CLI への依存を持つ optional 機能である。Core の「5 deps 固定・`uvx` 1-line 配布」（L208・L221・L248）の薄さを守るには、CLI ごとに増える churn を Core に抱えるべきでない。
+- **Ecosystem でもない**: プロセス内（in-process）で `BaseAdapter` を実装し、wire 層のリクエストフローに tight に組み込まれる。別プロセス・別言語（HTTP loose 結合）ではない。
+- **Plugin が正位置**: `future.md` L222 の Plugin 層定義「tight（in-process）/ `pip install coderouter-plugin-X` / Python only」に完全一致する。`coderouter-plugin-memory` が既に踏んだ道（L289-322）を、adapter hook で辿る。
+
+したがって本切り出しは、`future.md` タスク #15（L112）「agent_cli Plugin 切り出し（Phase 2）」の実体化であり、三層モデルの当初設計どおりの帰着である。
+
+### 1.4 動機の正確な限定（過剰主張の回避）
+
+切り出しの便益は **churn 分離とコード量削減**であり、**Core の依存削減ではない**。`AgentCliAdapter` は `asyncio` / `subprocess` / `os` / `signal` / `json` / `re` / `shutil` など stdlib のみに依存し（agent_cli.py L103-114）、新規サードパーティ依存を一切持たない。すなわち in-core のままでも Core の 5 deps（`fastapi` / `uvicorn` / `httpx` / `pydantic` / `pyyaml`、`pyproject.toml` L39-45）は不変であり、切り出しによって deps が減るわけではない。§8 で後述するとおり、5 deps 不変条件への影響はゼロである。本設計はこの点を honest に扱い、deps 削減を便益として主張しない。
+
+---
+
+## 2. Adapter hook の実体化設計
+
+### 2.1 現状: 空 Protocol とデッドエンド
+
+`coderouter/plugins/base.py` の `Adapter` Protocol（L156-168）は `name: str` のみを宣言し、生成インターフェースを持たない。docstring（L164-166）が明記するとおり「engine 統合は未実装（Protocol contract only）」であり、loader は `adapter` group を `PLUGIN_GROUPS_FUTURE`（loader.py L50-55）に置いて `plugin-group-not-yet-active` 警告（L116-128）を出しつつロードするのみで、engine のリクエストフローには一切配線されていない。
+
+一方、既存の active hook（`InputFilter` / `Observer`、base.py L40-93）は次のパターンで配線済みである。
+
+1. Protocol に `name: str` + 非同期メソッド（`transform` / `on_event`）を宣言（base.py L65-67, L91-93）。
+2. loader が entry-point group `coderouter.<group>` を走査し（loader.py L94-95）、`plugins.enabled` にある名前のみ `cls(**cfg)` で構築して registry に `add`（loader.py L96-134）。
+3. `PluginRegistry` が group ごとの typed property（`input_filters` / `observers`、registry.py L53-66）を公開。
+4. engine が hot path でその property を反復（fallback.py L2510-2512, L2545 付近）。
+
+### 2.2 adapter が既存 hook と構造的に異なる点
+
+`InputFilter` / `Observer` は「**engine が hot path で反復して呼ぶ instance**」である。対して adapter は「**`kind` 文字列を BaseAdapter へ解決する factory**」であり、リクエストごとに反復されるものではない。アダプタ生成は engine 起動時（fallback.py L1108-1110）と runtime 登録時（register_provider、L1220）の 2 か所で `build_adapter(provider)` を通じて **一度だけ**行われ、生成物は `self._adapters` に provider 名でキャッシュされる（L1108, L1220）。
+
+したがって adapter hook は「instance を反復する」モデルではなく、「**plugin が担当する `kind` 文字列を申告し、その `kind` の ProviderConfig を受けて BaseAdapter を返す factory を提供する**」モデルが正しい。これは `build_adapter` の既存の分岐（registry.py L13-22、`kind` 文字列 → アダプタクラス）を plugin へ拡張する形になる。
+
+### 2.3 実体化する Adapter Protocol
+
+`coderouter/plugins/base.py` L156-168 を次の契約で実体化する。
+
+```python
+@runtime_checkable
+class Adapter(Protocol):
+    """New ``kind`` value in providers.yaml, backed by a plugin.
+
+    The plugin declares the ``kind`` string it serves and a factory that
+    turns a matching ``ProviderConfig`` into a ``BaseAdapter`` instance —
+    the same surface ``coderouter.adapters.registry.build_adapter`` uses
+    for in-core kinds, so the engine treats plugin adapters
+    indistinguishably from built-ins once registered.
+    """
+
+    name: str
+    # providers.yaml の `kind` 値。build_adapter がこの値で dispatch する。
+    kind: str
+
+    def build(self, config: ProviderConfig) -> BaseAdapter: ...
+```
+
+設計判断:
+
+- **`kind: str` を申告させる**（`name` とは別）。`name` は plugin 識別子（ログ・エラー用、既存 hook と揃える）、`kind` は providers.yaml で dispatch する値。両者を分けるのは、1 plugin が複数 `kind` を出す将来余地を残しつつ Phase 2 では 1:1 で足りるため、まずは単一 `kind` とする（複数申告が必要になったら `kinds: tuple[str, ...]` へ拡張。plugins/__init__.py L16-18 の「real plugin が要求を駆動したら拡張する」方針に従い、今は最小契約）。
+- **`build(config) -> BaseAdapter` は同期**とする。`build_adapter`（registry.py L11）が同期であり、生成に I/O を要さない（BaseAdapter.__init__ は httpx client を lazy 構築、base.py L176-181）ため、async 化する理由がない。既存 hook が async なのは hot path で呼ぶからであり、adapter factory は起動時 1 回なので同期で整合する。
+- **plugin instance 自身は「adapter provider（factory）」であって adapter ではない**。loader は既存パターン `cls(**cfg)`（loader.py L131-133）でこの factory を構築し、`build_adapter` がリクエスト経路の外で `factory.build(provider)` を呼ぶ。
+
+### 2.4 loader / registry 側の配線
+
+1. **loader.py**: `"adapter"` を `PLUGIN_GROUPS_FUTURE`（L50-55）から active 群へ移す。既存の `PLUGIN_GROUPS_V2_3`（L44）は履歴的な命名なので、`PLUGIN_GROUPS_ACTIVE = ("input_filter", "observer", "adapter")` へ改称（または新タプル追加）する。この 1 変更で `plugin-group-not-yet-active` 警告（L116-128）が adapter に出なくなる。loader の他ロジック（enable ゲート L96-108、`cls(**cfg)` 構築 L130-134、typo 検出 L157-174）は adapter でもそのまま機能する。
+2. **registry.py**: `input_filters` / `observers`（L53-66）に倣い `adapters` property を追加する。
+
+```python
+@property
+def adapters(self) -> list[Any]:
+    """Plugins registered as ``coderouter.adapter`` (kind factories)."""
+    return list(self._by_group.get("adapter", ()))
+```
+
+### 2.5 entry-point group 名の確定
+
+§9.3 L553 は例として `group="coderouter.adapters"`（複数形）を挙げるが、これは loader の実装と**不整合**である。loader.py L94 は `ep_group = f"coderouter.{group}"` を組み立て、`group` は `PLUGIN_GROUPS_*` の**単数形**（`"input_filter"` / `"observer"` / `"adapter"`、L44・L50-55）である。registry.py docstring L10-12 も「group key は `[project.entry-points."coderouter.<group>"]` と一致」と明記する。
+
+**確定: entry-point group は `coderouter.adapter`（単数形）とする。** これにより loader は一切改修せず（L94 の `f"coderouter.{group}"` がそのまま解決）、plugin 側の `pyproject.toml` は次を宣言する。
+
+```toml
+[project.entry-points."coderouter.adapter"]
+agents = "coderouter_plugin_agents:AgentCliProvider"
+```
+
+§9.3 L553 の「`coderouter.adapters`」表記は本設計で単数形へ訂正する（歴史的記録として §9.3 本文は改変しない）。
+
+---
+
+## 3. build_adapter の拡張
+
+### 3.1 現状（23 行）
+
+`coderouter/adapters/registry.py` L11-23 の `build_adapter(provider)` は、`kind` を if 連鎖で in-core アダプタへ解決し、未知 `kind` で `ValueError`（L23）を投げる。agent_cli は lazy import（L17-22）で subprocess/os 系を遅延ロードする。
+
+### 3.2 拡張後のシグネチャと解決順序
+
+`build_adapter` に plugin registry を渡す引数を追加する。
+
+```python
+def build_adapter(
+    provider: ProviderConfig,
+    plugin_registry: PluginRegistry | None = None,
+) -> BaseAdapter:
+    # 1. in-core kind を先に解決（openai_compat / anthropic /
+    #    移行期は agent_cli も）
+    if provider.kind == "openai_compat":
+        return OpenAICompatAdapter(provider)
+    if provider.kind == "anthropic":
+        return AnthropicAdapter(provider)
+    if provider.kind == "agent_cli":
+        # 移行期のみ: in-core fallback（§5 の deprecation 対象）
+        from coderouter.adapters.agent_cli import AgentCliAdapter
+        # plugin も同 kind を提供している場合は deprecation を 1 度だけログ
+        return AgentCliAdapter(provider)
+    # 2. plugin 提供 kind を解決
+    if plugin_registry is not None:
+        for factory in plugin_registry.adapters:
+            if factory.kind == provider.kind:
+                return factory.build(provider)
+    # 3. 未知 kind
+    raise ValueError(
+        f"Unknown adapter kind {provider.kind!r}. "
+        f"in-core kinds: openai_compat, anthropic"
+        f"{', agent_cli' if _AGENT_CLI_IN_CORE else ''}; "
+        f"plugin-provided kinds: {_plugin_kinds(plugin_registry)}. "
+        f"If a plugin should provide {provider.kind!r}, ensure it is "
+        f"installed AND listed in plugins.enabled."
+    )
+```
+
+**解決順序: in-core → plugin → error。** in-core を先に見るのは、Core が保証する kind（openai_compat / anthropic）を plugin が上書き・shadow できないようにする安全側の既定である。移行期（Phase 2b）は agent_cli も in-core が先に勝ち、plugin は同 kind を提供しても後回しになる（§5 で deprecation 経路として扱う）。Phase 2c で in-core agent_cli 分岐を除去すると、agent_cli は plugin 経路（ステップ 2）でのみ解決される。
+
+### 3.3 未知 kind のエラーメッセージ
+
+未知 kind のエラー（L23 相当）を拡張し、**in-core kind 一覧・plugin 提供 kind 一覧・二段ゲートの案内**を含める。特に「plugin が該当 kind を出すはずなのに解決できない」ケース（install 忘れ or `plugins.enabled` 未記載）を切り分けられる文言にする。これは schemas.py の fail-fast 哲学（`_check_output_filters_known` L466-479 / `_check_kind_requirements` L482-505）と揃え、設定ミスを起動時に明示する。
+
+### 3.4 plugins.enabled 二段ゲートの通し方
+
+adapter plugin は既存 hook と同じ二段ゲートを通る（`PluginsConfig` L1477-1519、loader.py L9-16）。
+
+1. `pip install coderouter-plugin-agents` で entry-point `coderouter.adapter` → `agents` が discoverable になる。
+2. `plugins.enabled: [agents]` に列挙されて初めて loader が factory を構築（loader.py L96-108 の enable ゲート）、`PluginRegistry.adapters` に載る。
+
+未列挙なら `plugin-skipped`（loader.py L100-107）でログされ、`PluginRegistry.adapters` は空 → `build_adapter` は agent_cli を解決できず §3.3 のエラーになる。これは供給網防御（loader.py L9-16）の設計意図どおりであり、adapter でも同一の防御が働く。
+
+**UX 上の注意（互換への影響）**: 移行前は provider に `kind: agent_cli` を書くだけで有効だったが、移行後（2c 以降）は加えて `plugins.enabled: [agents]` が必須になる。この差分は §5 の後方互換・移行手順で扱う。
+
+### 3.5 registry を build_adapter へ流す配線
+
+`build_adapter` の呼び出し 2 か所に registry を渡す。registry は engine が既に保持している（`self._plugin_registry`、fallback.py L1100、`discover_and_load` の産物を受け取る）。
+
+| 呼び出し箇所 | 現状 | 改修 |
+|---|---|---|
+| engine 起動時 | `build_adapter(p) for p in config.providers`（fallback.py L1108-1110） | `build_adapter(p, self._plugin_registry)` |
+| runtime 登録時 | `self._adapters[provider.name] = build_adapter(provider)`（fallback.py L1220、register_provider） | `build_adapter(provider, self._plugin_registry)` |
+
+`self._plugin_registry` は L1100 で L1108 より前に設定済みなので順序上の問題はない。register_provider（L1178）は launcher 経由の runtime 登録で、launcher backend は openai_compat 前提だが、将来 plugin kind を runtime 登録しても解決できるよう registry を渡しておく。
+
+---
+
+## 4. `coderouter-plugin-agents` パッケージ設計
+
+### 4.1 別リポ構成
+
+```
+coderouter-plugin-agents/            # 別 GitHub repo・別 PyPI パッケージ
+├── pyproject.toml
+├── README.md / README.en.md
+├── src/coderouter_plugin_agents/
+│   ├── __init__.py                  # AgentCliProvider を export
+│   ├── provider.py                  # Adapter Protocol 実装（factory）
+│   └── adapter.py                   # AgentCliAdapter 本体（現 agent_cli.py 移設）
+└── tests/
+    └── test_agent_cli.py            # 移設テスト（§4.5）
+```
+
+### 4.2 pyproject.toml と entry-point 宣言
+
+```toml
+[project]
+name = "coderouter-plugin-agents"
+version = "0.1.0"
+requires-python = ">=3.11"
+# Core への依存は Protocol/基底クラスの契約バージョン範囲で pin（§5.4）
+dependencies = ["coderouter-cli>=2.8,<3.0"]
+
+[project.entry-points."coderouter.adapter"]
+agents = "coderouter_plugin_agents:AgentCliProvider"
+```
+
+plugin 本体（adapter.py）は Core と同様 stdlib のみで完結し、新規サードパーティ依存を持たない（現 agent_cli.py L103-114 の import は全 stdlib）。`coderouter-cli` への依存は `BaseAdapter` / `ProviderConfig` / `AgentCliConfig` / `AdapterError` などの型契約を得るためであり、実行時 import である。
+
+### 4.3 AgentCliProvider（Adapter Protocol 実装）
+
+`provider.py` に factory を薄く実装する。churn するアダプタ本体（adapter.py）とは分離し、Protocol 適合だけを担わせる。
+
+```python
+from coderouter.adapters.base import BaseAdapter
+from coderouter.config.schemas import ProviderConfig
+from coderouter_plugin_agents.adapter import AgentCliAdapter
+
+class AgentCliProvider:
+    """coderouter.adapter entry point: serves kind="agent_cli"."""
+    name = "agents"
+    kind = "agent_cli"
+
+    def __init__(self, **config: object) -> None:
+        # plugins.config["agents"] が渡る（loader.py L132）。
+        # Phase 2 では plugin レベルの追加設定は不要なので無視で足りる。
+        pass
+
+    def build(self, config: ProviderConfig) -> BaseAdapter:
+        return AgentCliAdapter(config)
+```
+
+loader は `cls(**cfg)`（loader.py L131-133）で `AgentCliProvider()` を構築し、`build_adapter` が `provider.build(config)` を呼ぶ。
+
+### 4.4 AgentCliConfig の置き場所（3 案比較と推奨）
+
+**問題**: `ProviderConfig` は `model_config = ConfigDict(extra="forbid")`（schemas.py L342）であり、`agent_cli:` キーは `agent_cli: AgentCliConfig | None` フィールド（L421-424）が Core に存在するからこそ受理される。さらに `kind` は `Literal["openai_compat", "anthropic", "agent_cli"]`（L345）、`_check_kind_requirements`（L482-505）が `kind=="agent_cli"` に対し agent_cli サブ設定を要求（L500-504）する。アダプタ本体を plugin へ出すと、この Core 側スキーマ知識をどうするかが焦点になる。
+
+| 案 | 内容 | 長所 | 短所 |
+|---|---|---|---|
+| **(a) plugin 側 pydantic + Core dict 透過** | `AgentCliConfig` を plugin へ移し、Core は provider 内に汎用の `adapter_config: dict[str, Any]` を持つ。plugin factory が dict を自前 pydantic で検証 | Core がアダプタ固有スキーマを知らない（純粋な分離） | `extra="forbid"` の**起動時 fail-fast を喪失**。typo（例 `sandbox_moe`）は plugin 構築時にしか出ず、loader は degraded-continue（loader.py L18-26）なので `plugin-load-failed` ログのみで engine は起動してしまう。運用体験の後退 |
+| **(b) AgentCliConfig を Core に残置** | `AgentCliConfig`（L166-329）・`agent_cli` フィールド・`kind` Literal・`_check_kind_requirements` を Core に残し、**アダプタ本体（adapter.py）だけ**を plugin へ移す | churn は本体（argv/parser/sandbox 表）に閉じており、スキーマは §11.3〜§11.5 で**一度も変わっていない**安定契約。`extra="forbid"` fail-fast 維持。§4.5 のスキーマ検証テストが Core に無改変で残る。Core 改修が最小 | Core が約 164 行の安定スキーマを持ち続ける。「Core は agent_cli を全く知らない」という純度は得られない |
+| **(c) 汎用 extra config 機構** | Core に `adapter_config: dict` を新設し、全サード adapter が共通で使う汎用機構にする | 将来の任意 kind に再利用可能 | (a) と同じ fail-fast 喪失に加え、利用者が 1 つも居ない汎用機構の先行実装（plugins/__init__.py L16-18 の「real plugin が要求を駆動するまで待つ」方針に反する YAGNI） |
+
+**推奨: (b) AgentCliConfig を Core に残置。** 根拠は次の 3 点。
+
+1. **churn の所在**: §11.3〜§11.5 に記録された破壊的変更はすべて argv builder / parser / sandbox フラグ表（adapter.py 側）であり、`AgentCliConfig` のフィールド（`agent` / `command` / `workdir` / `exec_timeout_s` / `allow_file_writes` / `sandbox_mode` / `model` / `max_turns` / `passthrough_env` / `agent_depth_limit`、L214-305）は一度も変わっていない。切り出しの目的（churn 分離）は本体を出せば達成され、スキーマを出す必要はない。
+2. **fail-fast は Core の価値**: `extra="forbid"`（L342）と `_check_kind_requirements`（L482-505）による起動時検証は Core 全体の設計哲学（L466-479 と同一パターン）である。(a)/(c) はこれを degraded-continue な plugin 構築時検証へ格下げし、設定ミスの発見を遅らせる。
+3. **最小改修**: (b) は `build_adapter` の agent_cli 分岐（registry.py L17-22）除去と adapter.py 移設のみで済み、Core スキーマ（L166-329, L345, L421-424, L482-505）は無改変で残る。§4.5 のスキーマ検証テスト群も Core に据え置ける。
+
+補足: (b) を採ると「Core は agent_cli の存在を kind Literal レベルで知り続ける」が、これは欠陥ではなく**安定した公開契約**の残置である。将来 agent_cli 以外の第三者 adapter が現れ、その時に汎用機構が本当に要るなら、その時点で (c) を driver 付きで導入すればよい（現在は不要）。
+
+### 4.5 テスト 91 件の移設マップ
+
+`tests/test_agent_cli.py`（1507 行・91 件）を、推奨案 (b) に基づき分割する。判定基準は「**アダプタ本体の振る舞いか、Core スキーマの振る舞いか**」である。
+
+| 区分 | 対象テスト（代表） | 件数（概算） | 行き先 |
+|---|---|---|---|
+| argv 構築（T1） | `test_argv_*` / `test_grok_argv_*` / `test_codex_argv_*` / `test_antigravity_argv_*`（L286-560） | 約 30 | plugin |
+| 出力パーサ（T2） | `test_parse_*` / `test_grok_parse_*` / `test_codex_parse_*` / `test_antigravity_parse_*`（L659-930 付近） | 約 25 | plugin |
+| 子 env 分離（T7） | `test_env_*`（L566-657） | 約 8 | plugin |
+| subprocess スタブ / timeout / 再帰 / healthcheck（T3・T6・T8） | `_FakeProc` 系・`test_error_detail_*`・timeout kill・depth limit・healthcheck | 約 14 | plugin |
+| E2E（T4） | `test_e2e_chat_completions` / `_grok_` / `_codex_` / `_antigravity_`（L1315-1492） | 4 | plugin（下記注記） |
+| gemini 拒否 | `test_gemini_rejected_with_antigravity_migration_message`（L1194、`AgentCliAdapter.__init__` の拒否） | 1 | plugin |
+| **Core スキーマ検証** | `test_schema_agent_cli_required_for_kind`（L1218）・`test_schema_base_url_optional_for_agent_cli`（L1223）・`test_schema_base_url_required_for_openai_compat`（L1233）・`test_schema_command_defaults_to_*`（L1238-1255、3 件）・`test_schema_antigravity_accepted_by_literal`（L1256）・`test_schema_antigravity_explicit_command_not_overridden`（L1261）・`test_schema_write_conflict_rejected`（L1266） | 9 | **Core 残置** |
+
+概算: **約 82 件が plugin へ移設、9 件（`ProviderConfig` / `AgentCliConfig` の pydantic 検証）が Core に残置（合計 91 件と一致）。** 案 (a)/(c) を採った場合はこの 9 件も plugin へ移り、代わりに Core は「未知 kind エラー」「dict 透過」の新規テストを持つことになる — (b) はテスト移動量も最小である点で有利。
+
+E2E（T4）についての注記: `test_e2e_*` は `TestClient(create_app())` によるフルスタックで、移設後は plugin をインストール + `plugins.enabled` へ列挙した config を要する。4 件は plugin repo が保有し、Core 側には **fake adapter plugin を使った wiring E2E を 1 件**新設して「plugin 提供 kind が `build_adapter` 経由で解決され `/v1/chat/completions` が通る」ことだけを検証する（Core は agent_cli 具体ではなく「plugin adapter が配線される」ことを守る）。
+
+---
+
+## 5. 移行と互換性
+
+### 5.1 移行期の in-core 残置（deprecation 方針）
+
+Phase 2b では in-core `AgentCliAdapter` を**即時削除しない**。`build_adapter` の agent_cli 分岐（registry.py L17-22）を残したまま、plugin も同 kind を提供できる状態にする（§3.2 の解決順序で in-core が先勝ち）。plugin が enable されている（`PluginRegistry.adapters` に `kind=="agent_cli"` の factory がある）にもかかわらず in-core 分岐が使われた場合、`agent-cli-in-core-deprecated` を **1 プロセス 1 回**ログし、plugin 経路へ移るよう促す。Phase 2c で in-core 分岐と adapter.py 本体を Core から削除する。
+
+### 5.2 providers.yaml の後方互換
+
+- **kind と agent_cli サブ設定**: 推奨案 (b) では `kind: agent_cli` と `agent_cli:` ブロックの記法は Core に残るため、**providers.yaml の provider エントリ自体は無改変で受理される**（スキーマ互換完全維持）。
+- **plugins.enabled の追加要件**: 2c 以降は `plugins.enabled: [agents]` の追記が必須になる（未記載だと §3.3 のエラー）。移行手順として、2b リリースの CHANGELOG / doctor 診断で「agent_cli を使う config には `plugins.enabled: [agents]` を追加し `pip install coderouter-plugin-agents` せよ」と案内する。2b の期間（in-core 残置）に猶予を設け、2c で切り替える。
+- **doctor 支援**: `kind: agent_cli` を含むが `plugins.enabled` に `agents` が無い config を検出したら、doctor が明示警告 + 修正スニペットを出す（fail-fast 哲学の延長）。
+
+### 5.3 CI / テストの分離
+
+- Core repo: agent_cli 具体テストが消え、Core CI から実 CLI 依存の smoke（T9 相当、opt-in）が外れる。Core は「plugin adapter wiring」1 件 + 残置スキーマ 9 件のみを持つ。
+- plugin repo: 移設した約 82 件を独立 CI で回す。実 CLI smoke（§11.3〜§11.5 のような実機検証）は plugin repo の opt-in ジョブに閉じ、Core CI を汚さない。これにより CLI churn 追従は **plugin repo のリリースサイクル**で完結する（§1.2 の目的達成）。
+
+### 5.4 バージョン整合（互換マトリクス方針）
+
+plugin と Core を独立配布するため、契約は **Adapter Protocol + BaseAdapter + ProviderConfig/AgentCliConfig** の 3 面である。方針:
+
+- plugin は `dependencies = ["coderouter-cli>=2.8,<3.0"]` のように **Core の互換範囲を pin**する。
+- Core は Protocol / BaseAdapter / AgentCliConfig の破壊的変更を **minor 以上**で行い、その際に plugin 側の下限を上げる。Protocol は `runtime_checkable`（base.py L40 の既存方針）なので、loader が `isinstance` で不適合を早期検出でき（plugins/base.py L13-15 の意図）、契約破れは `plugin-load-failed`（loader.py L143-155）として degraded-continue で顕在化する。
+- 互換マトリクスは plugin repo の README に「plugin x.y ↔ Core a.b」の表として維持する（`coderouter-plugin-memory` の前例に倣う）。
+
+---
+
+## 6. セキュリティ不変条件の維持
+
+`external-agents-adapter.md` §6（L481-494）が非交渉と定める要件が、plugin 境界を越えても損なわれないことを保証する。要件はすべて**アダプタ本体（adapter.py）内に自己完結**しており、Core の配線に依存しない — したがって本体をそのまま移設すれば保証も移る。
+
+| §6 要件 | 実装箇所（移設後は adapter.py の同一コード） | 境界越えでの保証 |
+|---|---|---|
+| **allowlist argv のみ**（`shell=True` 禁止） | `create_subprocess_exec(*argv, ...)`（agent_cli.py L355-366）、executable を絶対パス解決（L339-341） | argv 構築は本体内で完結。Core は argv に一切関与しない（build_adapter は生成のみ）。移設で不変 |
+| **env allowlist**（親環境非継承・`ANTHROPIC_API_KEY` 非転送） | `_build_child_env`（L1063-1089）、`passthrough_env` 限定（L1085-1088） | env 構築は本体内。Core の環境は子に流れない。移設で不変 |
+| **PGID kill** | `_kill_process_group`（L1144-1152）、`start_new_session=True`（L365）、`asyncio.wait_for` + 超過 SIGKILL（L380-391） | timeout/kill は本体内の `generate` に閉じる。移設で不変 |
+| **read-only クランプ** | `_claude_permission_mode`（L481）・`_codex_sandbox_args`（L631）・`_grok_sandbox_args`（L806）・`_antigravity_mode_args`（L933）が `allow_file_writes` False で read_only 強制 | クランプは本体内。`AgentCliConfig`（Core 残置）の値を本体が解釈。移設で不変 |
+| **再帰上限** | `_current_depth`（L1055）・上限拒否（L303-309）・`CODEROUTER_AGENT_DEPTH` +1 伝播（L1079） | 深度は**環境変数ベースのプロセス横断プロトコル**であり import 依存でない。plugin 化しても env 名（`_DEPTH_ENV`、L136）が同一である限り、ネストした CodeRouter が同じ env を読む。移設で不変 |
+| **workdir 境界**（`..` 拒否・隔離ディレクトリ） | `_resolve_workdir`（L1114-1142）、`..` 拒否（L1124-1129） | 本体内。移設で不変 |
+
+加えて §6 L494 の**wire 層 guards**（`tool_loop.py` / `context_budget.py` / `memory_budget.py`）は engine 層で全 `BaseAdapter` に自動適用される。これらは adapter の**上流**（engine のリクエストフロー）で働くため、adapter が in-core か plugin かに無関係に効く。plugin 化はこの保証を弱めない。
+
+**plugin 境界に固有の新リスク**: 悪意ある / バグのある adapter plugin が上記要件を省いた実装を出す可能性。緩和は 2 段。(1) 二段ゲート（§3.4）で未 enable の plugin は factory すら構築されない（供給網防御、loader.py L9-16）。(2) `coderouter-plugin-agents` を**一次配布（first-party）**とし、Core と同じレビュー基準で維持する（§8 のサプライチェーン項参照）。
+
+---
+
+## 7. 実装フェーズ分割
+
+| Phase | 対象 | 主な変更 | 規模見積り |
+|---|---|---|---|
+| **2a** | Adapter hook を Core に配線（本体移設なし） | base.py（Adapter Protocol 実体化 §2.3）/ loader.py（`adapter` を active 群へ §2.4）/ registry.py（`adapters` property §2.4）/ adapters/registry.py（`build_adapter` に registry 引数・plugin lookup・エラー拡張 §3）/ fallback.py（registry を 2 か所へ流す §3.5） | Core 約 30〜40 行 + wiring テスト（fake adapter plugin）約 80 行 |
+| **2b** | plugin パッケージ作成・移設 | 別リポ `coderouter-plugin-agents` 新設（§4.1-4.3）/ adapter.py = 現 agent_cli.py 移設 / テスト約 82 件移設（§4.5）/ Core は in-core agent_cli 分岐残置 + deprecation ログ（§5.1） | plugin 新規 約 1200 行（本体 1168 + provider 約 30）+ テスト約 1300 行 / Core 追加約 5 行 |
+| **2c** | in-core 削除 | registry.py の agent_cli 分岐（L17-22）除去 / Core から adapter.py・移設済み約 82 テスト削除 / `AgentCliConfig`・kind Literal・`_check_kind_requirements`・残置 9 テストは維持（§4.4 案 b） / CHANGELOG + doctor 移行案内（§5.2） | Core 削減 約 1168 行 + テスト約 1300 行 / 追加は doctor 診断 約 20 行 |
+
+### 7.1 各フェーズのテスト計画
+
+- **2a**: Core 単体で完結。fake adapter plugin（`kind="fake"`、`build` が echo adapter を返す）を entry-point 登録するテスト用パッケージ or monkeypatch で `PluginRegistry.adapters` を注入し、(i) `build_adapter` が plugin kind を解決 (ii) 未知 kind が §3.3 のメッセージで `ValueError` (iii) in-core kind を plugin が shadow しない（順序 §3.2） (iv) 未 enable なら解決しない、を検証。既存 91 件は無改変で緑のまま（in-core agent_cli 温存のため）。
+- **2b**: plugin repo で移設 82 件が緑。Core は残置 9 件 + wiring 1 件が緑。deprecation ログの発火を 1 件で検証。plugin↔Core を同一 venv に入れた統合 smoke を plugin repo に置く。
+- **2c**: Core から agent_cli 具体が消えても残置スキーマ 9 件が緑（`AgentCliConfig` 検証は Core 責務のまま）。plugin repo が全 agent_cli 責務を負う。回帰防止として、Core に「`kind: agent_cli` だが plugin 無効」→ doctor 警告のテストを追加。
+
+---
+
+## 8. リスクと未解決事項
+
+| リスク / 事項 | 内容 | 対応方針 |
+|---|---|---|
+| **plugin 供給網リスク** | adapter は subprocess 実行面（§6）を持つため、悪意 plugin の影響が大きい | 二段ゲート（§3.4、loader.py L9-16）で未 enable を無効化 + `coderouter-plugin-agents` を first-party 維持。third-party adapter を将来受け入れる際の審査基準は別途 open |
+| **5 deps 不変条件** | 切り出しが Core deps に影響しないか | **影響ゼロ**を確認。agent_cli は元来 stdlib のみ（agent_cli.py L103-114）で 5 deps（pyproject.toml L39-45）に含まれない。plugin 側も stdlib のみ。切り出しは deps を減らしも増やしもしない（§1.4）。便益は churn 分離であって deps 削減ではない |
+| **ダウンロード導線 / 発見性** | in-core なら設定だけで動いたものが、pip install + enable を要する | 2b の in-core 猶予期間 + doctor 診断（§5.2）で導線を明示。README / CHANGELOG に手順明記。`uvx` 配布の Core とは別に plugin を PyPI 配布（`coderouter-plugin-memory` 前例） |
+| **entry-point group 名の不整合** | §9.3 L553 は `coderouter.adapters`（複数形）だが loader は単数形（loader.py L94・L50-55） | §2.5 で `coderouter.adapter`（単数形）に確定。§9.3 の表記は本設計で訂正（§9.3 本文は歴史記録として不改変） |
+| **移行期の kind 二重提供** | 2b で in-core と plugin が同時に agent_cli を出す | §3.2 の解決順序で in-core 先勝ち + deprecation ログ（§5.1）。2c で in-core 除去し一本化 |
+| **Adapter Protocol の将来拡張** | Phase 2 は単一 `kind`。複数 kind / plugin レベル設定検証の需要 | 現状は単一 `kind` 最小契約（§2.3）。`kinds` 複数化・plugin 設定 pydantic 化は real driver 出現時に拡張（plugins/__init__.py L16-18 方針）。案 (b) のため AgentCliConfig 検証は当面 Core が担い、plugin 側検証は未導入 |
+| **register_provider 経路の plugin kind** | launcher runtime 登録（fallback.py L1178）は現状 openai_compat 前提 | §3.5 で registry を渡すのみに留め、launcher が plugin kind を登録する UX は本設計の非スコープ（発火条件待ち） |
+
+### 8.1 `ProviderConfig.kind` の Literal → str 拡張（2026-07-11 実装追記）
+
+Phase 2a 実装時に、`ProviderConfig.kind`（schemas.py L353）を
+`Literal["openai_compat", "anthropic", "agent_cli"]` から `str` へ拡張した。
+これは §4.4 案 (b)（「kind Literal を Core に残置」）に対する**意図的な逸脱**で
+あり、記録に残す。
+
+**逸脱の理由（設計の欠落補完）**である。§4.4 案 (b) は AgentCliConfig の置き場所を
+論じたものだが、そこで前提とした「kind を Literal のまま残す」構えは、plugin が
+新 `kind` を申告する Phase 2a の目的そのものと衝突する。plugin 探索
+（`discover_and_load`）は `load_config` の**後**に走る（ingress/app.py L176-182）
+ため、pydantic が config-load 時点で有効な `kind` 集合を知り得ない。Literal を
+維持すると、`kind: fake_agent` のような plugin kind は plugin が有効化されていても
+pydantic 段階で機械的に拒否され、adapter hook は永久に到達不能になる。したがって
+`kind` の str 化は plugin kind を受理するための**最小かつ必須**の変更である。
+
+**fail-fast の移設**である。Literal 除去により未知 `kind` の検出時点が
+「config-load（pydantic）」から「engine 構築時（`build_adapter`）」へ 1 段後退する。
+ただし `FallbackEngine.__init__` は全 provider のアダプタを**起動時に一括生成**する
+（fallback.py L1112-1114 の dict 内包表記）ため、typo した `kind`（例
+`openai_compt`）は `serve` 起動時＝`create_app` 内で `ValueError("Unknown adapter
+kind ...")` として即座に露見する。リクエスト時まで遅延することはなく、fail-fast の
+タイミングは実質維持される（起動失敗）。runtime 登録経路（register_provider,
+fallback.py L1224）も同様に登録時点で `build_adapter` を通すため即失敗する。
+エラーメッセージは in-core kind 一覧・plugin 提供 kind 一覧・二段ゲート案内を含み
+（registry.py L54-60）、旧 pydantic Literal エラーより診断性は高い。
+
+**残る副作用（許容）**である。(1) `_check_kind_requirements`（schemas.py L505）は
+`kind in ("openai_compat","anthropic")` の時のみ base_url を必須とするため、typo した
+`kind` では base_url 必須検証が発火しない。だが未知 kind エラーがそれを上回って
+起動を止めるので実害はない。(2) `doctor` は `build_adapter` を呼ばず HTTP プローブを
+直接行うため、typo `kind` を `build_adapter` 経路では捕捉しない（doctor の
+`kind != "anthropic"` 分岐は未知 kind を openai_compat 相当として扱う）。これは
+diagnostics の限定であって fail-fast の権威経路（serve 起動）は別途守られている。
+将来 doctor に未知 kind 明示警告を足す余地はある（§5.2 の doctor 支援の延長）。
+
+代替案として「Literal を in-core 用に温存し、plugin kind は `plugin:` 接頭辞で
+逃がす」構えも検討し得たが、providers.yaml の `kind` 表記に接頭辞規約を持ち込む
+非互換・非直感を嫌い、単純な str 化を採った。in-core kind の shadow 防止は
+`build_adapter` の解決順序（in-core → plugin、registry.py L40-53）で担保され、
+Literal による静的保証は不要と判断した。
+
+---
+
+## 9. 参照
+
+- [`external-agents-adapter.md`](./external-agents-adapter.md) — agent_cli の Phase 1 設計。§6（セキュリティ L481-494）・§9.3（移行パス L551-555）・§11.3〜§11.5（実 CLI churn 記録 L608-660）
+- [`docs/inside/future.md`](../inside/future.md) — §1.2 三層モデル・Core 5 deps 不変条件（L187-253）、§2.5 方向性（L368+）、タスク #15（L112）
+- [`plan.md`](../../plan.md) — Core 5 deps 方針 / プラグイン制による外部委譲（L689）
+- 実装典拠: `coderouter/plugins/base.py` L156-168 / `coderouter/plugins/loader.py` L44-134 / `coderouter/plugins/registry.py` L43-66 / `coderouter/adapters/registry.py` L11-23 / `coderouter/adapters/agent_cli.py` L204-1168 / `coderouter/adapters/base.py` L162-263 / `coderouter/config/schemas.py` L166-329・L342-505・L1477-1519・L1674-1684 / `coderouter/routing/fallback.py` L1100-1110・L1178-1220 / `tests/test_agent_cli.py`（91 件）

--- a/docs/designs/external-agents-adapter.md
+++ b/docs/designs/external-agents-adapter.md
@@ -552,6 +552,10 @@ Grok の公式 API は OpenAI 互換であり、**既存 `kind="openai_compat"` 
 
 現状 Adapter Protocol は実体が空（`name: str` のみ、`plugins/base.py` L168-169、`ANALYSIS-code.md` §1）でデッドエンドである。将来 core が Adapter hook を配線したら、in-core の `AgentCliAdapter` を**ほぼそのまま** `coderouter-plugin-agents` へ移設できる（前方互換、`ANALYSIS-code.md` §3）。ロードは entry-point 方式（`group="coderouter.adapters"` 等）+ `plugins.enabled` の二段ゲート（`PluginsConfig`、`schemas.py` L1247）を経る。
 
+> **ステータス（2026-07-11 追記）**: 作者の方向性指示（「作業ごとにモデルを割当・サブエージェントを利用する」、`_article/direction-brief-2026-07-11.md`）を受けた方向性確定により、Phase 2 の優先度が上昇した（`docs/inside/future.md` §2.5 参照）。あわせて、§11.3〜§11.5 に記録した実 CLI 検証（grok の `--sandbox`/認証仕様変更、codex の承認フラグ obsolete 化、gemini 個人向け終了→antigravity 移行）が示す **CLI churn（バージョン間の破壊的変更）に Core を追従させ続けるコストを Core のリリース周期から切り離す**動機も加わった。移行トリガは変わらず: (i) agent_cli 利用比重の恒常化 (ii) CLI churn 追従コストが Core リリースを圧迫 (iii) コミュニティ要望。着手そのものは未着手（発火条件待ち）。
+>
+> 訂正（2026-07-11）: entry-point group 名は loader 実装（`plugins/loader.py` L94）に合わせ `coderouter.adapter`（単数形）が正。詳細は [`agent-cli-plugin-extraction.md`](./agent-cli-plugin-extraction.md) を参照。
+
 ---
 
 ## 10. リスクと未解決事項

--- a/docs/designs/orchestration-companion.md
+++ b/docs/designs/orchestration-companion.md
@@ -1,0 +1,109 @@
+# オーケストレーション・コンパニオン設計書（Ecosystem 層、構想）
+
+> ステータス: **構想（Concept）**。実装前。Core/Plugin の変更は伴わない。
+> 正典: [`docs/inside/future.md`](../inside/future.md) §5（2026-06-27 追記）・§1.2（三層モデル）・§2.5（2026-07-11 追記）
+> 前提: agent_cli Phase 1 完結（v2.7.10、[`external-agents-adapter.md`](./external-agents-adapter.md)）
+> 作成: 2026-07-11 / 出典: 作者方向性指示 `_article/direction-brief-2026-07-11.md`・解析書 `_article/analysis-direction-2026-07.md` D-補足
+
+本書は、「作業ごとにモデルを割当・サブエージェントを利用する」という作者の方向性指示のうち、**マルチステップ・オーケストレーション（Plan → 実行 → レビューの制御ループ）** をどう実現するかの構想を1枚にまとめたものである。**作るかどうか自体は未確定**（future.md §5 が既に詳しいため、当面は §2.5 の framing 追記で足りる）。実プロダクト化する段になったとき、本書を出発点にする。
+
+---
+
+## 1. 位置づけ
+
+CodeRouter の「クライアント」。**別 repo・standalone・別プロセス**として作る。CodeRouter 本体（Core）にも Plugin にも組み込まない。
+
+三層モデル（future.md §1.2）の判定基準を当てはめると: engine 内 hook（filter/guard/observer/新 ingress/新 adapter）は不要（HTTP クライアントとしてヘッダを付けて叩くだけ）→ Plugin ではない。独立プロセス・既存の Anthropic/OpenAI 互換クライアントを再利用（`X-CodeRouter-Profile` ヘッダを足すだけ）→ **Ecosystem**（`HTTP loose` 結合）。
+
+Voice Bridge と同型で、CodeRouter Plugin SDK は使わない。future.md §1.2 Ecosystem partners に「(将来候補) multi-agent orchestrator」として登録済み。
+
+---
+
+## 2. 責務境界（線引き）
+
+### 持つもの（orchestrator 側、上位層の責務）
+
+- **制御ループ**: planner → coder → reviewer の直列実行（将来: 並列・分岐）
+- **検証ループ**: reviewer の `VERDICT: PASS/FAIL` を受けて coder に再生成させる
+- **safe-edit**: SEARCH/REPLACE 適用 + `git apply --check` + AST/構文検証 + テストゲート（FS に触る処理はすべてここ。wire 層の責務外）
+- **セッション状態**: 会話履歴、反復回数、コスト上界などのマルチターン状態
+- **サブエージェント深度管理**: 何段目のサブタスクかの追跡（future.md §2.5 の G4 に対応）
+- **並列 fan-out**: 同一リクエストを複数 backend に投げて集約する場合の制御（G5 に対応）
+
+### 持たないもの（CodeRouter wire 層に委譲）
+
+- routing（役割 → backend の解決）
+- 修復（tool-call repair、byte-fallback 等）
+- ガード（context budget、tool loop、memory pressure、drift detection、self-healing）
+- 記憶（plugin-memory による透過注入）
+- 圧縮（plugin-compress）
+
+この境界により、planner も coder も reviewer も CodeRouter を通すだけで上記の恩恵を**自動で**受ける（future.md §5.2 の「CodeRouter が全サブ呼び出しの共通インフラ」という絵そのもの）。
+
+---
+
+## 3. CodeRouter (wire 層) への接続
+
+各サブ呼び出しに `X-CodeRouter-Profile: {planner|coder|reviewer-audit|reviewer-light}` を明示付与して、Anthropic 互換 (`/v1/messages`) または OpenAI 互換 (`/v1/chat/completions`) で CodeRouter に投げる。precedence は既存どおり `body.profile > X-CodeRouter-Profile > X-CodeRouter-Mode > auto_router`。
+
+```
+[orchestration companion]                    ← 本書のスコープ（別プロセス）
+   ├─ Conductor: planner → coder → reviewer の制御ループ + 検証ループ
+   ├─ safe-edit: SEARCH/REPLACE + git apply --check + AST 検証
+   └─ 各サブ呼び出しに X-CodeRouter-Profile ヘッダを付与
+        ↓ HTTP (Anthropic / OpenAI 互換)
+[CodeRouter (wire 層)] — 既存資産そのまま、変更不要
+   ├─ auto_router / capability / fallback（役割解決・能力吸収・降格）
+   ├─ guards（context/memory/tool-loop/drift/self-healing）
+   └─ plugin-memory / plugin-compress（透過注入）
+        ↓
+[推論バックエンド] — agent_cli(claude opus 等) / ローカル / クラウド混在
+```
+
+`providers.yaml` 側の構成例は future.md §2.5「opusplan 型構成例」を参照（本書では重複させない）。
+
+---
+
+## 4. CodeRouter 本体に要求するもの
+
+**現状（Phase 1 完結時点）で足りている点**:
+
+- 役割別 profile 解決、agent_cli backend、fallback、L1〜L6 guards、plugin-memory/compress の透過適用は**すべて既存資産で足りる**。追加実装は不要（future.md §2.5 (1) 確信度 HIGH）。
+- `X-CodeRouter-Profile` ヘッダの precedence 機構は v1.6 以降既存。
+
+**G1/G3（future.md §2.5 (4) のギャップ表）が欲しくなる条件**:
+
+- G1（複合条件マッチャ）: orchestrator が profile ヘッダを明示付与している限り不要。**auto_router の保険ルールを複雑化させたい場合のみ**（例: 「コード密度が高く *かつ* ツール宣言あり」を 1 ルールで表現したい）に欲しくなる。orchestrator 側が常にヘッダを付ける設計なら発生しない。
+- G3（ヘッダ/ツール名ベースのルール条件）: 同上。orchestrator が特定 MCP ツール名に応じて動的に profile を切り替えたい場合に初めて必要になる。
+
+**明確に CodeRouter 側に要求しないもの**: 段階判定（今が Plan か実行かの意味的分類、G2）・深度連動 routing（G4）・並列 fan-out（G5）はすべて orchestrator 側の責務であり、wire 層に持ち込まない。
+
+---
+
+## 5. `_OUTPUTS/04-計画-方向性/multiagent/` プロトタイプとの関係
+
+2026-06-27 の実現可能性検証（future.md §5.4-progress・§5.4-bench）で、以下のプロトタイプが M3 Max / EVO-X2 実機で動作確認済み:
+
+- `2026-06-27_orchestrator_v1.py` / `orchestrator_v2.py` — 標準ライブラリのみの最小 Conductor。`X-CodeRouter-Profile` 付与・VERDICT 解析・safe-edit との二段ゲート化まで実証済み
+- `2026-06-27_safe_edit_v1.py` — SEARCH/REPLACE 適用 + AST/構文検証 + pytest 非依存テストランナー
+- `llmbench_multiagent.py` ほか — 単一 vs 役割別のベンチハーネス（結論: 役割分離の価値はコーダーの弱さに比例、L6 難所でのみ強コーダーでも逆転）
+
+**本書が実プロダクト化に進む場合、これらは書き直しではなく卒業（別 repo への移設）が前提**。CodeRouter 本体は無改造のまま。移設手順は「実装時に定める」段階で、本書の対象外。
+
+---
+
+## 6. やらないこと
+
+- **Core への統合**: 制御ループ・マルチターン状態・並列 fan-out は 1 リクエスト = 1 変換のステートレス契約（future.md §5.1）と Core 5 deps 不変条件を破る。
+- **Plugin 化**: input_filter/observer hook は 1 リクエストの前後を触る器であり、複数リクエストにまたがる制御ループを持たせると透過性が混線する。
+- **wire 層への意味的判定器の追加**: 「今が Plan 段階か」の判断は orchestrator が持つ（G2 は欠陥ではなく責務境界）。
+- **サブスク Consumer Terms を越える常時稼働化**: agent_cli 経由の claude/codex/grok/antigravity は個人ワークフロー限定（external-agents-adapter.md §10）。orchestrator が 24/7 サービスとして常駐しサブスク OAuth を使い回す設計にはしない。
+- **完全自立型エージェント化**: ゴールの管理・チェックポイント保存・完了判断は agent（Claude Code 等）または orchestrator 自身の責務であり、CodeRouter 生態系がこれを代替することはしない（future.md §2.4・§3 の既存判定を継承）。
+
+---
+
+## 関連ドキュメント
+
+- [`docs/inside/future.md`](../inside/future.md) §5・§1.2・§2.5 — 正典
+- [`docs/designs/external-agents-adapter.md`](./external-agents-adapter.md) — agent_cli backend（本書が利用する CodeRouter 側の対応機能）
+- `_OUTPUTS/04-計画-方向性/multiagent/` — 実機プロトタイプ一式（orchestrator/safe-edit/ベンチ）

--- a/plan.md
+++ b/plan.md
@@ -3,7 +3,7 @@
 > **Local-first, free-first, fallback-built-in な LLM ルーター。**
 > Claude Code / OpenAI 互換クライアントから単一エンドポイントで叩けて、内部で「ローカル → 無料クラウド → 有料クラウド」の3層 fallback を自動で行う。
 
-最終更新: 2026-07-02 (全ソースレビュー改修マージ + 版況更新)
+最終更新: 2026-07-02 (全ソースレビュー改修マージ + 版況更新) → **2026-07-11 追記: agent_cli Phase 1 完結 (v2.7.10) + 方向性関連タスク追記**
 作成者: zephel01
 状態: **v2.7.0 リリース済み (2026-07-02)**。6 系統障害 (L1〜L6) 全対処 + 自己修復 + 状態永続化 + Plugin 層 + Goal モード + Launcher (llama.cpp / vllm / MLX GUI) + Language Tax 計測/ルーティング + Token-savings accounting に到達。Runtime deps: 5 (出荷以来据え置き連続)、完全互換。**2026-07-02: 全ソースレビュー (26,600 行) を経て高優先度 8 件 (H1〜H8) を PR #34、中優先度 14 件 (M1〜M14) を PR #35 で main にマージし、**v2.7.0 として出荷**。**
 - **過去の出荷済みリリース (版履歴の正本)**: [`CHANGELOG.md`](./CHANGELOG.md) を参照
@@ -16,7 +16,8 @@
 
 到達点 (v2.6.1 時点): 6 系統障害 (L1〜L6) 全対処 + 自己修復 (self-healing) + 状態永続化 (sqlite3 StateStore) + Plugin 層 (input_filter / observer hook) + Goal モード対応 + Launcher (llama.cpp / vllm / MLX GUI)。v2.5.4 で Gemma `<0xNN>` byte-fallback 修復フィルタ (Ollama 0.30 detokenizer 対策)、v2.5.5 で Claude Code CLI ≥ 2.1.154 の非仕様 `role: "system"` 正規化 (ingress 側 workaround)、v2.6.0 で **Language Tax** (CJK トークン税) の計測 / ルーティング (`cjk_ratio_min` matcher) / 可視化 + starlette 1.3.1 への CVE 更新、v2.6.1 で **Token-savings accounting** (trim / compress のトークン節約量をメトリクス・ダッシュボードに集約) を出荷。Runtime deps は出荷以来 5 本据え置き連続。
 
-- **2026-07-02 レビュー改修 (v2.7.0)**: 全ソース (26,600 行) レビューで検出した高優先度 8 件 (H1〜H8、PR #34) / 中優先度 14 件 (M1〜M14、PR #35) を main にマージ。テストは **1263 → 1401** (回帰テスト 139 件追加、既存非破壊)。運用に効く新要素: 環境変数 **`CODEROUTER_LAUNCHER_TOKEN`** (launcher start/stop/delete のトークン認証、opt-in・未設定は従来動作) / **`CODEROUTER_ALLOWED_HOSTS`** (Host 検証の追加許可) / **`CODEROUTER_MAX_BODY_BYTES`** (ボディ上限、既定 64MB)。挙動変更: 不正設定 (存在しない provider 名 / 重複名 / 逆転閾値 / `has_tools: false`) が起動時 fail-fast エラーに、drift 降格が adaptive 無効時も実効化、adaptive routing がストリーミングでも観測収集を実効化、request/audit ログが最大 20 件 / 2 秒の遅延書き込みに。詳細: `_OUTPUTS/code-review/2026-07-02_コードレビュー改善提案_v1.md` (ローカル保管) / 改修サマリ H1-H8 (`_OUTPUTS/code-review/fixes_H/`) / 改修サマリ M1-M14 (`_OUTPUTS/code-review/fixes_M/`)。
+- **2026-07-02 レビュー改修 (v2.7.0)**: 全ソース (26,600 行) レビューで検出した高優先度 8 件 (H1〜H8、PR #34) / 中優先度 14 件 (M1〜M14、PR #35) を main にマージ。テストは **1263 → 1401** (回帰テスト 139 件追加、既存非破壊)。運用に効く新要素: 環境変数 **`CODEROUTER_LAUNCHER_TOKEN`** (launcher start/stop/delete のトークン認証、opt-in・未設定は従来動作) / **`CODEROUTER_ALLOWED_HOSTS`** (Host 検証の追加許可) / **`CODEROUTER_MAX_BODY_BYTES`** (ボディ上限、既定 64MB)。挙動変更: 不正設定 (存在しない provider 名 / 重複名 / 逆転閾値 / `has_tools: false`) が起動時 fail-fast エラーに、drift 降格が adaptive 無効時も実効化、adaptive routing がストリーミングでも観測収集を実効化、request/audit ログが最大 20 件 / 2 秒の遅延書き込みに。詳細: `_OUTPUTS/02-レビュー監査/code-review/2026-07-02_コードレビュー改善提案_v1.md` (ローカル保管) / 改修サマリ H1-H8 (`_OUTPUTS/02-レビュー監査/code-review/fixes_H/`) / 改修サマリ M1-M14 (`_OUTPUTS/02-レビュー監査/code-review/fixes_M/`)。
+- **2026-07-11 agent_cli Phase 1 完結 (v2.7.8〜v2.7.10)**: claude/codex/grok/antigravity の4 CLI をワンショット backend 化 (gemini は個人向け終了で antigravity `agy` に置換)。あわせて作者の方向性指示 (`_article/direction-brief-2026-07-11.md`) を受け、「作業ごとにモデルを割当・サブエージェントを利用する」路線を検討 — **結論: 既存資産 (auto_router + profiles + fallback + agent_cli) の構成パターンで表現可能**、詳細は [`docs/inside/future.md`](./docs/inside/future.md) §5・§2.5 参照。plan.md では検討中テーブルと docs/examples 作業に反映 (下記)。
 - **v2.5+ の今後ロードマップ / Vision / 競合分析 / 市場分析** は [`docs/inside/future.md`](./docs/inside/future.md) を参照 (plan.md では重複させない)。
 - **Reactive 発火条件** (運用ルール、reactive but focused) も future.md §3 に集約済み。
 
@@ -77,10 +78,11 @@ lmstudio-anthropic:
 実装本体は v2.6.1 まで出荷完了 + 2026-07-02 レビュー改修 (H1〜H8 / M1〜M14) を **v2.7.0 (2026-07-02)** として出荷済み。残るのは docs / examples 系の継続作業と、レビューで積み残した低優先度リファクタのみ:
 
 - **新 env var の docs 反映**: `CODEROUTER_LAUNCHER_TOKEN` / `CODEROUTER_ALLOWED_HOSTS` / `CODEROUTER_MAX_BODY_BYTES` を運用ガイド・troubleshooting に追記 (レビュー改修で追加、未 doc 化)
-- **レビュー低優先度リファクタ (L1〜L5)**: バグ修正が落ち着いてから着手予定。L1 = `fallback.py` (2,416 行) の 1 試行前後処理の集約、L2 = `logging.py` (1,481 行) の汎用 `emit_event()` 化、L3 = `schemas.py` / `doctor.py` の分割、L4 = 重複コード (プロファイル解決 / adapter エラー変換 / output filter) の集約、L5 = その他小粒 (Prometheus 未出力メトリクス / `restart_command` の `shell=True` / 月次予算 TOCTOU 等)。詳細は `_OUTPUTS/code-review/2026-07-02_コードレビュー改善提案_v1.md` (ローカル保管) の「優先度: 低」節
+- **レビュー低優先度リファクタ (L1〜L5)**: バグ修正が落ち着いてから着手予定。L1 = `fallback.py` (2,416 行) の 1 試行前後処理の集約、L2 = `logging.py` (1,481 行) の汎用 `emit_event()` 化、L3 = `schemas.py` / `doctor.py` の分割、L4 = 重複コード (プロファイル解決 / adapter エラー変換 / output filter) の集約、L5 = その他小粒 (Prometheus 未出力メトリクス / `restart_command` の `shell=True` / 月次予算 TOCTOU 等)。詳細は `_OUTPUTS/02-レビュー監査/code-review/2026-07-02_コードレビュー改善提案_v1.md` (ローカル保管) の「優先度: 低」節
 - **`docs/verification.md` の精緻化**: MoE モデルの罠・rolling-window タイミング制約・goal_mode 実機検証知見を反映
 - **`examples/providers.production-grade.yaml`**: `monthly_budget_usd` / `memory_pressure_action` / `goal_mode: true` を組み合わせた production yaml 雛形
 - **Unsloth Studio プロバイダー検証**: E2E 手動テスト (~2h、安定版確認後)
+- **`examples/providers.opusplan.yaml`** (2026-07-11 追加、方向性 framing 由来): planner (agent_cli claude opus, read_only) / coder (local 優先→cloud-mid フォールバック) / reviewer-audit (agent_cli claude opus) / reviewer-light (local) の役割別 profile + auto_router 保険ルールの雛形。作者 Note 記事の opusplan 型ワークフロー提案を構成パターンとして実体化する。詳細スケッチは [`docs/inside/future.md`](./docs/inside/future.md) §2.5 参照
 
 > v2.5+ の機能ロードマップ (goal context bridge / public benchmark / plugin-memory backend 等) は [`docs/inside/future.md`](./docs/inside/future.md) に集約。plan.md では重複させない。
 
@@ -93,6 +95,10 @@ lmstudio-anthropic:
 | **`coderouter-cli` を Go で別配布** | Python 配布で詰んだ場合の B プラン (§16 リスク対応案) | 現状 PyPI publish が安定して機能しているため保留。将来 (i) Python 環境構築の摩擦が再燃 / (ii) single static binary の需要、いずれかで再評価 |
 | **`npm i -g coderouter` 経路** | Node ユーザー向け配布 | uvx で十分という判断。Claude Code が npm 経由なので「同じ install 経路」需要が顕在化したら検討 |
 | **依存最小主義の「次の絞り」** | 5 deps 据え置きの継続 vs `httpx` HTTP/2 / async 安定性のための backport 受容 | 需要なし、現状維持の方針 (§5.4)。BREAKING に踏み込むなら別途 |
+| **agent_cli Plugin 切り出し (Phase 2)** (2026-07-11 追加、詳細設計 2026-07-11 追記) | `docs/designs/external-agents-adapter.md` §9.3。詳細設計: [`docs/designs/agent-cli-plugin-extraction.md`](./docs/designs/agent-cli-plugin-extraction.md)（設計中・レビュー前）。状況: 構想確定。Adapter Protocol 配線後に in-core `AgentCliAdapter` を `coderouter-plugin-agents` へ前方互換移設。CLI churn (grok モデル廃止・gemini→antigravity・codex スキーマ未凍結) を Core リリース周期から分離するのが動機 | 着手は発火条件待ち: (i) agent_cli 利用比重の恒常化 (ii) CLI churn 追従コストが Core リリースを圧迫 (iii) コミュニティ要望 |
+| **orchestration companion (Ecosystem 層)** (2026-07-11 追加) | Plan→実行→レビューの制御ループ・safe-edit を持つ別プロセスの構想。`_OUTPUTS/04-計画-方向性/multiagent/` のプロトタイプ (orchestrator_v2.py / safe_edit_v1.py) を別 repo standalone 化する候補。骨子は [`docs/designs/orchestration-companion.md`](./docs/designs/orchestration-companion.md) (新設、構想) | 実プロダクト化する段で新設判断。現状は構想文書のみ。CodeRouter 本体 (Core/Plugin) には入れない (`docs/inside/future.md` §2.5・§5 参照) |
+| **サブエージェント明示指定チャネル** (2026-07-11 追加、ccr 由来の検討項目) | claude-code-router の `<CCR-SUBAGENT-MODEL>` タグ相当。system prompt/先頭メッセージから明示タグを検出する最優先ルールを `auto_router.py` の推測ベース分類の前段に追加する案 (`_competitive/2026-07-11_ccr実装解析_v1.md` §6 #1) | 未着手。着手条件は今後精査 (`docs/inside/future.md` §0 P2 #17) |
+| **Presets 的設定共有** (2026-07-11 追加、ccr 由来の検討項目) | `ccr preset export/install` 相当。provider chain + auto_router rules を 1 ファイルに export/import する CLI サブコマンド案。コミュニティでの設定共有・オンボーディング摩擦削減が動機 (`_competitive/2026-07-11_ccr実装解析_v1.md` §6 #2) | 未着手 (`docs/inside/future.md` §0 P2 #18) |
 
 ### ❌ やらないこと (Out of Scope)
 
@@ -703,7 +709,7 @@ v0.1〜v2.6 の item-level 実装履歴は [`CHANGELOG.md`](./CHANGELOG.md) に�
 実装本体は v2.6.1 まで出荷完了 + 2026-07-02 レビュー改修 (H1〜H8 / M1〜M14) を **v2.7.0 (2026-07-02)** として出荷済み。残るのは小粒の継続作業とレビュー低優先度リファクタ (L1〜L5) のみ:
 
 - [ ] **新 env var の docs 反映** — `CODEROUTER_LAUNCHER_TOKEN` / `CODEROUTER_ALLOWED_HOSTS` / `CODEROUTER_MAX_BODY_BYTES` を運用ガイド・troubleshooting に追記 (レビュー改修で追加、未 doc 化)。
-- [ ] **レビュー低優先度リファクタ (L1〜L5)** — `fallback.py` / `logging.py` / `schemas.py` / `doctor.py` の分解、重複コード集約、Prometheus 未出力メトリクス等の小粒。詳細は `_OUTPUTS/code-review/2026-07-02_コードレビュー改善提案_v1.md` (ローカル保管)。
+- [ ] **レビュー低優先度リファクタ (L1〜L5)** — `fallback.py` / `logging.py` / `schemas.py` / `doctor.py` の分解、重複コード集約、Prometheus 未出力メトリクス等の小粒。詳細は `_OUTPUTS/02-レビュー監査/code-review/2026-07-02_コードレビュー改善提案_v1.md` (ローカル保管)。
 - [ ] **Anthropic ヒューリスティック表のメンテ signal** — (a) 週次 `/v1/models` diff、または (b) 未知モデル検出時に warn ログ。capability registry をモデルファミリ追加に追従させる仕組み。(b) は既存 gate 計算からほぼ無料で取れる。
 - [ ] **`docs/verification.md` の精緻化** — MoE モデルの罠 / rolling-window タイミング制約 / goal_mode 実機検証知見を反映。
 - [ ] **`examples/providers.production-grade.yaml`** — `monthly_budget_usd` / `memory_pressure_action` / `goal_mode: true` を組み合わせた production yaml 雛形。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 # in plan.md §11.B; once granted, this name will become an alias and
 # `coderouter` will become the canonical distribution name.
 name = "coderouter-cli"
-version = "2.7.10"
+version = "2.8.0"
 description = "Local-first, free-first, fallback-built-in LLM router. Claude Code / OpenAI compatible."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_plugin_adapter.py
+++ b/tests/test_plugin_adapter.py
@@ -1,0 +1,404 @@
+"""Tests for the Adapter plugin hook wiring (Phase 2a, v2.8.0).
+
+Covers docs/designs/agent-cli-plugin-extraction.md §7's Phase 2a test
+plan: a fake ``kind="fake_agent"`` adapter plugin is registered
+through the same paths a real ``coderouter.adapter`` entry point would
+use, and we verify:
+
+* ``build_adapter`` resolves plugin-provided kinds (§3.2 step 2).
+* in-core kinds always win over a plugin claiming the same kind — no
+  shadowing (§3.2 "in-core を先に見る").
+* the unknown-kind error lists both in-core and plugin kinds (§3.3).
+* the two-stage gate (installed but not ``plugins.enabled`` ->
+  unavailable) holds for the ``adapter`` group exactly like it does
+  for ``input_filter`` / ``observer`` (§3.4).
+* a provider using a plugin kind flows end to end through the fallback
+  engine to serve a real ``/v1/chat/completions`` request (§4.5's "fake
+  adapter plugin wiring E2E" replacement for the agent_cli-specific E2E
+  tests moved to the plugin package in Phase 2b).
+* the *runtime* ``register_provider`` path (fallback.py:1224, the second
+  of §3.5's two ``build_adapter`` call sites) also passes the plugin
+  registry, so a plugin kind registered after startup resolves too.
+
+The loader-level tests reuse the ``importlib.metadata.entry_points``
+monkeypatch pattern from ``tests/test_plugins_loader.py`` so they
+exercise the real discovery path rather than hand-building a registry.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as md
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from coderouter.adapters.agent_cli import AgentCliAdapter
+from coderouter.adapters.base import BaseAdapter, ChatRequest, ChatResponse, StreamChunk
+from coderouter.adapters.openai_compat import OpenAICompatAdapter
+from coderouter.adapters.registry import build_adapter
+from coderouter.config.schemas import (
+    AgentCliConfig,
+    Capabilities,
+    CodeRouterConfig,
+    FallbackChain,
+    PluginsConfig,
+    ProviderConfig,
+)
+from coderouter.ingress.app import create_app
+from coderouter.metrics import uninstall_collector
+from coderouter.plugins import loader as loader_mod
+from coderouter.plugins.loader import discover_and_load
+from coderouter.plugins.registry import PluginRegistry
+from coderouter.routing.fallback import FallbackEngine
+
+# ---------------------------------------------------------------------
+# Fake adapter plugin — module-level so entry-point strings
+# ("tests.test_plugin_adapter:_ClassName") resolve via importlib, same
+# convention as tests/test_plugins_loader.py's synthetic plugins.
+# ---------------------------------------------------------------------
+
+
+class _FakeAgentAdapter(BaseAdapter):
+    """Trivial in-process adapter — no I/O, echoes a fixed reply."""
+
+    async def healthcheck(self) -> bool:
+        return True
+
+    async def generate(
+        self, request: ChatRequest, *, overrides: Any = None
+    ) -> ChatResponse:
+        return ChatResponse(
+            id="fake-agent-1",
+            created=int(time.time()),
+            model=self.config.model,
+            coderouter_provider=self.name,
+            choices=[
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "hello from fake_agent",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+        )
+
+    async def stream(
+        self, request: ChatRequest, *, overrides: Any = None
+    ) -> AsyncIterator[StreamChunk]:
+        raise NotImplementedError  # pragma: no cover - not exercised here
+        yield  # pragma: no cover
+
+
+class _FakeAgentProvider:
+    """``coderouter.adapter`` entry point: serves kind="fake_agent"."""
+
+    name = "fake-agent-plugin"
+    kind = "fake_agent"
+
+    def __init__(self, **_config: object) -> None:
+        pass
+
+    def build(self, config: ProviderConfig) -> BaseAdapter:
+        return _FakeAgentAdapter(config)
+
+
+class _ShadowOpenAICompatProvider:
+    """Malicious/buggy plugin that tries to claim an in-core kind.
+
+    ``build_adapter`` must never reach this factory for
+    ``kind="openai_compat"`` — in-core resolution always wins.
+    """
+
+    name = "shadow-plugin"
+    kind = "openai_compat"
+
+    def __init__(self, **_config: object) -> None:
+        pass
+
+    def build(self, config: ProviderConfig) -> BaseAdapter:
+        raise AssertionError(
+            "plugin factory must not be consulted for an in-core kind"
+        )
+
+
+def _fake_agent_provider_config(**overrides: object) -> ProviderConfig:
+    kwargs: dict[str, object] = {
+        "name": "agent-fake",
+        "kind": "fake_agent",
+        "model": "fake-model",
+        "capabilities": Capabilities(),
+    }
+    kwargs.update(overrides)
+    return ProviderConfig(**kwargs)  # type: ignore[arg-type]
+
+
+def _entry_points_factory(
+    mapping: dict[str, list[tuple[str, str]]],
+):
+    """Same helper shape as tests/test_plugins_loader.py's version."""
+
+    def fake_entry_points(*, group: str | None = None, **_: Any) -> tuple[md.EntryPoint, ...]:
+        if group is None:
+            return tuple()
+        eps = mapping.get(group, [])
+        return tuple(md.EntryPoint(name=n, value=v, group=group) for n, v in eps)
+
+    return fake_entry_points
+
+
+# ---------------------------------------------------------------------
+# build_adapter — direct unit tests
+# ---------------------------------------------------------------------
+
+
+def test_build_adapter_resolves_plugin_kind() -> None:
+    reg = PluginRegistry()
+    reg.add("adapter", _FakeAgentProvider())
+
+    adapter = build_adapter(_fake_agent_provider_config(), reg)
+
+    assert isinstance(adapter, _FakeAgentAdapter)
+    assert adapter.config.kind == "fake_agent"
+
+
+def test_build_adapter_without_registry_still_resolves_in_core() -> None:
+    """``plugin_registry=None`` (legacy call sites) must keep working."""
+    provider = ProviderConfig(
+        name="local",
+        kind="openai_compat",
+        base_url="http://localhost:8080/v1",
+        model="qwen-coder",
+    )
+    assert isinstance(build_adapter(provider), OpenAICompatAdapter)
+
+
+def test_in_core_kind_is_not_shadowed_by_plugin() -> None:
+    """A plugin claiming ``openai_compat`` must never be consulted."""
+    reg = PluginRegistry()
+    reg.add("adapter", _ShadowOpenAICompatProvider())
+
+    provider = ProviderConfig(
+        name="local",
+        kind="openai_compat",
+        base_url="http://localhost:8080/v1",
+        model="qwen-coder",
+    )
+    adapter = build_adapter(provider, reg)
+
+    assert isinstance(adapter, OpenAICompatAdapter)
+
+
+def test_in_core_agent_cli_kind_is_not_shadowed_by_plugin() -> None:
+    """Phase 2a/2b: in-core agent_cli still wins over a plugin of the
+    same kind (docs/designs/agent-cli-plugin-extraction.md §3.2/§5.1).
+    """
+
+    class _ShadowAgentCliProvider:
+        name = "shadow-agent-cli"
+        kind = "agent_cli"
+
+        def __init__(self, **_config: object) -> None:
+            pass
+
+        def build(self, config: ProviderConfig) -> BaseAdapter:
+            raise AssertionError("plugin must not shadow in-core agent_cli")
+
+    reg = PluginRegistry()
+    reg.add("adapter", _ShadowAgentCliProvider())
+
+    provider = ProviderConfig(
+        name="agent",
+        kind="agent_cli",
+        model="opus",
+        agent_cli=AgentCliConfig(agent="claude"),
+    )
+    adapter = build_adapter(provider, reg)
+
+    assert isinstance(adapter, AgentCliAdapter)
+
+
+def test_unknown_kind_error_lists_in_core_and_plugin_kinds() -> None:
+    reg = PluginRegistry()
+    reg.add("adapter", _FakeAgentProvider())
+
+    provider = _fake_agent_provider_config(kind="totally_unknown")
+
+    with pytest.raises(ValueError) as excinfo:
+        build_adapter(provider, reg)
+
+    message = str(excinfo.value)
+    assert "totally_unknown" in message
+    assert "openai_compat" in message
+    assert "anthropic" in message
+    assert "fake_agent" in message
+    assert "plugins.enabled" in message
+
+
+def test_unknown_kind_error_with_no_plugins_loaded() -> None:
+    provider = _fake_agent_provider_config(kind="fake_agent")
+
+    with pytest.raises(ValueError) as excinfo:
+        build_adapter(provider, PluginRegistry.empty())
+
+    message = str(excinfo.value)
+    assert "fake_agent" in message
+    assert "plugin-provided kinds: []" in message
+
+
+# ---------------------------------------------------------------------
+# Two-stage gate via the real loader (installed vs. enabled)
+# ---------------------------------------------------------------------
+
+
+def _plugins_config() -> CodeRouterConfig:
+    return CodeRouterConfig(
+        providers=[
+            ProviderConfig(
+                name="dummy",
+                kind="openai_compat",
+                base_url="http://localhost:9999",
+                model="x",
+            )
+        ],
+        profiles=[FallbackChain(name="default", providers=["dummy"])],
+        plugins=PluginsConfig(enabled=["agents"]),
+    )
+
+
+def test_adapter_group_is_active_not_future(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The ``adapter`` group must load without the
+    ``plugin-group-not-yet-active`` warning now that it's wired in
+    (docs/designs/agent-cli-plugin-extraction.md §2.4).
+    """
+    fake_eps = _entry_points_factory(
+        {
+            "coderouter.adapter": [
+                ("agents", "tests.test_plugin_adapter:_FakeAgentProvider"),
+            ],
+        }
+    )
+    monkeypatch.setattr(loader_mod.md, "entry_points", fake_eps)
+
+    with caplog.at_level("WARNING"):
+        reg = discover_and_load(_plugins_config())
+
+    assert reg.count("adapter") == 1
+    assert reg.adapters[0].kind == "fake_agent"
+    assert not any(
+        rec.msg == "plugin-group-not-yet-active" for rec in caplog.records
+    )
+
+
+def test_installed_but_not_enabled_adapter_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two-stage gate: entry point discoverable but not in
+    ``plugins.enabled`` -> ``PluginRegistry.adapters`` stays empty and
+    ``build_adapter`` can't resolve the kind.
+    """
+    fake_eps = _entry_points_factory(
+        {
+            "coderouter.adapter": [
+                ("agents", "tests.test_plugin_adapter:_FakeAgentProvider"),
+            ],
+        }
+    )
+    monkeypatch.setattr(loader_mod.md, "entry_points", fake_eps)
+
+    cfg = CodeRouterConfig(
+        providers=[
+            ProviderConfig(
+                name="dummy",
+                kind="openai_compat",
+                base_url="http://localhost:9999",
+                model="x",
+            )
+        ],
+        profiles=[FallbackChain(name="default", providers=["dummy"])],
+        plugins=PluginsConfig(enabled=[]),  # NOT enabled
+    )
+    reg = discover_and_load(cfg)
+
+    assert reg.count("adapter") == 0
+    with pytest.raises(ValueError, match="fake_agent"):
+        build_adapter(_fake_agent_provider_config(), reg)
+
+
+# ---------------------------------------------------------------------
+# E2E: plugin-provided kind serves a real /v1/chat/completions request
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture
+def _fake_agent_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    config = CodeRouterConfig(
+        default_profile="fake-agent",
+        providers=[_fake_agent_provider_config()],
+        profiles=[FallbackChain(name="fake-agent", providers=["agent-fake"])],
+        plugins=PluginsConfig(enabled=["agents"]),
+    )
+    reg = PluginRegistry()
+    reg.add("adapter", _FakeAgentProvider())
+
+    monkeypatch.setattr("coderouter.ingress.app.load_config", lambda path=None: config)
+    monkeypatch.setattr("coderouter.ingress.app.discover_and_load", lambda cfg: reg)
+    uninstall_collector()
+    app = create_app()
+    with TestClient(app) as tc:
+        yield tc
+    uninstall_collector()
+
+
+def test_e2e_plugin_adapter_serves_chat_completions(
+    _fake_agent_client: TestClient,
+) -> None:
+    resp = _fake_agent_client.post(
+        "/v1/chat/completions",
+        json={"model": "fake-model", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"X-CodeRouter-Profile": "fake-agent"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["choices"][0]["message"]["content"] == "hello from fake_agent"
+    assert body["coderouter_provider"] == "agent-fake"
+
+
+# ---------------------------------------------------------------------
+# Runtime path: register_provider is the SECOND build_adapter call site
+# (fallback.py:1224, §3.5) — verify it also threads the plugin registry
+# so a plugin kind registered after startup resolves via the plugin.
+# ---------------------------------------------------------------------
+
+
+def test_register_provider_resolves_plugin_kind_at_runtime() -> None:
+    reg = PluginRegistry()
+    reg.add("adapter", _FakeAgentProvider())
+
+    # Engine starts with only an in-core provider; the plugin kind is
+    # introduced at runtime via register_provider (the launcher path).
+    config = CodeRouterConfig(
+        default_profile="default",
+        providers=[
+            ProviderConfig(
+                name="static-local",
+                kind="openai_compat",
+                base_url="http://localhost:8080/v1",
+                model="qwen-coder",
+            )
+        ],
+        profiles=[FallbackChain(name="default", providers=["static-local"])],
+    )
+    engine = FallbackEngine(config, plugins=reg)
+
+    engine.register_provider(_fake_agent_provider_config(), profile_name="launcher")
+
+    adapter = engine._adapters["agent-fake"]
+    assert isinstance(adapter, _FakeAgentAdapter)
+    assert adapter.config.kind == "fake_agent"

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "coderouter-cli"
-version = "2.7.10"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Wires the Plugin SDK's **Adapter hook** into the engine — an external
plugin package can now provide new provider `kind` values without
touching Core. This is **Phase 2a** of the agent_cli plugin-extraction
design (`docs/designs/agent-cli-plugin-extraction.md`): hook wiring
only. The in-core `agent_cli` adapter is unchanged (all 91 tests pass
byte-identical); moving it into `coderouter-plugin-agents` is Phase
2b/2c.

## Implementation

- `Adapter` Protocol realized: `kind: str` + synchronous
  `build(config) -> BaseAdapter` (factory shape; startup-time, no I/O).
- entry-point group **`coderouter.adapter`** (singular — corrected from
  the older design assumption to match the loader's group mechanics);
  existing two-stage gate (installed + `plugins.enabled`) unchanged.
- `build_adapter` resolution order: in-core kinds first (never
  shadowable), then plugin kinds, then a `ValueError` listing all known
  kinds + an enable hint. Both call sites (startup cache + runtime
  `register_provider`) pass the plugin registry.
- **`ProviderConfig.kind`: `Literal` → `str`** — required, since plugins
  are discovered after config load. Fail-fast stays at startup (the
  engine builds all adapters eagerly in its constructor). Recorded as a
  design deviation in §8.1 with residual limitations (doctor is
  HTTP-probe based and does not surface typo'd kinds).

## Verification

- `tests/test_plugin_adapter.py` (new): **10 tests** — resolution,
  shadowing prevention, unknown-kind error, real entry-point loader
  path with the two-stage gate, runtime `register_provider`, and an E2E
  request served end-to-end by a plugin-provided adapter.
- Full suite: **1664 passed**, no new failures; agent_cli's 91 and the
  existing plugin-system 21 unchanged.
- Adversarial review: **APPROVE-WITH-FIXES** — the reviewer added the
  runtime `register_provider` coverage gap and judged the kind-widening
  "necessary, not merely defensible" (a closed Literal would make the
  hook unreachable); every `.kind` branch in doctor/capability/launcher
  audited for unknown-string safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NM473z8MscgHUsGDkiuDTq
