### PR TITLE
fix(translation): keep mid-conversation system messages in place

### DIFF
--- a/coderouter/translation/anthropic.py
+++ b/coderouter/translation/anthropic.py
@@ -143,9 +143,18 @@ def normalize_message_roles(payload: dict[str, Any]) -> dict[str, Any]:
     (see anthropics/claude-code#63469, vllm-project/vllm#44000).
 
     Policy:
-        - ``role: "system"`` → text content merged into the top-level
-          ``system`` field (appended after any existing system prompt;
-          same join rule as ``convert.to_anthropic_request``).
+        - leading ``role: "system"`` (before any user/assistant turn) →
+          text content merged into the top-level ``system`` field
+          (appended after any existing system prompt; same join rule as
+          ``convert.to_anthropic_request``). This is a genuine system
+          prompt from an OpenAI-style client, and it stays at position 0.
+        - mid-conversation ``role: "system"`` → coerced to ``user`` **in
+          place**, like any other non-spec role. Claude Code's
+          system-reminders are volatile per-turn text; hoisting them to
+          the top-level field moves content that changes every turn ahead
+          of the whole conversation, which invalidates the prefix cache of
+          local backends (llama.cpp / LM Studio) and forces a full prompt
+          reprocess on every request.
         - any other non-spec role (``ctx``, ``msg``, ...) → coerced to
           ``user`` so conversation position is preserved. Anthropic
           merges consecutive same-role turns, so this is safe.
@@ -175,9 +184,21 @@ def normalize_message_roles(payload: dict[str, Any]) -> dict[str, Any]:
             continue
         if role == "system":
             text = _content_as_text(msg.get("content"))
-            if text:
-                system_texts.append(text)
             coerced_roles.append("system")
+            if text:
+                if not messages_out:
+                    # Leading system message — a genuine system prompt from an
+                    # OpenAI-style client. Hoisting to the top-level field is
+                    # correct and prefix-safe (it stays at position 0).
+                    system_texts.append(text)
+                else:
+                    # Mid-conversation system message — volatile per-turn text
+                    # (Claude Code >= 2.1.154 system-reminders). Keep it where
+                    # the client put it. Hoisting moves text that changes every
+                    # turn ahead of the entire conversation, which invalidates
+                    # the prefix cache of local backends (llama.cpp / LM Studio)
+                    # and forces a full prompt reprocess on every request.
+                    messages_out.append({"role": "user", "content": text})
             continue
         # Unknown role (ctx / msg / future surprises): keep its position
         # in the conversation as a user turn; drop if nothing salvageable.

--- a/tests/test_role_normalization.py
+++ b/tests/test_role_normalization.py
@@ -41,8 +41,11 @@ def test_claude_code_system_role_in_messages_is_accepted():
             {"role": "assistant", "content": "hi"},
         ]
     )
-    assert [m.role for m in req.messages] == ["user", "assistant"]
-    assert req.system == "injected system reminder"
+    # Mid-conversation system text stays where the client put it, so the
+    # cacheable prefix ahead of it is unchanged.
+    assert [m.role for m in req.messages] == ["user", "user", "assistant"]
+    assert req.messages[1].content == "injected system reminder"
+    assert req.system is None
 
 
 def test_system_role_with_block_list_content():
@@ -58,10 +61,11 @@ def test_system_role_with_block_list_content():
             },
         ]
     )
-    assert req.system == "part one\npart two"
+    assert req.messages[1].content == "part one\npart two"
+    assert req.system is None
 
 
-def test_system_role_appends_to_existing_string_system():
+def test_mid_conversation_system_does_not_touch_existing_system():
     req = _req(
         [
             {"role": "user", "content": "q"},
@@ -69,10 +73,12 @@ def test_system_role_appends_to_existing_string_system():
         ],
         system="original",
     )
-    assert req.system == "original\nextra"
+    # The system prompt — the cache prefix — must not move.
+    assert req.system == "original"
+    assert req.messages[1].content == "extra"
 
 
-def test_system_role_appends_to_existing_block_list_system():
+def test_mid_conversation_system_does_not_touch_block_list_system():
     req = _req(
         [
             {"role": "user", "content": "q"},
@@ -80,13 +86,11 @@ def test_system_role_appends_to_existing_block_list_system():
         ],
         system=[{"type": "text", "text": "original"}],
     )
-    assert req.system == [
-        {"type": "text", "text": "original"},
-        {"type": "text", "text": "extra"},
-    ]
+    assert req.system == [{"type": "text", "text": "original"}]
+    assert req.messages[1].content == "extra"
 
 
-def test_multiple_system_messages_joined_in_order():
+def test_leading_system_is_hoisted_but_mid_conversation_is_not():
     req = _req(
         [
             {"role": "system", "content": "first"},
@@ -94,8 +98,41 @@ def test_multiple_system_messages_joined_in_order():
             {"role": "system", "content": "second"},
         ]
     )
-    assert req.system == "first\nsecond"
-    assert [m.role for m in req.messages] == ["user"]
+    # A leading system message is a genuine system prompt (OpenAI-style
+    # client) and belongs at position 0. A later one is per-turn text.
+    assert req.system == "first"
+    assert [m.role for m in req.messages] == ["user", "user"]
+    assert req.messages[1].content == "second"
+
+
+def test_system_prompt_is_stable_as_conversation_grows():
+    """The regression this guards: Claude Code appends a system-reminder each
+    turn. If those are hoisted, the system prompt — which sits ahead of the
+    whole conversation — changes every request and local backends
+    (llama.cpp / LM Studio) reprocess the entire prompt.
+    """
+    turn1 = _req(
+        [
+            {"role": "user", "content": "q1"},
+            {"role": "system", "content": "reminder A"},
+        ],
+        system="STABLE PROMPT",
+    )
+    turn2 = _req(
+        [
+            {"role": "user", "content": "q1"},
+            {"role": "system", "content": "reminder A"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+            {"role": "system", "content": "reminder B"},
+        ],
+        system="STABLE PROMPT",
+    )
+    assert turn1.system == turn2.system == "STABLE PROMPT"
+    # turn2's message list extends turn1's — an append-only prefix.
+    assert [(m.role, m.content) for m in turn2.messages][: len(turn1.messages)] == [
+        (m.role, m.content) for m in turn1.messages
+    ]
 
 
 # ------------------------------------------------------------


### PR DESCRIPTION
## 概要

`normalize_message_roles()` が、`messages[]` 配列**の途中**にある `role:"system"` メッセージをトップレベルの `system` フィールドへ巻き上げています。

Claude Code CLI (>= 2.1.154) は、システムリマインダを**会話中のその位置**に `role:"system"` メッセージとして送ります。これは毎ターン増えていく揮発性のテキストです。

これを `system` へ巻き上げると、**毎ターン変化するテキストが会話全体より前（プロンプト先頭付近）へ移動**します。llama.cpp / LM Studio 系のローカルバックエンドは KV キャッシュを**プレフィックスの前方一致**で再利用するため、先頭付近が変わると**プロンプト全体が毎回再処理**されます。

CodeRouter はローカルモデルへのルーターなので、この副作用が最も高くつく構成で発生してしまいます。

## 実測

LM Studio (Qwen3.6-35B, 262144ctx) + Claude Code 2.1.211 の実セッションを、CodeRouter の上流でキャプチャして計測しました。

```
req4 -> req5:  再利用可能プレフィックス 11.8%（242,419 文字を再処理）
               原因: system ブロックが 32,059 -> 33,340 文字（+1,281）
               tools 配列は完全に同一
```

その時点の system ブロック（33,340 文字）の内訳です。

| 内容 | 備考 |
|---|---|
| Claude Code 本来のシステムプロンプト | 正常 |
| `The task tools haven't been used recently...` × **16** | 巻き上げられたリマインダ |
| `<task-notification>` × **3** | 巻き上げられた通知 |
| profile の `append_system_prompt` | 正常 |

これらが**会話 146,746 文字の手前**に位置します。そのためリマインダが 1 つ増えるたびに会話全体が再計算されます。**コンテキスト長には依存せず**、数千トークンのセッションでも発生します。

## Claude Code 側の問題ではないことの確認

同じ Claude Code を**素の Anthropic API に直結**して計測しました（CodeRouter を経由しない対照実験です）。

```
req 3: blocks=3  system=1,317 文字  msgs=1
req 4: blocks=3  system=9,909 文字  msgs=2   リマインダ混入 0
req 5: blocks=3  system=9,909 文字  msgs=4   リマインダ混入 0
```

メッセージが増えても `system` フィールドは**バイト単位で不変**でした（対話モード `cc_entrypoint=cli`、ヘッドレス `sdk-cli` の双方で確認）。Claude Code は `system` を綺麗に保っており、混入は CodeRouter の変換で発生しています。

## 最小再現

```bash
curl http://127.0.0.1:8088/v1/messages -H 'Content-Type: application/json' \
  -H 'anthropic-version: 2023-06-01' -d '{
 "model":"claude-sonnet-4","max_tokens":8,
 "system":[{"type":"text","text":"REAL SYSTEM PROMPT"}],
 "messages":[
   {"role":"user","content":"first question"},
   {"role":"assistant","content":"first answer"},
   {"role":"system","content":"VOLATILE REMINDER"},
   {"role":"user","content":"second question"}]}'
```

**修正前**（v2.9.3）— 上流に送られる内容:

```
msg[0] system    | "REAL SYSTEM PROMPT\nVOLATILE REMINDER\n..."   <- 巻き上げられ先頭を汚染
msg[1] user      | "first question"
msg[2] assistant | "first answer"
msg[3] user      | "second question"
```

**修正後**:

```
msg[0] system    | "REAL SYSTEM PROMPT\n..."       <- 清潔・安定
msg[1] user      | "first question"
msg[2] assistant | "first answer"
msg[3] user      | "VOLATILE REMINDER"             <- 元の位置を保持
msg[4] user      | "second question"
```

## 原因

同じ関数の中で、`system` ロールだけが位置を保持されていませんでした。他の非仕様ロールについては、コメントで明示されているとおり**その場で `user` に変換して位置を保持**しています。

```python
if role == "system":
    text = _content_as_text(msg.get("content"))
    if text:
        system_texts.append(text)      # <- 位置を捨てて巻き上げる
    coerced_roles.append("system")
    continue
# Unknown role (ctx / msg / future surprises): keep its position
# in the conversation as a user turn; drop if nothing salvageable.
text = _content_as_text(msg.get("content"))
coerced_roles.append(str(role))
if text:
    messages_out.append({"role": "user", "content": text})   # <- こちらは位置を保持
```

この非対称性が問題の本体です。

## 修正方針

単純に巻き上げをやめると、**OpenAI 形式のクライアントが先頭に置く `role:"system"`**（＝本物のシステムプロンプト）まで `user` になってしまい、そちらが壊れます。そこで**位置で二分**しました。

| 位置 | 挙動 | 理由 |
|---|---|---|
| **先頭**（user/assistant より前） | 従来どおり `system` へ巻き上げ | OpenAI 形式クライアントの正当なシステムプロンプト。position 0 に留まるためプレフィックスに影響しない |
| **会話途中** | その場で `user` に変換 | Claude Code のリマインダ。内容はモデルに届き、位置も保たれる |

これで両方の意味論を保てます。既存クライアントへの影響はありません。

docstring の Policy 節も新しい挙動に合わせて更新しました。

## テスト

旧来の巻き上げ挙動を固定していた 5 件を新挙動に合わせて更新し、**今回のバグが破っていた性質を直接検証するテストを 1 件追加**しました。

```python
def test_system_prompt_is_stable_as_conversation_grows():
    """会話が伸びても system は不変で、messages は append-only であること"""
```

先頭の system が従来どおり巻き上げられることも、明示的にカバーしています（`test_leading_system_is_hoisted_but_mid_conversation_is_not`）。

### 結果

```
tests/test_role_normalization.py :  17 passed

全体（--continue-on-collection-errors）
  パッチあり :  1270 passed, 7 failed, 8 skipped
  main       :  1269 passed, 7 failed, 8 skipped     <- 差は +1 passed（追加テスト）のみ
```

失敗する 7 件とコレクションエラー 25 件は**未修正の main でも同一**（依存バージョン不整合による既存の問題）で、本 PR とは無関係です。**回帰はありません。**

## 環境

- coderouter-cli 2.9.3
- Claude Code CLI 2.1.211（`cc_entrypoint=cli` / `sdk-cli` 双方で再現）
- LM Studio + Qwen3.6-35B (262144ctx) / Qwen3-122B (262144ctx)